### PR TITLE
Logging cleanup, cache purging, and a small refactor

### DIFF
--- a/pkg/alb/ls/listener_test.go
+++ b/pkg/alb/ls/listener_test.go
@@ -78,7 +78,7 @@ func TestNewHTTPListener(t *testing.T) {
 		Logger: logr,
 	}
 
-	l := NewDesiredListener(o)
+	l, _ := NewDesiredListener(o)
 
 	desiredProto := "HTTP"
 	if o.CertificateArn != nil {
@@ -105,7 +105,7 @@ func TestNewHTTPSListener(t *testing.T) {
 		Logger:         logr,
 	}
 
-	l := NewDesiredListener(o)
+	l, _ := NewDesiredListener(o)
 
 	desiredProto := "HTTP"
 	if o.CertificateArn != nil {

--- a/pkg/alb/ls/listeners.go
+++ b/pkg/alb/ls/listeners.go
@@ -5,7 +5,6 @@ import (
 
 	extensions "k8s.io/api/extensions/v1beta1"
 
-	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/alb/rs"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/alb/tg"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/annotations"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/util/log"
@@ -20,18 +19,6 @@ func (ls Listeners) Reconcile(rOpts *ReconcileOptions) (Listeners, error) {
 			return nil, err
 		}
 
-		if l.ls.current != nil {
-			rsOpts := &rs.ReconcileOptions{
-				Eventf:       rOpts.Eventf,
-				ListenerArn:  l.ls.current.ListenerArn,
-				TargetGroups: rOpts.TargetGroups,
-			}
-			if rs, err := l.rules.Reconcile(rsOpts); err != nil {
-				return nil, err
-			} else {
-				l.rules = rs
-			}
-		}
 		if !l.deleted {
 			output = append(output, l)
 		}

--- a/pkg/alb/tg/targetgroup.go
+++ b/pkg/alb/tg/targetgroup.go
@@ -385,6 +385,8 @@ func (t *TargetGroup) registerTargets(additions util.AWSStringSlice, rOpts *Reco
 	}
 
 	if _, err := albelbv2.ELBV2svc.RegisterTargets(in); err != nil {
+		// Flush the cached health of the TG so that on the next iteration it will get fresh data, these change often
+		albelbv2.ELBV2svc.CacheDelete(albelbv2.DescribeTargetGroupTargetsForArnCache, *t.CurrentARN())
 		return err
 	}
 

--- a/pkg/alb/tg/targetgroup.go
+++ b/pkg/alb/tg/targetgroup.go
@@ -210,17 +210,19 @@ func (t *TargetGroup) create(rOpts *ReconcileOptions) error {
 		return fmt.Errorf("Failed TargetGroup creation. Unable to register targets:  %s.", err.Error())
 	}
 
-	// Add TargetGroup attributes
-	attributes := &elbv2.ModifyTargetGroupAttributesInput{
-		Attributes:     t.attributes.desired,
-		TargetGroupArn: t.CurrentARN(),
-	}
+	if len(t.attributes.desired) > 0 {
+		// Add TargetGroup attributes
+		attributes := &elbv2.ModifyTargetGroupAttributesInput{
+			Attributes:     t.attributes.desired,
+			TargetGroupArn: t.CurrentARN(),
+		}
 
-	if _, err := albelbv2.ELBV2svc.ModifyTargetGroupAttributes(attributes); err != nil {
-		rOpts.Eventf(api.EventTypeWarning, "ERROR", "Error adding attributes to target group %s: %s", t.ID, err.Error())
-		return fmt.Errorf("Failed TargetGroup creation. Unable to add target group attributes: %s.", err.Error())
+		if _, err := albelbv2.ELBV2svc.ModifyTargetGroupAttributes(attributes); err != nil {
+			rOpts.Eventf(api.EventTypeWarning, "ERROR", "Error adding attributes to target group %s: %s", t.ID, err.Error())
+			return fmt.Errorf("Failed TargetGroup creation. Unable to add target group attributes: %s.", err.Error())
+		}
+		t.attributes.current = t.attributes.desired
 	}
-	t.attributes.current = t.attributes.desired
 
 	return nil
 }

--- a/pkg/alb/tg/targetgroup.go
+++ b/pkg/alb/tg/targetgroup.go
@@ -161,16 +161,10 @@ func (t *TargetGroup) Reconcile(rOpts *ReconcileOptions) error {
 	default:
 		// Current and Desired exist and need for modification should be evaluated.
 		if mods := t.needsModification(); mods != 0 {
-			t.logger.Infof("Start TargetGroup modification.")
 			if err := t.modify(mods, rOpts); err != nil {
 				return err
 			}
 			rOpts.Eventf(api.EventTypeNormal, "CREATE", "%s target group modified", t.ID)
-			t.logger.Infof("Succeeded TargetGroup modification. ARN: %s | Name: %s.",
-				*t.tg.current.TargetGroupArn,
-				*t.tg.current.TargetGroupName)
-		} else {
-			// t.logger.Debugf("No TargetGroup modification required.")
 		}
 	}
 
@@ -199,24 +193,21 @@ func (t *TargetGroup) create(rOpts *ReconcileOptions) error {
 	o, err := albelbv2.ELBV2svc.CreateTargetGroup(in)
 	if err != nil {
 		rOpts.Eventf(api.EventTypeWarning, "ERROR", "Error creating target group %s: %s", t.ID, err.Error())
-		t.logger.Infof("Failed TargetGroup creation: %s.", err.Error())
-		return err
+		return fmt.Errorf("Failed TargetGroup creation: %s.", err.Error())
 	}
 	t.tg.current = o.TargetGroups[0]
 
 	// Add tags
 	if err = albelbv2.ELBV2svc.UpdateTags(t.CurrentARN(), t.tags.current, t.tags.desired); err != nil {
 		rOpts.Eventf(api.EventTypeWarning, "ERROR", "Error tagging target group %s: %s", t.ID, err.Error())
-		t.logger.Infof("Failed TargetGroup creation. Unable to add tags: %s.", err.Error())
-		return err
+		return fmt.Errorf("Failed TargetGroup creation. Unable to add tags: %s.", err.Error())
 	}
 	t.tags.current = t.tags.desired
 
 	// Register Targets
 	if err = t.registerTargets(t.targets.desired, rOpts); err != nil {
 		rOpts.Eventf(api.EventTypeWarning, "ERROR", "Error registering targets to target group %s: %s", t.ID, err.Error())
-		t.logger.Infof("Failed TargetGroup creation. Unable to register targets:  %s.", err.Error())
-		return err
+		return fmt.Errorf("Failed TargetGroup creation. Unable to register targets:  %s.", err.Error())
 	}
 
 	// Add TargetGroup attributes
@@ -227,8 +218,7 @@ func (t *TargetGroup) create(rOpts *ReconcileOptions) error {
 
 	if _, err := albelbv2.ELBV2svc.ModifyTargetGroupAttributes(attributes); err != nil {
 		rOpts.Eventf(api.EventTypeWarning, "ERROR", "Error adding attributes to target group %s: %s", t.ID, err.Error())
-		t.logger.Infof("Failed TargetGroup creation. Unable to add target group attributes: %s.", err.Error())
-		return err
+		return fmt.Errorf("Failed TargetGroup creation. Unable to add target group attributes: %s.", err.Error())
 	}
 	t.attributes.current = t.attributes.desired
 

--- a/pkg/albingress/albingress.go
+++ b/pkg/albingress/albingress.go
@@ -235,11 +235,9 @@ func (a *ALBIngress) Hostnames() ([]api.LoadBalancerIngress, error) {
 	}
 
 	if len(hostnames) == 0 {
-		a.logger.Errorf("No ALB hostnames for ingress")
 		return nil, fmt.Errorf("No ALB hostnames for ingress")
 	}
 
-	// a.logger.Debugf("Ingress library requested hostname list and we returned %s", *a.loadBalancer.Hostname())
 	return hostnames, nil
 }
 

--- a/pkg/aws/albelbv2/elbv2.go
+++ b/pkg/aws/albelbv2/elbv2.go
@@ -28,10 +28,13 @@ const (
 	deleteTargetGroupReattemptSleep int = 10
 	// Maximum attempts should be made to delete a target group
 	deleteTargetGroupReattemptMax int = 10
+
+	DescribeTargetGroupTargetsForArnCache string = "ELBV2-DescribeTargetGroupTargetsForArn"
 )
 
 type ELBV2API interface {
 	elbv2iface.ELBV2API
+	CacheDelete(string, string)
 	ClusterLoadBalancers(*albrgt.Resources) ([]*elbv2.LoadBalancer, error)
 	ClusterTargetGroups(*albrgt.Resources) (map[string][]*elbv2.TargetGroup, error)
 	UpdateTags(arn *string, old util.ELBv2Tags, new util.ELBv2Tags) error
@@ -311,9 +314,15 @@ func (e *ELBV2) DescribeListenersForLoadBalancer(loadBalancerArn *string) ([]*el
 	return listeners, nil
 }
 
+// CacheDelete deletes an item from the cache
+func (e *ELBV2) CacheDelete(cache, key string) {
+	cacheKey := cache + "." + key
+	e.cache.Delete(cacheKey)
+}
+
 // DescribeTargetGroupTargetsForArn looks up target group targets by an ARN.
 func (e *ELBV2) DescribeTargetGroupTargetsForArn(arn *string, targets ...[]*elbv2.TargetDescription) (result util.AWSStringSlice, err error) {
-	cache := "ELBV2-DescribeTargetGroupTargetsForArn"
+	cache := DescribeTargetGroupTargetsForArnCache
 	key := cache + "." + *arn
 	item := e.cache.Get(key)
 


### PR DESCRIPTION
Cleaned up a log of unnecessary log lines around errors.

Purge the TG health cache when targets prove to be unhealthy..

Refactored the current rule assembly code from being imbedded in the current listeners assemble code.