### PR TITLE
configurable target group attributes

### DIFF
--- a/docs/ingress-resources.md
+++ b/docs/ingress-resources.md
@@ -66,6 +66,7 @@ alb.ingress.kubernetes.io/security-groups
 alb.ingress.kubernetes.io/subnets
 alb.ingress.kubernetes.io/successCodes
 alb.ingress.kubernetes.io/tags
+alb.ingress.kubernetes.io/target-group-attributes
 alb.ingress.kubernetes.io/ignore-host-header
 alb.ingress.kubernetes.io/ip-address-type
 ```
@@ -107,6 +108,8 @@ Optional annotations are:
 - **successCodes**: Defines the HTTP status code that should be expected when doing health checks against the defined `healthcheck-path`. When omitted, `200` is used.
 
 - **tags**: Defines [AWS Tags](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) that should be applied to the ALB instance and Target groups.
+
+- **target-group-attributes**: Defines [Target Group Attributes](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#target-group-attributes) which can be assigned to the Target Groups. Currently these are applied equally to all target groups in the ingress.
 
 - **ignore-host-header**: Creates routing rules without [Host Header Checks](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#host-conditions).
 

--- a/pkg/alb/loadbalancer/loadbalancer.go
+++ b/pkg/alb/loadbalancer/loadbalancer.go
@@ -692,10 +692,9 @@ func (lb *LoadBalancer) needsModification() (loadBalancerChange, bool) {
 		*lb.DesiredIdleTimeout > 0 && *lb.CurrentIdleTimeout != *lb.DesiredIdleTimeout {
 		changes |= connectionIdleTimeoutModified
 	}
-	currentAttributes := albelbv2.Attributes{Items: lb.CurrentAttributes}
-	desiredAttributes := albelbv2.Attributes{Items: lb.DesiredAttributes}
-	sort.Sort(currentAttributes)
-	sort.Sort(desiredAttributes)
+
+	currentAttributes := albelbv2.LoadBalancerAttributes(lb.CurrentAttributes).Sorted()
+	desiredAttributes := albelbv2.LoadBalancerAttributes(lb.DesiredAttributes).Sorted()
 	if log.Prettify(currentAttributes) != log.Prettify(desiredAttributes) {
 		changes |= attributesModified
 	}

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -45,7 +45,7 @@ const (
 	successCodesKey               = "alb.ingress.kubernetes.io/successCodes"
 	tagsKey                       = "alb.ingress.kubernetes.io/tags"
 	ignoreHostHeader              = "alb.ingress.kubernetes.io/ignore-host-header"
-	tgAttributesKey               = "alb.ingress.kubernetes.io/targetgroup-attributes"
+	targetGroupAttributesKey      = "alb.ingress.kubernetes.io/target-group-attributes"
 	clusterTagKey                 = "tag:kubernetes.io/cluster"
 	clusterTagValue               = "shared"
 	albRoleTagKey                 = "tag:kubernetes.io/role/alb-ingress"
@@ -75,7 +75,7 @@ type Annotations struct {
 	SuccessCodes               *string
 	Tags                       []*elbv2.Tag
 	IgnoreHostHeader           *bool
-	TgAttributes               []*elbv2.TargetGroupAttribute
+	TargetGroupAttributes      []*elbv2.TargetGroupAttribute
 	VPCID                      *string
 	Attributes                 []*elbv2.LoadBalancerAttribute
 }
@@ -651,7 +651,7 @@ func (a *Annotations) setTags(annotations map[string]string) error {
 func (a *Annotations) setTargetGroupAttributes(annotations map[string]string) error {
 	var attrs []*elbv2.TargetGroupAttribute
 	var badAttrs []string
-	rawAttrs := util.NewAWSStringSlice(annotations[tgAttributesKey])
+	rawAttrs := util.NewAWSStringSlice(annotations[targetGroupAttributesKey])
 
 	for _, rawAttr := range rawAttrs {
 		parts := strings.Split(*rawAttr, "=")
@@ -667,7 +667,7 @@ func (a *Annotations) setTargetGroupAttributes(annotations map[string]string) er
 			Value: aws.String(parts[1]),
 		})
 	}
-	a.TgAttributes = attrs
+	a.TargetGroupAttributes = attrs
 
 	if len(badAttrs) > 0 {
 		return fmt.Errorf("Unable to parse `%s` into Key=Value pair(s)", strings.Join(badAttrs, ", "))

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -161,16 +161,16 @@ func TestSetAttributesAsList(t *testing.T) {
 
 func TestSetTargetGroupAttributes(t *testing.T) {
 	annotations := &Annotations{}
-	attributes := map[string]string{tgAttributesKey: "deregistration_delay.timeout_seconds=60,stickiness.enabled=true"}
+	attributes := map[string]string{targetGroupAttributesKey: "deregistration_delay.timeout_seconds=60,stickiness.enabled=true"}
 	err := annotations.setTargetGroupAttributes(attributes)
-	if err != nil || len(annotations.TgAttributes) != 2 {
+	if err != nil || len(annotations.TargetGroupAttributes) != 2 {
 		t.Errorf("setTargetGroupAttributes - number of attributes incorrect")
 	}
 
-	if err == nil && *annotations.TgAttributes[0].Key != "deregistration_delay.timeout_seconds" || *annotations.TgAttributes[0].Value != "60" {
+	if err == nil && *annotations.TargetGroupAttributes[0].Key != "deregistration_delay.timeout_seconds" || *annotations.TargetGroupAttributes[0].Value != "60" {
 		t.Errorf("setTargetGroupAttributes - values did not match")
 	}
-	if err == nil && *annotations.TgAttributes[1].Key != "stickiness.enabled" || *annotations.TgAttributes[1].Value != "true" {
+	if err == nil && *annotations.TargetGroupAttributes[1].Key != "stickiness.enabled" || *annotations.TargetGroupAttributes[1].Value != "true" {
 		t.Errorf("setTargetGroupAttributes - values did not match")
 	}
 }

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -12,11 +12,11 @@ const ingressName = "testIngressName"
 const ingressNamespace = "test-namespace"
 
 func fakeValidator() FakeValidator {
-	return FakeValidator{VpcId:"vpc-1"}
+	return FakeValidator{VpcId: "vpc-1"}
 }
 
 func TestParseAnnotations(t *testing.T) {
-	vf := NewValidatingAnnotationFactory(FakeValidator{VpcId:"vpc-1"})
+	vf := NewValidatingAnnotationFactory(FakeValidator{VpcId: "vpc-1"})
 	_, err := vf.ParseAnnotations(&extensions.Ingress{})
 	if err == nil {
 		t.Fatalf("ParseAnnotations should not accept nil for annotations")
@@ -156,5 +156,21 @@ func TestSetAttributesAsList(t *testing.T) {
 
 	if err == nil && *actual.Key != *expected.Key || *actual.Value != *expected.Value {
 		t.Errorf("setAttributes - values did not match")
+	}
+}
+
+func TestSetTargetGroupAttributes(t *testing.T) {
+	annotations := &Annotations{}
+	attributes := map[string]string{tgAttributesKey: "deregistration_delay.timeout_seconds=60,stickiness.enabled=true"}
+	err := annotations.setTargetGroupAttributes(attributes)
+	if err != nil || len(annotations.TgAttributes) != 2 {
+		t.Errorf("setTargetGroupAttributes - number of attributes incorrect")
+	}
+
+	if err == nil && *annotations.TgAttributes[0].Key != "deregistration_delay.timeout_seconds" || *annotations.TgAttributes[0].Value != "60" {
+		t.Errorf("setTargetGroupAttributes - values did not match")
+	}
+	if err == nil && *annotations.TgAttributes[1].Key != "stickiness.enabled" || *annotations.TgAttributes[1].Value != "true" {
+		t.Errorf("setTargetGroupAttributes - values did not match")
 	}
 }

--- a/pkg/aws/elbv2/elbv2.go
+++ b/pkg/aws/elbv2/elbv2.go
@@ -42,32 +42,22 @@ type ELBV2API interface {
 	Status() func() error
 }
 
-type AttributesAPI interface {
-	Len() int
-	Less(i, j int) bool
-	Swap(i, j int)
+type LoadBalancerAttributes []*elbv2.LoadBalancerAttribute
+
+func (a LoadBalancerAttributes) Sorted() LoadBalancerAttributes {
+	sort.Slice(a, func(i, j int) bool {
+		return *a[i].Key < *a[j].Key
+	})
+	return a
 }
 
-type Attributes struct {
-	AttributesAPI
-	Items []*elbv2.LoadBalancerAttribute
-}
+type TargetGroupAttributes []*elbv2.TargetGroupAttribute
 
-func (a Attributes) Len() int {
-	return len(a.Items)
-}
-
-func (a Attributes) Less(i, j int) bool {
-	comparison := strings.Compare(*a.Items[i].Key, *a.Items[j].Key)
-	if comparison == -1 {
-		return true
-	} else {
-		return false
-	}
-}
-
-func (a Attributes) Swap(i, j int) {
-	a.Items[i], a.Items[j] = a.Items[j], a.Items[i]
+func (a TargetGroupAttributes) Sorted() TargetGroupAttributes {
+	sort.Slice(a, func(i, j int) bool {
+		return *a[i].Key < *a[j].Key
+	})
+	return a
 }
 
 // ELBV2 is our extension to AWS's elbv2.ELBV2

--- a/pkg/aws/elbv2/elbv2_test.go
+++ b/pkg/aws/elbv2/elbv2_test.go
@@ -1,7 +1,6 @@
 package elbv2
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -78,53 +77,43 @@ func TestSortLoadBalancerAttributes(t *testing.T) {
 	value2 := "value"
 	key3 := "something"
 	value3 := "else"
-	attributes1 := Attributes{
-		Items: []*elbv2.LoadBalancerAttribute{
-			&elbv2.LoadBalancerAttribute{
-				Key:   &key2,
-				Value: &value2,
-			},
-			&elbv2.LoadBalancerAttribute{
-				Key:   &key1,
-				Value: &value1,
-			},
+	attributes1 := LoadBalancerAttributes{
+		&elbv2.LoadBalancerAttribute{
+			Key:   &key2,
+			Value: &value2,
 		},
-	}
-	attributes2 := Attributes{
-		Items: []*elbv2.LoadBalancerAttribute{
-			&elbv2.LoadBalancerAttribute{
-				Key:   &key1,
-				Value: &value1,
-			},
-			&elbv2.LoadBalancerAttribute{
-				Key:   &key2,
-				Value: &value2,
-			},
+		&elbv2.LoadBalancerAttribute{
+			Key:   &key1,
+			Value: &value1,
 		},
-	}
-	sort.Sort(attributes1)
-	sort.Sort(attributes2)
+	}.Sorted()
+	attributes2 := LoadBalancerAttributes{
+		&elbv2.LoadBalancerAttribute{
+			Key:   &key1,
+			Value: &value1,
+		},
+		&elbv2.LoadBalancerAttribute{
+			Key:   &key2,
+			Value: &value2,
+		},
+	}.Sorted()
 	if log.Prettify(attributes1) != log.Prettify(attributes2) {
 		t.Errorf("LoadBalancerAttribute sort failed, expected attributes to be inequal.")
 	}
-	attributes2 = Attributes{
-		Items: []*elbv2.LoadBalancerAttribute{
-			&elbv2.LoadBalancerAttribute{
-				Key:   &key1,
-				Value: &value1,
-			},
-			&elbv2.LoadBalancerAttribute{
-				Key:   &key2,
-				Value: &value2,
-			},
-			&elbv2.LoadBalancerAttribute{
-				Key:   &key3,
-				Value: &value3,
-			},
+	attributes2 = LoadBalancerAttributes{
+		&elbv2.LoadBalancerAttribute{
+			Key:   &key1,
+			Value: &value1,
 		},
-	}
-	sort.Sort(attributes1)
-	sort.Sort(attributes2)
+		&elbv2.LoadBalancerAttribute{
+			Key:   &key2,
+			Value: &value2,
+		},
+		&elbv2.LoadBalancerAttribute{
+			Key:   &key3,
+			Value: &value3,
+		},
+	}.Sorted()
 	if log.Prettify(attributes1) == log.Prettify(attributes2) {
 		t.Errorf("LoadBalancerAttribute sort failed, expected attributes to be equal.")
 	}


### PR DESCRIPTION
This will allow setting the deregistration delay and other attributes for the target groups. Here is the complete list of supported attributes: http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#target-group-attributes