### PR TITLE
Support a subset of annotations on the service resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,4 +1,4 @@
-# Ingress Resources
+# Resources
 
 This document covers how ingress resources work in relation to The ALB Ingress Controller.
 
@@ -35,9 +35,9 @@ The host field specifies the eventual Route 53-managed domain that will route to
 
 ## Annotations
 
-The ALB Ingress Controller is configured by Annotations on the `Ingress` resource object. Some are required and some are optional. All annotations use the namespace `alb.ingress.kubernetes.io/`.
+The ALB Ingress Controller is configured by Annotations on the `Ingress` and `Service` resource objects. Some are required and some are optional. All annotations use the namespace `alb.ingress.kubernetes.io/`.
 
-### Required Annotations
+### Required Ingress Annotations
 
 ```
 alb.ingress.kubernetes.io/scheme
@@ -47,7 +47,7 @@ Required annotations are:
 
 - **scheme**: Defines whether an ALB should be `internal` or `internet-facing`. See [Load balancer scheme](http://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html#load-balancer-scheme) in the AWS documentation for more details.
 
-### Optional Annotations
+### Optional Ingress Annotations
 
 ```
 alb.ingress.kubernetes.io/backend-protocol
@@ -104,3 +104,19 @@ Optional annotations are:
 - **successCodes**: Defines the HTTP status code that should be expected when doing health checks against the defined `healthcheck-path`. When omitted, `200` is used.
 
 - **tags**: Defines [AWS Tags](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) that should be applied to the ALB instance and Target groups.
+
+### Services
+A subset of these annotations are supported on Services. This is used to customize the Target Group created for the Service. If a Service has no annotations, the Target Group options will default to the same options configured on the Ingress.
+
+#### Optional Service Annotations
+```
+alb.ingress.kubernetes.io/backend-protocol
+alb.ingress.kubernetes.io/healthcheck-interval-seconds
+alb.ingress.kubernetes.io/healthcheck-path
+alb.ingress.kubernetes.io/healthcheck-port
+alb.ingress.kubernetes.io/healthcheck-protocol
+alb.ingress.kubernetes.io/healthcheck-timeout-seconds
+alb.ingress.kubernetes.io/healthy-threshold-count
+alb.ingress.kubernetes.io/unhealthy-threshold-count
+alb.ingress.kubernetes.io/successCodes
+```

--- a/pkg/albingress/albingress.go
+++ b/pkg/albingress/albingress.go
@@ -85,6 +85,7 @@ type NewALBIngressFromIngressOptions struct {
 	ClusterName           string
 	ALBNamePrefix         string
 	GetServiceNodePort    func(string, int32) (*int64, error)
+	GetServiceAnnotations func(string) (*annotations.Annotations, error)
 	GetNodes              func() util.AWSStringSlice
 	Recorder              record.EventRecorder
 	ConnectionIdleTimeout int64
@@ -153,16 +154,17 @@ func NewALBIngressFromIngress(o *NewALBIngressFromIngressOptions) *ALBIngress {
 
 	// Assemble the target groups
 	newIngress.LoadBalancer.TargetGroups, err = targetgroups.NewDesiredTargetGroups(&targetgroups.NewDesiredTargetGroupsOptions{
-		Ingress:              o.Ingress,
-		LoadBalancerID:       newIngress.LoadBalancer.ID,
-		ExistingTargetGroups: newIngress.LoadBalancer.TargetGroups,
-		Annotations:          newIngress.annotations,
-		ALBNamePrefix:        o.ALBNamePrefix,
-		Namespace:            o.Ingress.GetNamespace(),
-		Tags:                 newIngress.Tags(),
-		Logger:               newIngress.logger,
-		GetServiceNodePort:   o.GetServiceNodePort,
-		GetNodes:             o.GetNodes,
+		Ingress:               o.Ingress,
+		LoadBalancerID:        newIngress.LoadBalancer.ID,
+		ExistingTargetGroups:  newIngress.LoadBalancer.TargetGroups,
+		Annotations:           newIngress.annotations,
+		ALBNamePrefix:         o.ALBNamePrefix,
+		Namespace:             o.Ingress.GetNamespace(),
+		Tags:                  newIngress.Tags(),
+		Logger:                newIngress.logger,
+		GetServiceNodePort:    o.GetServiceNodePort,
+		GetServiceAnnotations: o.GetServiceAnnotations,
+		GetNodes:              o.GetNodes,
 	})
 	if err != nil {
 		msg := fmt.Sprintf("Error instantiating target groups: %s", err.Error())

--- a/pkg/albingresses/albingresses.go
+++ b/pkg/albingresses/albingresses.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/ingress/core/pkg/ingress/annotations/class"
 
 	"github.com/coreos/alb-ingress-controller/pkg/albingress"
+	"github.com/coreos/alb-ingress-controller/pkg/annotations"
 	"github.com/coreos/alb-ingress-controller/pkg/aws/ec2"
 	albelbv2 "github.com/coreos/alb-ingress-controller/pkg/aws/elbv2"
 	"github.com/coreos/alb-ingress-controller/pkg/util/log"
@@ -29,15 +30,16 @@ func init() {
 
 // NewALBIngressesFromIngressesOptions are the options to NewALBIngressesFromIngresses
 type NewALBIngressesFromIngressesOptions struct {
-	Recorder            record.EventRecorder
-	ClusterName         string
-	ALBNamePrefix       string
-	Ingresses           []interface{}
-	ALBIngresses        ALBIngresses
-	IngressClass        string
-	DefaultIngressClass string
-	GetServiceNodePort  func(string, int32) (*int64, error)
-	GetNodes            func() util.AWSStringSlice
+	Recorder              record.EventRecorder
+	ClusterName           string
+	ALBNamePrefix         string
+	Ingresses             []interface{}
+	ALBIngresses          ALBIngresses
+	IngressClass          string
+	DefaultIngressClass   string
+	GetServiceNodePort    func(string, int32) (*int64, error)
+	GetServiceAnnotations func(string) (*annotations.Annotations, error)
+	GetNodes              func() util.AWSStringSlice
 }
 
 // NewALBIngressesFromIngresses returns a ALBIngresses created from the Kubernetes ingress state.
@@ -60,13 +62,14 @@ func NewALBIngressesFromIngresses(o *NewALBIngressesFromIngressesOptions) ALBIng
 		// Produce a new ALBIngress instance for every ingress found. If ALBIngress returns nil, there
 		// was an issue with the ingress (e.g. bad annotations) and should not be added to the list.
 		ALBIngress := albingress.NewALBIngressFromIngress(&albingress.NewALBIngressFromIngressOptions{
-			Ingress:            ingResource,
-			ExistingIngress:    existingIngress,
-			ClusterName:        o.ClusterName,
-			ALBNamePrefix:      o.ALBNamePrefix,
-			GetServiceNodePort: o.GetServiceNodePort,
-			GetNodes:           o.GetNodes,
-			Recorder:           o.Recorder,
+			Ingress:               ingResource,
+			ExistingIngress:       existingIngress,
+			ClusterName:           o.ClusterName,
+			ALBNamePrefix:         o.ALBNamePrefix,
+			GetServiceNodePort:    o.GetServiceNodePort,
+			GetServiceAnnotations: o.GetServiceAnnotations,
+			GetNodes:              o.GetNodes,
+			Recorder:              o.Recorder,
 		})
 
 		// Add the new ALBIngress instance to the new ALBIngress list.


### PR DESCRIPTION
This should allow users to specify custom healthchecks per service and resolve #93.