### PR TITLE
Support for service level annotations

### DIFF
--- a/docs/ingress-resources.md
+++ b/docs/ingress-resources.md
@@ -36,9 +36,9 @@ The host field specifies the eventual Route 53-managed domain that will route to
 
 ## Annotations
 
-The ALB Ingress Controller is configured by Annotations on the `Ingress` resource object. Some are required and some are optional. All annotations use the namespace `alb.ingress.kubernetes.io/`.
+The ALB Ingress Controller is configured by Annotations on the `Ingress` and `Service` resource objects. Some are required and some are optional. All annotations use the namespace `alb.ingress.kubernetes.io/`.
 
-### Required Annotations
+### Required Ingress Annotations
 
 ```
 alb.ingress.kubernetes.io/scheme
@@ -48,7 +48,7 @@ Required annotations are:
 
 - **scheme**: Defines whether an ALB should be `internal` or `internet-facing`. See [Load balancer scheme](http://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html#load-balancer-scheme) in the AWS documentation for more details.
 
-### Optional Annotations
+### Optional Ingress Annotations
 
 ```
 alb.ingress.kubernetes.io/load-balancer-attributes
@@ -120,3 +120,22 @@ Optional annotations are:
 - **ip-address-type**: The IP address type thats used to either route IPv4 traffic only or to route both IPv4 and IPv6 traffic. Can be either `dualstack` or `ipv4`. When omitted `ipv4` is used.
 
 - **ssl-policy**: Defines the [Security Policy](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) that should be assigned to the ALB, allowing you to control the protocol and ciphers.
+
+### Services
+
+A subset of these annotations are supported on Services. This is used to customize the Target Group created for the Service. If a Service has no annotations, the Target Group options will default to the same options configured on the Ingress.
+
+#### Optional Service Annotations
+
+```
+alb.ingress.kubernetes.io/backend-protocol
+alb.ingress.kubernetes.io/healthcheck-interval-seconds
+alb.ingress.kubernetes.io/healthcheck-path
+alb.ingress.kubernetes.io/healthcheck-port
+alb.ingress.kubernetes.io/healthcheck-protocol
+alb.ingress.kubernetes.io/healthcheck-timeout-seconds
+alb.ingress.kubernetes.io/healthy-threshold-count
+alb.ingress.kubernetes.io/unhealthy-threshold-count
+alb.ingress.kubernetes.io/success-codes
+alb.ingress.kubernetes.io/target-group-attributes
+```

--- a/pkg/alb/lb/loadbalancer.go
+++ b/pkg/alb/lb/loadbalancer.go
@@ -26,17 +26,20 @@ import (
 )
 
 type NewDesiredLoadBalancerOptions struct {
-	ALBNamePrefix        string
-	Namespace            string
-	IngressName          string
-	ExistingLoadBalancer *LoadBalancer
-	Logger               *log.Logger
-	Annotations          *annotations.Annotations
-	Tags                 util.Tags
-	Attributes           []*elbv2.LoadBalancerAttribute
-	IngressRules         []extensions.IngressRule
-	GetServiceNodePort   func(string, int32) (*int64, error)
-	GetNodes             func() util.AWSStringSlice
+	ALBNamePrefix         string
+	Namespace             string
+	IngressName           string
+	ExistingLoadBalancer  *LoadBalancer
+	Logger                *log.Logger
+	Annotations           *annotations.Annotations
+	AnnotationFactory     annotations.AnnotationFactory
+	IngressAnnotations    *map[string]string
+	Tags                  util.Tags
+	Attributes            []*elbv2.LoadBalancerAttribute
+	IngressRules          []extensions.IngressRule
+	GetServiceNodePort    func(string, int32) (*int64, error)
+	GetServiceAnnotations func(string, string) (*map[string]string, error)
+	GetNodes              func() util.AWSStringSlice
 }
 
 // NewDesiredLoadBalancer returns a new loadbalancer.LoadBalancer based on the opts provided.
