### PR TITLE
alb-ingress-controller tag changed

### DIFF
--- a/alb-ingress-controller-helm/README.md
+++ b/alb-ingress-controller-helm/README.md
@@ -47,7 +47,7 @@ Parameter | Description | Default
 `awsRegion` | (REQUIRED) AWS region in which this ingress controller will operate | `us-west-1`
 `clusterName` | (REQUIRED) Resources created by the ALB Ingress controller will be prefixed with this string | `k8s`
 `controller.image.repository` | controller container image repository | `quay.io/coreos/alb-ingress-controller`
-`controller.image.tag` | controller container image tag | `0.8`
+`controller.image.tag` | controller container image tag | `latest`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
 `controller.extraEnv` | map of environment variables to be injected into the controller pod | `{}`
 `controller.nodeSelector` | node labels for controller pod assignment | `{}`

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -17,7 +17,7 @@ clusterName: k8s
 controller:
   image:
     repository: quay.io/coreos/alb-ingress-controller
-    tag: "1.0-beta.2"
+    tag: "latest"
     pullPolicy: IfNotPresent
 
   extraEnv: {}


### PR DESCRIPTION
The default `1.0-beta.2` tag makes the pod keep restarting, because the liveness probe fails and Kubernetes tries to heal it. 
The `latest` tag seems to work good. We are not having troubles with the restarts anymore.