### PR TITLE
Add liveness check against /state

### DIFF
--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -65,6 +65,14 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: {{ .Values.controller.readinessProbeInterval }}
+            timeout: {{ .Values.controller.readinessProbeTimeout }}
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 60
         {{- if .Values.controller.resources }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -43,6 +43,9 @@ controller:
   # How often (in seconds) to check controller readiness
   readinessProbeInterval: 10
 
+  # How long to wait before timeout (in seconds) when checking controller readiness
+  readinessProbeTimeout: 1
+
   resources: {}
     # limits:
     #   cpu: 100m

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,6 +56,7 @@ func main() {
 
 	http.HandleFunc("/state", ac.StateHandler)
 	http.HandleFunc("/healthz", ac.StatusHandler)
+	http.HandleFunc("/alive", ac.AliveHandler)
 
 	defer func() {
 		logger.Infof("Shutting down ingress controller...")

--- a/pkg/aws/albec2/ec2.go
+++ b/pkg/aws/albec2/ec2.go
@@ -84,7 +84,7 @@ func (e *EC2) DescribeSGByPermissionGroup(sg *string) (*string, error) {
 	}
 
 	if len(o.SecurityGroups) != 1 {
-		return nil, fmt.Errorf("Found more than 1 matching (managed) instance SGs. Found %d", len(o.SecurityGroups))
+		return nil, fmt.Errorf("Didn't find exactly 1 matching (managed) instance SG. Found %d", len(o.SecurityGroups))
 	}
 
 	e.cache.Set(key, o.SecurityGroups[0].GroupId, time.Minute*5)

--- a/pkg/controller/alb-controller_test.go
+++ b/pkg/controller/alb-controller_test.go
@@ -313,6 +313,7 @@ func TestALBController_StateHandler(t *testing.T) {
 	ingress := albingress.ALBIngress{}
 	encodedIngressByteSlice, _ := json.Marshal(ingress)
 	expectedBody := fmt.Sprintf("[%s]\n", encodedIngressByteSlice)
+	expectedResponseCode := 200
 	ac := albController{
 		ALBIngresses: []*albingress.ALBIngress{&ingress},
 	}
@@ -322,6 +323,9 @@ func TestALBController_StateHandler(t *testing.T) {
 
 	if rw.Header().Get("Content-Type") != "application/json" {
 		t.Errorf("Expected header Content-Type: application-json")
+	}
+	if rw.Result().StatusCode != expectedResponseCode {
+		t.Errorf("Expected http status code to be %d, got %d", expectedResponseCode, rw.Result().StatusCode)
 	}
 	bodyString := fmt.Sprintf("%s", rw.Body.Bytes())
 	if expectedBody != bodyString {
@@ -364,5 +368,25 @@ func TestALBController_StatusHandler(t *testing.T) {
 		if tt.expectedBody != responseBody {
 			t.Errorf("Expected %v in response body, got %v", tt.expectedBody, responseBody)
 		}
+	}
+}
+func TestALBController_AliveHandler(t *testing.T) {
+
+	expectedResponseCode := 200
+	expectedResponseBody := "{}\n"
+	ac := albController{}
+	w := httptest.NewRecorder()
+	ac.AliveHandler(w, nil)
+
+	if w.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("Expected header Content-Type: application-json")
+	}
+	if w.Result().StatusCode != expectedResponseCode {
+		t.Errorf("Expected http status code to be %d, got %d", expectedResponseCode, w.Result().StatusCode)
+	}
+
+	responseBody := fmt.Sprintf("%s", string(w.Body.Bytes()[:w.Body.Len()]))
+	if responseBody != expectedResponseBody {
+		t.Errorf("Expected response body to be '%s', found '%s'", expectedResponseBody, responseBody)
 	}
 }


### PR DESCRIPTION
### What
- Add liveness check against /state into deployment.yaml.
- Tweak stateHandler to include an explicit responseCode and optional empty response with a query-param toggle. 
- Make readinessProbe timeout configurable
- Correct log statement.

### Why
We’ve been running an older version of the controller which was working fine for us but recently we starting seeing the liveness and readiness probes start to sporadically fail, with the liveness probe causing the pod to restart. My guess is that we're being rate limited by AWS and so the API calls in /healthz are failing/retrying.
We've mitigated this by increasing the timeouts for both our liveness and readiness probes manually and increasing the period between checks.

When I went to create a PR on the project to make the probe timeout configurable, I noticed that the liveness probe has since been removed. 
I'm unsure as to why, but I guess people may have run into similar issues where the liveness probe failures could cause the pod to be killed. 

We feel that the liveness probe shouldn't be checking downstream dependencies (AWS APIs) through the /healthz endpoint since if these downstream dependencies fail then all that will happen is that the controller will be restarted by kube - which would leave it in no better state. I propose that it should instead just conduct a simple check to see if the controller is alive.

### Notes
I chose to copy the query-param approach from /healthz onto the /state handler - shout if you'd prefer me to refactor /healthz to support liveness checking without downstream calls.

If people hate this addition, or if there's some reason I'm missing as to why there is no liveness check then let me know and I can amend the PR to simply include the timeout and logging change.

Thanks for a great project, great to see the recently activity & migration to kubernetes-sig!