@@ -102,13 +105,16 @@ func NewDesiredLoadBalancer(o *NewDesiredLoadBalancerOptions) (newLoadBalancer *
 		IngressRules:         o.IngressRules,
 		LoadBalancerID:       newLoadBalancer.id,
 		ExistingTargetGroups: existingtgs,
-		Annotations:          o.Annotations,
-		ALBNamePrefix:        o.ALBNamePrefix,
-		Namespace:            o.Namespace,
-		Tags:                 o.Tags,
-		Logger:               o.Logger,
-		GetServiceNodePort:   o.GetServiceNodePort,
-		GetNodes:             o.GetNodes,
+		// Annotations:           o.Annotations,
+		IngressAnnotations:    o.IngressAnnotations,
+		ALBNamePrefix:         o.ALBNamePrefix,
+		Namespace:             o.Namespace,
+		Tags:                  o.Tags,
+		Logger:                o.Logger,
+		GetServiceNodePort:    o.GetServiceNodePort,
+		GetServiceAnnotations: o.GetServiceAnnotations,
+		AnnotationFactory:     o.AnnotationFactory,
+		GetNodes:              o.GetNodes,
 	})
 
 	if err != nil {

--- a/pkg/alb/tg/targetgroups_test.go
+++ b/pkg/alb/tg/targetgroups_test.go
@@ -1,0 +1,81 @@
+package tg
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/annotations"
+)
+
+func TestMergeAnnotations(t *testing.T) {
+	var tests = []struct {
+		ingressAnnotations map[string]string
+		serviceAnnotations map[string]string
+		expected           annotations.Annotations
+		pass               bool
+	}{
+		{
+			map[string]string{
+				"alb.ingress.kubernetes.io/subnets":          "subnet-abcdfg",
+				"alb.ingress.kubernetes.io/scheme":           "internal",
+				"alb.ingress.kubernetes.io/healthcheck-path": "/ingressPath",
+			},
+			map[string]string{
+				"alb.ingress.kubernetes.io/healthcheck-path": "/servicePath",
+			},
+			annotations.Annotations{
+				HealthcheckPath: aws.String("/servicePath"),
+			},
+			true,
+		},
+		{
+			map[string]string{
+				"alb.ingress.kubernetes.io/subnets":          "subnet-abcdfg",
+				"alb.ingress.kubernetes.io/scheme":           "internal",
+				"alb.ingress.kubernetes.io/healthcheck-path": "/ingressPath",
+			},
+			map[string]string{},
+			annotations.Annotations{
+				HealthcheckPath: aws.String("/ingressPath"),
+			},
+			true,
+		},
+		{
+			map[string]string{
+				"alb.ingress.kubernetes.io/subnets":          "subnet-abcdfg",
+				"alb.ingress.kubernetes.io/scheme":           "internal",
+				"alb.ingress.kubernetes.io/healthcheck-path": "/ingressPath",
+			},
+			map[string]string{},
+			annotations.Annotations{
+				HealthcheckPath: aws.String("/"),
+			},
+			false,
+		},
+	}
+	vf := annotations.NewValidatingAnnotationFactory(&annotations.NewValidatingAnnotationFactoryOptions{
+		Validator:   annotations.FakeValidator{VpcId: "vpc-1"},
+		ClusterName: "clusterName"})
+
+	for i, tt := range tests {
+		a, err := mergeAnnotations(&mergeAnnotationsOptions{
+			AnnotationFactory:  vf,
+			IngressAnnotations: &tt.ingressAnnotations,
+			GetServiceAnnotations: func(string, string) (*map[string]string, error) {
+				return &tt.serviceAnnotations, nil
+			},
+		})
+
+		if err != nil && tt.pass {
+			t.Errorf("mergeAnnotations(%v): got %v expected %v, errored: %v", i, *a.HealthcheckPath, *tt.expected.HealthcheckPath, err)
+		}
+
+		if err == nil && tt.pass && *tt.expected.HealthcheckPath != *a.HealthcheckPath {
+			t.Errorf("mergeAnnotations(%v): expected %v, actual %v", i, *tt.expected.HealthcheckPath, *a.HealthcheckPath)
+		}
+
+		if err == nil && !tt.pass && *tt.expected.HealthcheckPath == *a.HealthcheckPath {
+			t.Errorf("mergeAnnotations(%v): not expected %v, actual %v", i, *tt.expected.HealthcheckPath, *a.HealthcheckPath)
+		}
+	}
+}

--- a/pkg/albingress/albingress_test.go
+++ b/pkg/albingress/albingress_test.go
@@ -66,6 +66,10 @@ func TestNewALBIngressFromIngress(t *testing.T) {
 			nodePort := int64(8000)
 			return &nodePort, nil
 		},
+		GetServiceAnnotations: func(namespace string, serviceName string) (*map[string]string, error) {
+			a := make(map[string]string)
+			return &a, nil
+		},
 		GetNodes: func() types.AWSStringSlice {
 			instance1 := "i-1"
 			instance2 := "i-2"
@@ -73,11 +77,13 @@ func TestNewALBIngressFromIngress(t *testing.T) {
 		},
 		ClusterName:   "testCluster",
 		ALBNamePrefix: "albNamePrefix",
+		AnnotationFactory: annotations.NewValidatingAnnotationFactory(&annotations.NewValidatingAnnotationFactoryOptions{
+			Validator:   annotations.FakeValidator{VpcId: "vpc-1"},
+			ClusterName: "testCluster",
+		},
+		),
 	}
