### PR TITLE
Addressing two small regressions

### DIFF
--- a/pkg/alb/targetgroups/targetgroups.go
+++ b/pkg/alb/targetgroups/targetgroups.go
@@ -169,9 +169,14 @@ func NewDesiredTargetGroups(o *NewDesiredTargetGroupsOptions) (TargetGroups, err
 						Port: port,
 					})
 				}
-				desired, err := albelbv2.ELBV2svc.DescribeTargetGroupTargetsForArn(tg.Current.TargetGroupArn, targets)
-				if err != nil {
-					return nil, err
+
+				// Only set with current TargetGroup Arn if current target group exists
+				desired := targetGroup.Targets.Desired
+				if tg.Current != nil {
+					desired, err = albelbv2.ELBV2svc.DescribeTargetGroupTargetsForArn(tg.Current.TargetGroupArn, targets)
+					if err != nil {
+						return nil, err
+					}
 				}
 
 				tg.Tags.Desired = targetGroup.Tags.Desired

--- a/pkg/albingress/albingress.go
+++ b/pkg/albingress/albingress.go
@@ -122,7 +122,7 @@ func NewALBIngressFromIngress(o *NewALBIngressFromIngressOptions, annotationFact
 	}
 
 	// Load up the ingress with our current annotations.
-	newIngress.annotations, err = annotationFactory.ParseAnnotations(o.Ingress)
+	newIngress.annotations, err = annotationFactory.ParseAnnotations(o.Ingress, o.ClusterName)
 	if err != nil {
 		msg := fmt.Sprintf("Error parsing annotations: %s", err.Error())
 		newIngress.Reconciled = false

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -84,7 +84,7 @@ type PortData struct {
 }
 
 type AnnotationFactory interface {
-	ParseAnnotations(ingress *extensions.Ingress) (*Annotations, error)
+	ParseAnnotations(ingress *extensions.Ingress, clusterName string) (*Annotations, error)
 }
 
 type ValidatingAnnotationFactory struct {
@@ -99,11 +99,10 @@ func NewValidatingAnnotationFactory(validator Validator) ValidatingAnnotationFac
 // If there is an issue with an annotation, an error is returned. In the case of an error, the
 // annotations are also cached, meaning there will be no reattempt to parse annotations until the
 // cache expires or the value(s) change.
-func (vf ValidatingAnnotationFactory) ParseAnnotations(ingress *extensions.Ingress) (*Annotations, error) {
+func (vf ValidatingAnnotationFactory) ParseAnnotations(ingress *extensions.Ingress, clusterName string) (*Annotations, error) {
 	annotations := ingress.Annotations
 	ingressNamespace := ingress.Namespace
 	ingressName := ingress.Name
-	clusterName := ingress.ClusterName
 	if annotations == nil {
 		return nil, fmt.Errorf("Necessary annotations missing. Must include at least %s, %s, %s", subnetsKey, securityGroupsKey, schemeKey)
 	}

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -17,7 +17,7 @@ func fakeValidator() FakeValidator {
 
 func TestParseAnnotations(t *testing.T) {
 	vf := NewValidatingAnnotationFactory(FakeValidator{VpcId:"vpc-1"})
-	_, err := vf.ParseAnnotations(&extensions.Ingress{})
+	_, err := vf.ParseAnnotations(&extensions.Ingress{}, clusterName)
 	if err == nil {
 		t.Fatalf("ParseAnnotations should not accept nil for annotations")
 	}


### PR DESCRIPTION
Encountered a couple issues when attempting to build master and deploy it as my ALB Ingress Controller. 

Environment details: I'm testing with a Kops (1.9.0) deployed cluster on top of AWS, using CNI and a private topology (Weave as my networking layer). 

Both issues look to be fairly recent regressions. 

Issue 1: After a recent code update, the cluster name is no longer passed explicitly to the ParseAnnotations method; rather the value is attempted to get grabbed directly from an ingress type in a nested object. In my testing, I found the clusterName was not available in that type. This broke the controller's ability to find properly tagged subnets to deploy an ALB into since the clusterName was nil.

Issue 2: In my testing, the master branch build of the controller would crash with a seg fault when attempting to deploy an ingress/ALB that did not already exist. This looks to occur because another recent commit attempts to grab a target group Arn for a target group that does not currently exist. Added some safety logic around that call. 

Commit comments:
Added clusterName back to Annotation Parser.
Added check for if current TargetGroup exists before attempting to retrieve its Arn.