### PR TITLE
Use clusterName in annotation parser

### DIFF
--- a/pkg/albingress/albingress_test.go
+++ b/pkg/albingress/albingress_test.go
@@ -76,7 +76,7 @@ func TestNewALBIngressFromIngress(t *testing.T) {
 	}
 	ingress := NewALBIngressFromIngress(
 		options,
-		annotations.NewValidatingAnnotationFactory(annotations.FakeValidator{VpcId: "vpc-1"}),
+		annotations.NewValidatingAnnotationFactory(annotations.FakeValidator{VpcId: "vpc-1"}, "testCluster"),
 	)
 	if ingress == nil {
 		t.Errorf("NewALBIngressFromIngress returned nil")

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -93,11 +93,15 @@ type AnnotationFactory interface {
 }
 
 type ValidatingAnnotationFactory struct {
-	validator Validator
+	validator   Validator
+	clusterName string
 }
 
-func NewValidatingAnnotationFactory(validator Validator) ValidatingAnnotationFactory {
-	return ValidatingAnnotationFactory{validator: validator}
+func NewValidatingAnnotationFactory(validator Validator, clusterName string) ValidatingAnnotationFactory {
+	return ValidatingAnnotationFactory{
+		validator:   validator,
+		clusterName: clusterName,
+	}
 }
 
 // ParseAnnotations validates and loads all the annotations provided into the Annotations struct.
@@ -108,7 +112,7 @@ func (vf ValidatingAnnotationFactory) ParseAnnotations(ingress *extensions.Ingre
 	annotations := ingress.Annotations
 	ingressNamespace := ingress.Namespace
 	ingressName := ingress.Name
-	clusterName := ingress.ClusterName
+	clusterName := vf.clusterName
 	if annotations == nil {
 		return nil, fmt.Errorf("Necessary annotations missing. Must include at least %s, %s, %s", subnetsKey, securityGroupsKey, schemeKey)
 	}

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -16,7 +16,7 @@ func fakeValidator() FakeValidator {
 }
 
 func TestParseAnnotations(t *testing.T) {
-	vf := NewValidatingAnnotationFactory(FakeValidator{VpcId: "vpc-1"})
+	vf := NewValidatingAnnotationFactory(FakeValidator{VpcId: "vpc-1"}, clusterName)
 	_, err := vf.ParseAnnotations(&extensions.Ingress{})
 	if err == nil {
 		t.Fatalf("ParseAnnotations should not accept nil for annotations")

--- a/pkg/controller/alb-controller.go
+++ b/pkg/controller/alb-controller.go
@@ -93,7 +93,7 @@ func NewALBController(awsconfig *aws.Config, conf *config.Config) *albController
 	ac.syncer = syncALBs
 	ac.recorderGetter = recorderGetter
 	ac.classNameGetter = classNameGetter
-	ac.annotationFactory = annotations.NewValidatingAnnotationFactory(annotations.NewConcreteValidator())
+	ac.annotationFactory = annotations.NewValidatingAnnotationFactory(annotations.NewConcreteValidator(), ac.clusterName)
 
 	return ingress.Controller(ac).(*albController)
 }


### PR DESCRIPTION
Addresses issue 1 (and corresponding review comments) identified in #385 and removing fix for issue 2, which had been addressed in #384 