### PR TITLE
Normalizing clusterName to lowercase

### DIFF
--- a/pkg/controller/alb-controller.go
+++ b/pkg/controller/alb-controller.go
@@ -434,7 +434,7 @@ func cleanClusterName(cn string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	n := reg.ReplaceAllString(cn, "")
+	n := strings.ToLower(reg.ReplaceAllString(cn, ""))
 	if len(n) > 11 {
 		n = n[:11]
 	}


### PR DESCRIPTION
This PR lowercases `clusterName` for `albNamePrefix` so that the alb names will be requested as lowercase regardless of what clusterName is. Fixes #396. 