### PR TITLE
Change healthz port

### DIFF
--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -61,7 +61,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: 10254
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: {{ .Values.controller.readinessProbeInterval }}
@@ -69,7 +69,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /alive
-              port: 8080
+              port: 10254
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 60

--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -58,6 +58,8 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
+            - containerPort: 10254
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /healthz
@@ -69,7 +71,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /alive
-              port: 10254
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 60


### PR DESCRIPTION
We were having the same readiness probe problem as https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/281 and the changes in this PR appear to fix it.

FYI: an alternative fix might be possible by changing the entrypoint in the `alb-ingress-controller` Dockerfile to specify `--healthz-port=8080`. 