### PR TITLE
Resolves #429. The cluster name passed to the annotation factory was …

### DIFF
--- a/pkg/alb/tg/targetgroups_test.go
+++ b/pkg/alb/tg/targetgroups_test.go
@@ -55,7 +55,7 @@ func TestMergeAnnotations(t *testing.T) {
 	}
 	vf := annotations.NewValidatingAnnotationFactory(&annotations.NewValidatingAnnotationFactoryOptions{
 		Validator:   annotations.FakeValidator{VpcId: "vpc-1"},
-		ClusterName: "clusterName"})
+		ClusterName: aws.String("clusterName")})
 
 	for i, tt := range tests {
 		a, err := mergeAnnotations(&mergeAnnotationsOptions{

--- a/pkg/albingress/albingress_test.go
+++ b/pkg/albingress/albingress_test.go
@@ -3,6 +3,7 @@ package albingress
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/annotations"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/util/types"
 	"k8s.io/api/extensions/v1beta1"
@@ -79,7 +80,7 @@ func TestNewALBIngressFromIngress(t *testing.T) {
 		ALBNamePrefix: "albNamePrefix",
 		AnnotationFactory: annotations.NewValidatingAnnotationFactory(&annotations.NewValidatingAnnotationFactoryOptions{
 			Validator:   annotations.FakeValidator{VpcId: "vpc-1"},
-			ClusterName: "testCluster",
+			ClusterName: aws.String("testCluster"),
 		},
 		),
 	}

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -95,12 +95,12 @@ type AnnotationFactory interface {
 
 type ValidatingAnnotationFactory struct {
 	validator   Validator
-	clusterName string
+	clusterName *string
 }
 
 type NewValidatingAnnotationFactoryOptions struct {
 	Validator   Validator
-	ClusterName string
+	ClusterName *string
 }
 
 func NewValidatingAnnotationFactory(opts *NewValidatingAnnotationFactoryOptions) *ValidatingAnnotationFactory {
@@ -152,7 +152,7 @@ func (vf *ValidatingAnnotationFactory) ParseAnnotations(opts *ParseAnnotationsOp
 		a.setScheme(annotations, opts.Namespace, opts.IngressName, vf.validator),
 		a.setIPAddressType(annotations),
 		a.setSecurityGroups(annotations, vf.validator),
-		a.setSubnets(annotations, vf.clusterName, vf.validator),
+		a.setSubnets(annotations, *vf.clusterName, vf.validator),
 		a.setSuccessCodes(annotations),
 		a.setTags(annotations),
 		a.setIgnoreHostHeader(annotations),

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -18,7 +18,7 @@ func fakeValidator() FakeValidator {
 func TestParseAnnotations(t *testing.T) {
 	vf := NewValidatingAnnotationFactory(&NewValidatingAnnotationFactoryOptions{
 		Validator:   FakeValidator{VpcId: "vpc-1"},
-		ClusterName: clusterName})
+		ClusterName: aws.String(clusterName)})
 	_, err := vf.ParseAnnotations(&ParseAnnotationsOptions{})
 	if err == nil {
 		t.Fatalf("ParseAnnotations should not accept nil for annotations")

--- a/pkg/controller/alb-controller.go
+++ b/pkg/controller/alb-controller.go
@@ -75,6 +75,7 @@ func NewALBController(awsconfig *aws.Config, conf *config.Config) *albController
 	ac := &albController{
 		awsChecks: make(map[string]func() error),
 	}
+
 	sess := albsession.NewSession(awsconfig, conf.AWSDebug)
 	albelbv2.NewELBV2(sess)
 	albec2.NewEC2(sess)
@@ -96,7 +97,7 @@ func NewALBController(awsconfig *aws.Config, conf *config.Config) *albController
 	ac.classNameGetter = classNameGetter
 	ac.annotationFactory = annotations.NewValidatingAnnotationFactory(&annotations.NewValidatingAnnotationFactoryOptions{
 		Validator:   annotations.NewConcreteValidator(),
-		ClusterName: ac.clusterName,
+		ClusterName: &ac.clusterName,
 	})
 
 	return ingress.Controller(ac).(*albController)


### PR DESCRIPTION
…not yet parsed via pflag.Parse(), swapped out to a pointer so that it will get updated when the controller is configured.