-	ingress := NewALBIngressFromIngress(
-		options,
-		annotations.NewValidatingAnnotationFactory(annotations.FakeValidator{VpcId: "vpc-1"}, "testCluster"),
-	)
+	ingress := NewALBIngressFromIngress(options)
 	if ingress == nil {
 		t.Errorf("NewALBIngressFromIngress returned nil")
 	}

--- a/pkg/albingress/albingresses.go
+++ b/pkg/albingress/albingresses.go
@@ -21,19 +21,21 @@ import (
 
 // NewALBIngressesFromIngressesOptions are the options to NewALBIngressesFromIngresses
 type NewALBIngressesFromIngressesOptions struct {
-	Recorder            record.EventRecorder
-	ClusterName         string
-	ALBNamePrefix       string
-	Ingresses           []interface{}
-	ALBIngresses        ALBIngresses
-	IngressClass        string
-	DefaultIngressClass string
-	GetServiceNodePort  func(string, int32) (*int64, error)
-	GetNodes            func() util.AWSStringSlice
+	Recorder              record.EventRecorder
+	ClusterName           string
+	ALBNamePrefix         string
+	Ingresses             []interface{}
+	ALBIngresses          ALBIngresses
+	IngressClass          string
+	DefaultIngressClass   string
+	GetServiceNodePort    func(string, int32) (*int64, error)
+	GetServiceAnnotations func(string, string) (*map[string]string, error)
+	GetNodes              func() util.AWSStringSlice
+	AnnotationFactory     annotations.AnnotationFactory
 }
 
 // NewALBIngressesFromIngresses returns a ALBIngresses created from the Kubernetes ingress state.
-func NewALBIngressesFromIngresses(o *NewALBIngressesFromIngressesOptions, annotationFactory annotations.AnnotationFactory) ALBIngresses {
+func NewALBIngressesFromIngresses(o *NewALBIngressesFromIngressesOptions) ALBIngresses {
 	var ALBIngresses ALBIngresses
 
 	// Find every ingress currently in Kubernetes.
@@ -52,14 +54,16 @@ func NewALBIngressesFromIngresses(o *NewALBIngressesFromIngressesOptions, annota
 		// Produce a new ALBIngress instance for every ingress found. If ALBIngress returns nil, there
 		// was an issue with the ingress (e.g. bad annotations) and should not be added to the list.
 		ALBIngress := NewALBIngressFromIngress(&NewALBIngressFromIngressOptions{
-			Ingress:            ingResource,
-			ExistingIngress:    existingIngress,
-			ClusterName:        o.ClusterName,
-			ALBNamePrefix:      o.ALBNamePrefix,
-			GetServiceNodePort: o.GetServiceNodePort,
-			GetNodes:           o.GetNodes,
-			Recorder:           o.Recorder,
-		}, annotationFactory)
+			Ingress:               ingResource,
+			ExistingIngress:       existingIngress,
+			ClusterName:           o.ClusterName,
+			ALBNamePrefix:         o.ALBNamePrefix,
+			GetServiceNodePort:    o.GetServiceNodePort,
+			GetServiceAnnotations: o.GetServiceAnnotations,
+			GetNodes:              o.GetNodes,
+			Recorder:              o.Recorder,
+			AnnotationFactory:     o.AnnotationFactory,
+		})
 
 		// Add the new ALBIngress instance to the new ALBIngress list.
 		ALBIngresses = append(ALBIngresses, ALBIngress)

--- a/pkg/albingress/types.go
+++ b/pkg/albingress/types.go
@@ -39,3 +39,7 @@ type ALBIngress struct {
 	logger                *log.Logger
 	reconciled            bool
 }
+
+type ReconcileOptions struct {
+	Eventf func(string, string, string, ...interface{})
+}

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	extensions "k8s.io/api/extensions/v1beta1"
 )
 
 const clusterName = "testCluster"
@@ -17,8 +16,10 @@ func fakeValidator() FakeValidator {
 }
 
 func TestParseAnnotations(t *testing.T) {
-	vf := NewValidatingAnnotationFactory(FakeValidator{VpcId: "vpc-1"}, clusterName)
-	_, err := vf.ParseAnnotations(&extensions.Ingress{})
+	vf := NewValidatingAnnotationFactory(&NewValidatingAnnotationFactoryOptions{
+		Validator:   FakeValidator{VpcId: "vpc-1"},
+		ClusterName: clusterName})
+	_, err := vf.ParseAnnotations(&ParseAnnotationsOptions{})
 	if err == nil {
 		t.Fatalf("ParseAnnotations should not accept nil for annotations")
 	}


### PR DESCRIPTION
Takes the ingress annotations map and merges the services annotations on top, then uses this for generating desired target groups.

This allows users to customize healthchecks and other service specific configurations at the service, allowing for an ALB to have different healthcheck/successcodes/etc for each target group.