### PR TITLE
Adopt the  kubernetes.io/role/internal-elb and kubernetes.io/role/elb tags

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ A sample IAM policy, with the minimum permissions to run the controller, can be 
 
 By default, all ingress resources in your cluster are seen by the controller. However, only ingress resources that contain the [required annotations](https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/ingress-resources.md#required-annotations) will be satisfied by the ALB Ingress Controller.
 
-You can further limit the ingresses your controller has access to. The options available are limiting the ingress class  (`ingress.class`) or limiting the namespace watched (`--watch-namespace=`). Each approach is detailed below.
+You can further limit the ingresses your controller has access to. The options available are limiting the ingress class (`ingress.class`) or limiting the namespace watched (`--watch-namespace=`). Each approach is detailed below.
 
 ### Limiting Ingress Class
 
@@ -40,8 +40,6 @@ metadata:
   namespace: echoserver
   annotations:
     alb.ingress.kubernetes.io/port: "8080,9000"
-    alb.ingress.kubernetes.io/subnets: subnet-63bf6318,subnet-0b20aa62
-    alb.ingress.kubernetes.io/security-groups: sg-1f84f776
     kubernetes.io/ingress.class: "alb"
 spec:
 	...
@@ -75,6 +73,5 @@ kind: ConfigMap
 metadata:
   name: alb-ingress-controller-internet-facing-ingresses
 ```
-
 
 That ConfigMap is kept in `default` if unspecified, but can moved to another with the `ALB_CONTROLLER_RESTRICT_SCHEME_CONFIG_NAMESPACE` environment variable. This can also be passed to the command line via the `restrict-scheme-namespace` flag.

--- a/docs/ingress-resources.md
+++ b/docs/ingress-resources.md
@@ -17,8 +17,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internal
-    alb.ingress.kubernetes.io/subnets: subnet-1234
-    alb.ingress.kubernetes.io/security-groups: sg-1234
   labels:
     app: 2048-nginx-ingress
 spec:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,12 +24,12 @@ The controller determines subnets to deploy each ALB to based on an annotation o
 ##### Via tags on the subnets
 When subnet annotations are not present, the controller will attempt to choose the best subnets for deploying the ALBs. It uses the following tag criteria to determine the subnets it should use.
 
-* `kubernetes.io/cluster/$CLUSTER_NAME: = "shared"` `$CLUSTER_NAME` must match the `CLUSTER_NAME` environment variable on the controller.
+- `kubernetes.io/cluster/$CLUSTER_NAME` equal to `shared` or `owned`. `$CLUSTER_NAME` must match the `CLUSTER_NAME` environment variable on the controller.
 
 And one of the following:
 
-* `kubernetes.io/role/internal-elb: ""` For internal load balancers
-* `kubernetes.io/role/elb = ""` For internet-facing load balancers
+- `kubernetes.io/role/internal-elb: ""` For internal load balancers
+- `kubernetes.io/role/elb = ""` For internet-facing load balancers
 
 ### Security Group Selection
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -18,19 +18,24 @@ An example policy with the minimum rights can be found at [examples/iam-policy.j
 
 The controller determines subnets to deploy each ALB to based on an annotation or auto-detection.
 
-- annotation: `alb.ingress.kubernetes.io/subnets` may be specified in each ingress resource with the subnet IDs or `Name` tags. This allows for flexibility in where ALBs land. This list of subnets must include 2 or more that exist in unique availability zones. See the [annotations documentation](ingress-resources.md#annotations) for more details.
+##### Via annotation
+`alb.ingress.kubernetes.io/subnets` may be specified in each ingress resource with the subnet IDs or `Name` tags. This allows for flexibility in where ALBs land. This list of subnets must include 2 or more that exist in unique availability zones. See the [annotations documentation](ingress-resources.md#annotations) for more details.
 
-- auto-detection: When subnet annotations are not present, the controller will attempt to choose the best subnets for deploying the ALBs. It uses the following tag criteria to determine the subnets it should use.
+##### Via tags on the subnets
+When subnet annotations are not present, the controller will attempt to choose the best subnets for deploying the ALBs. It uses the following tag criteria to determine the subnets it should use.
 
-	- `kubernetes.io/cluster/$CLUSTER_NAME`=`shared` where `$CLUSTER_NAME` matches the `CLUSTER_NAME` environment variable from the `alb-ingress-controller.yaml` manifest.
+* `kubernetes.io/cluster/$CLUSTER_NAME: = "shared"` `$CLUSTER_NAME` must match the `CLUSTER_NAME` environment variable on the controller.
 
-	- `kubernetes.io/role/alb-ingress`=` ` where the value is empty.
+And one of the following:
+
+* `kubernetes.io/role/internal-elb: ""` For internal load balancers
+* `kubernetes.io/role/elb = ""` For internet-facing load balancers
 
 ### Security Group Selection
 
 The controller determines if it should create and manage security groups or use existing ones in AWS based on the presence of an annotation. When `alb.ingress.kubernetes.io/security-groups` is present, the list of security groups is assigned to the ALB instance. When the annotation is not present, the controller will create a security group with appropriate ports allowing access to `0.0.0.0/0` and attached to the ALB. It will also create a security group for instances that allows all TCP traffic when the source is the security group created for the ALB.
 
-## helm Deployments
+## Helm Deployments
 
 You must have the [Helm App Registry plugin](https://coreos.com/apps) installed for these instructions to work.
 
@@ -40,100 +45,98 @@ helm registry install quay.io/coreos/alb-ingress-controller-helm
 
 ## kubectl Deployments
 
-1. Setup default-backend-service
+1.  Setup default-backend-service
 
-	A default backend service is required for every ingress controller. The alb-ingress-controller does not make use of it, but will not be able to run the ingress libraries without it. To get around this, deploy a dummy default backend to the cluster. The following example will deploy one in `kube-system`; you may wish to adjust it.
- 
-	```
-	$ kubectl create -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/examples/default-backend.yaml
-	```
+    A default backend service is required for every ingress controller. The alb-ingress-controller does not make use of it, but will not be able to run the ingress libraries without it. To get around this, deploy a dummy default backend to the cluster. The following example will deploy one in `kube-system`; you may wish to adjust it.
 
-1. Configure the alb-ingress-controller manifest.
+    ```
+    $ kubectl create -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/examples/default-backend.yaml
+    ```
 
-	A sample manifest can be found below.
+1.  Configure the alb-ingress-controller manifest.
 
-	```  
-	$ wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/examples/alb-ingress-controller.yaml
-	```
+    A sample manifest can be found below.
 
-	At minimum, edit the following variables.
+    ```
+    $ wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/examples/alb-ingress-controller.yaml
+    ```
+
+    At minimum, edit the following variables.
 
     - `AWS_REGION`: region in AWS this cluster exists.
 
-		```yaml
-		- name: AWS_REGION
-		  value: us-west-1
-		```
+          	```yaml
+          	- name: AWS_REGION
+          	  value: us-west-1
+          	```
 
-	- `CLUSTER_NAME`: name of the cluster. If doing auto-detection of subnets (described in prerequisites above) `CLUSTER_NAME` must match the AWS tags associated with the subnets you wish ALBs to be provisioned.
+    - `CLUSTER_NAME`: name of the cluster. If doing auto-detection of subnets (described in prerequisites above) `CLUSTER_NAME` must match the AWS tags associated with the subnets you wish ALBs to be provisioned.
 
-		```yaml
-		- name: CLUSTER_NAME
-		  value: devCluster
-		```
+          	```yaml
+          	- name: CLUSTER_NAME
+          	  value: devCluster
+          	```
 
-1. Deploy the alb-ingress-controller manifest.
+1.  Deploy the alb-ingress-controller manifest.
 
-	```  
-	$ kubectl apply -f alb-ingress-controller.yaml	
-	```
+    ```
+    $ kubectl apply -f alb-ingress-controller.yaml
+    ```
 
-1. Verify the deployment was successful and the controller started.
+1.  Verify the deployment was successful and the controller started.
 
-	```bash
-	$ kubectl logs -n kube-system \
-	    $(kubectl get po -n kube-system | \
-	    egrep -o alb-ingress[a-zA-Z0-9-]+) | \
-	    egrep -o '\[ALB-INGRESS.*$'
-	```
+    ```bash
+    $ kubectl logs -n kube-system \
+        $(kubectl get po -n kube-system | \
+        egrep -o alb-ingress[a-zA-Z0-9-]+) | \
+        egrep -o '\[ALB-INGRESS.*$'
+    ```
 
-	Should display output similar to the following.
+    Should display output similar to the following.
 
-	```
-	[ALB-INGRESS] [controller] [INFO]: Log level read as "", defaulting to INFO. To change, set LOG_LEVEL environment variable to WARN, ERROR, or DEBUG.
-	[ALB-INGRESS] [controller] [INFO]: Ingress class set to alb
-	[ALB-INGRESS] [ingresses] [INFO]: Build up list of existing ingresses
-	[ALB-INGRESS] [ingresses] [INFO]: Assembled 0 ingresses from existing AWS resources
-	```
+    ```
+    [ALB-INGRESS] [controller] [INFO]: Log level read as "", defaulting to INFO. To change, set LOG_LEVEL environment variable to WARN, ERROR, or DEBUG.
+    [ALB-INGRESS] [controller] [INFO]: Ingress class set to alb
+    [ALB-INGRESS] [ingresses] [INFO]: Build up list of existing ingresses
+    [ALB-INGRESS] [ingresses] [INFO]: Assembled 0 ingresses from existing AWS resources
+    ```
 
 ## external-dns Deployment
 
 [external-dns](https://github.com/kubernetes-incubator/external-dns) provisions DNS records based on the host information. This project will setup and manage records in Route 53 that point to controller deployed ALBs.
 
+1.  Ensure your instance has the correct IAM permission required for external-dns. See https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md#iam-permissions.
 
-1. Ensure your instance has the correct IAM permission required for external-dns. See https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md#iam-permissions.
+1.  Download external-dns to manage Route 53.
 
+    ```bash
+    $ wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/examples/external-dns.yaml
+    ```
 
-1. Download external-dns to manage Route 53.
+1.  Edit the `--domain-filter` flag to include your hosted zone(s)
 
-	```bash
-	$ wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/examples/external-dns.yaml
-	```
+    The following example is for a hosted zone test-dns.com
 
-1. Edit the `--domain-filter` flag to include your hosted zone(s)
+    ```yaml
+    args:
+    - --source=service
+    - --source=ingress
+    - --domain-filter=test-dns.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
+    - --provider=aws
+    - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+    ```
 
-	The following example is for a hosted zone test-dns.com
+1.  Deploy external-dns
 
-	```yaml
-	args:
-	- --source=service
-	- --source=ingress
-	- --domain-filter=test-dns.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
-	- --provider=aws
-	- --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
-	```
+    ```
+    $ kubectl apply -f external-dns.yaml
+    ```
 
-1. Deploy external-dns
+1.  Verify it deployed successfully.
 
-	```  
-	$ kubectl apply -f external-dns.yaml	
-	```
+    ```
+    $ kubectl logs -f -n kube-system $(kubectl get po -n kube-system | egrep -o 'external-dns[A-Za-z0-9-]+')
 
-1. Verify it deployed successfully.
-
-	```
-	$ kubectl logs -f -n kube-system $(kubectl get po -n kube-system | egrep -o 'external-dns[A-Za-z0-9-]+')
-
-	time="2017-09-19T02:51:54Z" level=info msg="config: &{Master: KubeConfig: Sources:[service ingress] Namespace: FQDNTemplate: Compatibility: Provider:aws GoogleProject: DomainFilter:[] AzureConfigFile:/etc/kuberne tes/azure.json AzureResourceGroup: Policy:upsert-only Registry:txt TXTOwnerID:my-identifier TXTPrefix: Interval:1m0s Once:false DryRun:false LogFormat:text MetricsAddress::7979 Debug:false}"
-	time="2017-09-19T02:51:54Z" level=info msg="Connected to cluster at https://10.3.0.1:443"
-	```
+    time="2017-09-19T02:51:54Z" level=info msg="config: &{Master: KubeConfig: Sources:[service ingress] Namespace: FQDNTemplate: Compatibility: Provider:aws GoogleProject: DomainFilter:[] AzureConfigFile:/etc/kuberne tes/azure.json AzureResourceGroup: Policy:upsert-only Registry:txt TXTOwnerID:my-identifier TXTPrefix: Interval:1m0s Once:false DryRun:false LogFormat:text MetricsAddress::7979 Debug:false}"
+    time="2017-09-19T02:51:54Z" level=info msg="Connected to cluster at https://10.3.0.1:443"
+    ```

--- a/pkg/alb/lb/loadbalancer.go
+++ b/pkg/alb/lb/loadbalancer.go
@@ -38,6 +38,7 @@ type NewDesiredLoadBalancerOptions struct {
 	IngressAnnotations    *map[string]string
 	CommonTags            util.ELBv2Tags
 	IngressRules          []extensions.IngressRule
+	Resources             *albrgt.Resources
 	GetServiceNodePort    func(string, int32) (*int64, error)
 	GetServiceAnnotations func(string, string) (*map[string]string, error)
 	TargetsFunc           func(*string, string, string, *int64) albelbv2.TargetDescriptions
@@ -126,6 +127,7 @@ func NewDesiredLoadBalancer(o *NewDesiredLoadBalancerOptions) (newLoadBalancer *
 		GetServiceAnnotations: o.GetServiceAnnotations,
 		AnnotationFactory:     o.AnnotationFactory,
 		TargetsFunc:           o.TargetsFunc,
+		Resources:             o.Resources,
 	})
 
 	if err != nil {

--- a/pkg/alb/tg/targetgroups.go
+++ b/pkg/alb/tg/targetgroups.go
@@ -122,6 +122,7 @@ type NewDesiredTargetGroupsOptions struct {
 	LoadBalancerID        string
 	ExistingTargetGroups  TargetGroups
 	AnnotationFactory     annotations.AnnotationFactory
+	Resources             *albrgt.Resources
 	IngressAnnotations    *map[string]string
 	ALBNamePrefix         string
 	Namespace             string
@@ -151,6 +152,7 @@ func NewDesiredTargetGroups(o *NewDesiredTargetGroupsOptions) (TargetGroups, err
 				Namespace:             o.Namespace,
 				ServiceName:           path.Backend.ServiceName,
 				GetServiceAnnotations: o.GetServiceAnnotations,
+				Resources:             o.Resources,
 			})
 			if err != nil {
 				return output, err
@@ -196,6 +198,7 @@ type mergeAnnotationsOptions struct {
 	Namespace             string
 	ServiceName           string
 	GetServiceAnnotations func(string, string) (*map[string]string, error)
+	Resources             *albrgt.Resources
 }
 
 func mergeAnnotations(o *mergeAnnotationsOptions) (*annotations.Annotations, error) {
@@ -217,6 +220,7 @@ func mergeAnnotations(o *mergeAnnotationsOptions) (*annotations.Annotations, err
 		Annotations: mergedAnnotations,
 		Namespace:   o.Namespace,
 		ServiceName: o.ServiceName,
+		Resources:   o.Resources,
 	})
 
 	if err != nil {

--- a/pkg/albingress/albingress.go
+++ b/pkg/albingress/albingress.go
@@ -134,6 +134,7 @@ func NewALBIngressFromIngress(o *NewALBIngressFromIngressOptions) *ALBIngress {
 		GetServiceAnnotations: o.GetServiceAnnotations,
 		TargetsFunc:           o.TargetsFunc,
 		AnnotationFactory:     o.AnnotationFactory,
+		Resources:             o.Resources,
 	})
 
 	if err != nil {

--- a/pkg/albingress/albingress.go
+++ b/pkg/albingress/albingress.go
@@ -61,6 +61,7 @@ type NewALBIngressFromIngressOptions struct {
 	Recorder              record.EventRecorder
 	ConnectionIdleTimeout *int64
 	AnnotationFactory     annotations.AnnotationFactory
+	Resources             *albrgt.Resources
 }
 
 // NewALBIngressFromIngress builds ALBIngress's based off of an Ingress object
@@ -99,6 +100,7 @@ func NewALBIngressFromIngress(o *NewALBIngressFromIngressOptions) *ALBIngress {
 		Annotations: o.Ingress.Annotations,
 		Namespace:   o.Ingress.Namespace,
 		IngressName: o.Ingress.Name,
+		Resources:   o.Resources,
 	})
 	if err != nil {
 		msg := fmt.Sprintf("Error parsing annotations: %s", err.Error())

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/aws/albrgt"
+
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/karlseguin/ccache"
@@ -51,10 +52,6 @@ const (
 	tagsKey                       = "alb.ingress.kubernetes.io/tags"
 	ignoreHostHeader              = "alb.ingress.kubernetes.io/ignore-host-header"
 	targetGroupAttributesKey      = "alb.ingress.kubernetes.io/target-group-attributes"
-	clusterTagKey                 = "tag:kubernetes.io/cluster"
-	clusterTagValue               = "shared"
-	albRoleTagKey                 = "tag:kubernetes.io/role/alb-ingress"
-	albManagedSubnetsCacheKey     = "alb-managed-subnets"
 )
 
 // Annotations contains all of the annotation configuration for an ingress
@@ -116,6 +113,7 @@ type ParseAnnotationsOptions struct {
 	Namespace   string
 	IngressName string
 	ServiceName string
+	Resources   *albrgt.Resources
 }
 
 // ParseAnnotations validates and loads all the annotations provided into the Annotations struct.
@@ -153,7 +151,7 @@ func (vf *ValidatingAnnotationFactory) ParseAnnotations(opts *ParseAnnotationsOp
 		a.setIPAddressType(annotations),
 		a.setTargetType(annotations),
 		a.setSecurityGroups(annotations, vf.validator),
-		a.setSubnets(annotations, *vf.clusterName, vf.validator),
+		a.setSubnets(annotations, *vf.clusterName, opts.Resources, vf.validator),
 		a.setSuccessCodes(annotations),
 		a.setTags(annotations),
 		a.setIgnoreHostHeader(annotations),
@@ -488,58 +486,17 @@ func (a *Annotations) setSecurityGroups(annotations map[string]string, validator
 	return nil
 }
 
-func (a *Annotations) setSubnets(annotations map[string]string, clusterName string, validator Validator) error {
-	var names []*string
+func (a *Annotations) setSubnets(annotations map[string]string, clusterName string, resources *albrgt.Resources, validator Validator) error {
 	var out util.AWSStringSlice
+	var names []*string
 
 	// if the subnet annotation isn't specified, lookup appropriate subnets to use
 	if annotations[subnetsKey] == "" {
-
-		// check to see if subnets already exist in cache, if so return those
-		item := cacheLookup(albManagedSubnetsCacheKey)
-		if item != nil {
-			albprom.AWSCache.With(prometheus.Labels{"cache": "subnets", "action": "hit"}).Add(float64(1))
-			a.Subnets = item.Value().(util.Subnets)
-			return nil
-		}
-		albprom.AWSCache.With(prometheus.Labels{"cache": "subnets", "action": "miss"}).Add(float64(1))
-
-		in := &ec2.DescribeSubnetsInput{Filters: []*ec2.Filter{
-			{
-				Name:   aws.String(fmt.Sprintf("%s/%s", clusterTagKey, clusterName)),
-				Values: []*string{aws.String(clusterTagValue)},
-			},
-			{
-				Name:   aws.String(albRoleTagKey),
-				Values: []*string{},
-			},
-		}}
-		o, err := albec2.EC2svc.DescribeSubnets(in)
+		subnets, err := albec2.ClusterSubnets(a.Scheme, clusterName, resources)
 		if err != nil {
-			return fmt.Errorf("Unable to fetch subnets %v: %v", in.Filters, err)
+			a.Subnets = subnets
 		}
-
-		useableSubnets := []*ec2.Subnet{}
-		for _, subnet := range o.Subnets {
-			if subnetIsUsable(subnet, useableSubnets) {
-				useableSubnets = append(useableSubnets, subnet)
-				out = append(out, subnet.SubnetId)
-			}
-		}
-
-		if len(useableSubnets) < 2 {
-			return fmt.Errorf("Retrieval of subnets failed to resolve 2 qualified subnets. Subnets must "+
-				"contain the %s/%s tag with a value of %s and the %s tag signifying it should be used for ALBs "+
-				"Additionally, there must be at least 2 subnets with unique availability zones as required by "+
-				"ALBs. Either tag subnets to meet this requirement or use the subnets annotation on the "+
-				"ingress resource to explicitly call out what subnets to use for ALB creation. The subnets "+
-				"that did resolve were %v.", clusterTagKey, clusterName, clusterTagValue, albRoleTagKey,
-				awsutil.Prettify(useableSubnets))
-		}
-		sort.Sort(out)
-		a.Subnets = util.Subnets(out)
-		cache.Set(albManagedSubnetsCacheKey, a.Subnets, time.Minute*60)
-		return nil
+		return err
 	}
 
 	for _, subnet := range util.NewAWSStringSlice(annotations[subnetsKey]) {
@@ -615,18 +572,6 @@ func (a *Annotations) setSubnets(annotations map[string]string, clusterName stri
 	}
 
 	return nil
-}
-
-// subnetIsUsable determines if the subnet shares the same availablity zone as a subnet in the
-// existing list. If it does, false is returned as you cannot have albs provisioned to 2 subnets in
-// the same availability zone.
-func subnetIsUsable(new *ec2.Subnet, existing []*ec2.Subnet) bool {
-	for _, subnet := range existing {
-		if *new.AvailabilityZone == *subnet.AvailabilityZone {
-			return false
-		}
-	}
-	return true
 }
 
 func (a *Annotations) setSuccessCodes(annotations map[string]string) error {

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -493,7 +493,7 @@ func (a *Annotations) setSubnets(annotations map[string]string, clusterName stri
 	// if the subnet annotation isn't specified, lookup appropriate subnets to use
 	if annotations[subnetsKey] == "" {
 		subnets, err := albec2.ClusterSubnets(a.Scheme, clusterName, resources)
-		if err != nil {
+		if err == nil {
 			a.Subnets = subnets
 		}
 		return err

--- a/pkg/aws/albec2/ec2.go
+++ b/pkg/aws/albec2/ec2.go
@@ -30,8 +30,7 @@ const (
 	ManagedByKey     = "ManagedBy"
 	ManagedByValue   = "alb-ingress"
 
-	tagNameCluster  = "kubernetes.io/cluster"
-	tagValueCluster = "shared"
+	tagNameCluster = "kubernetes.io/cluster"
 
 	tagNameSubnetInternalELB = "kubernetes.io/role/internal-elb"
 	tagNameSubnetPublicELB   = "kubernetes.io/role/elb"
@@ -775,11 +774,11 @@ func ClusterSubnets(scheme *string, clusterName string, resources *albrgt.Resour
 
 	if len(useableSubnets) < 2 {
 		return nil, fmt.Errorf("Retrieval of subnets failed to resolve 2 qualified subnets. Subnets must "+
-			"contain the %s/%s tag with a value of %s and the %s tag signifying it should be used for ALBs "+
+			"contain the %s/%s tag with a value of shared or owned and the %s tag signifying it should be used for ALBs "+
 			"Additionally, there must be at least 2 subnets with unique availability zones as required by "+
 			"ALBs. Either tag subnets to meet this requirement or use the subnets annotation on the "+
 			"ingress resource to explicitly call out what subnets to use for ALB creation. The subnets "+
-			"that did resolve were %v.", tagNameCluster, clusterName, tagValueCluster, tagNameSubnetInternalELB,
+			"that did resolve were %v.", tagNameCluster, clusterName, tagNameSubnetInternalELB,
 			log.Prettify(useableSubnets))
 	}
 

--- a/pkg/aws/albec2/ec2.go
+++ b/pkg/aws/albec2/ec2.go
@@ -3,9 +3,13 @@ package albec2
 import (
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/aws/albelbv2"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/aws/albrgt"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/util/log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -16,12 +20,21 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	albprom "github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/prometheus"
+	util "github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/util/types"
 )
+
+var cache = ccache.New(ccache.Configure())
 
 const (
 	instSpecifierTag = "instance"
 	ManagedByKey     = "ManagedBy"
 	ManagedByValue   = "alb-ingress"
+
+	tagNameCluster  = "kubernetes.io/cluster"
+	tagValueCluster = "shared"
+
+	tagNameSubnetInternalELB = "kubernetes.io/role/internal-elb"
+	tagNameSubnetPublicELB   = "kubernetes.io/role/elb"
 )
 
 // EC2svc is a pointer to the awsutil EC2 service
@@ -702,4 +715,94 @@ func (e *EC2) Status() func() error {
 		}
 		return nil
 	}
+}
+
+// ClusterSubnets returns the subnets that are tagged for the cluster
+func ClusterSubnets(scheme *string, clusterName string, resources *albrgt.Resources) (util.Subnets, error) {
+	var useableSubnets []*ec2.Subnet
+	var out util.AWSStringSlice
+	var key string
+
+	if *scheme == "internal" {
+		key = tagNameSubnetInternalELB
+	} else if *scheme == "internet-facing" {
+		key = tagNameSubnetPublicELB
+	} else {
+		return nil, fmt.Errorf("Invalid scheme [%s]", *scheme)
+	}
+
+	var filterValues []*string
+	for arn, subnetTags := range resources.Subnets {
+		for _, tag := range subnetTags {
+			if *tag.Key == key {
+				p := strings.Split(arn, "/")
+				subnetID := &p[len(p)-1]
+				item := cacheLookup(*subnetID)
+				if item != nil {
+					albprom.AWSCache.With(prometheus.Labels{"cache": "subnets", "action": "hit"}).Add(float64(1))
+					if subnetIsUsable(item.Value().(*ec2.Subnet), useableSubnets) {
+						useableSubnets = append(useableSubnets, item.Value().(*ec2.Subnet))
+						out = append(out, item.Value().(*ec2.Subnet).SubnetId)
+					}
+				} else {
+					filterValues = append(filterValues, subnetID)
+					albprom.AWSCache.With(prometheus.Labels{"cache": "subnets", "action": "miss"}).Add(float64(1))
+				}
+			}
+		}
+	}
+
+	input := &ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name:   aws.String("subnet-id"),
+				Values: filterValues,
+			},
+		},
+	}
+	o, err := EC2svc.DescribeSubnets(input)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to fetch subnets %v: %v", log.Prettify(input.Filters), err)
+	}
+
+	for _, subnet := range o.Subnets {
+		if subnetIsUsable(subnet, useableSubnets) {
+			useableSubnets = append(useableSubnets, subnet)
+			out = append(out, subnet.SubnetId)
+			cache.Set(*subnet.SubnetId, subnet, time.Minute*60)
+		}
+	}
+
+	if len(useableSubnets) < 2 {
+		return nil, fmt.Errorf("Retrieval of subnets failed to resolve 2 qualified subnets. Subnets must "+
+			"contain the %s/%s tag with a value of %s and the %s tag signifying it should be used for ALBs "+
+			"Additionally, there must be at least 2 subnets with unique availability zones as required by "+
+			"ALBs. Either tag subnets to meet this requirement or use the subnets annotation on the "+
+			"ingress resource to explicitly call out what subnets to use for ALB creation. The subnets "+
+			"that did resolve were %v.", tagNameCluster, clusterName, tagValueCluster, tagNameSubnetInternalELB,
+			log.Prettify(useableSubnets))
+	}
+
+	sort.Sort(out)
+	return util.Subnets(out), nil
+}
+
+// subnetIsUsable determines if the subnet shares the same availablity zone as a subnet in the
+// existing list. If it does, false is returned as you cannot have albs provisioned to 2 subnets in
+// the same availability zone.
+func subnetIsUsable(new *ec2.Subnet, existing []*ec2.Subnet) bool {
+	for _, subnet := range existing {
+		if *new.AvailabilityZone == *subnet.AvailabilityZone {
+			return false
+		}
+	}
+	return true
+}
+
+func cacheLookup(key string) *ccache.Item {
+	i := cache.Get(key)
+	if i == nil || i.Expired() {
+		return nil
+	}
+	return i
 }

--- a/pkg/aws/albec2/ec2.go
+++ b/pkg/aws/albec2/ec2.go
@@ -772,14 +772,14 @@ func ClusterSubnets(scheme *string, clusterName string, resources *albrgt.Resour
 		}
 	}
 
-	if len(useableSubnets) < 2 {
+	if len(out) < 2 {
 		return nil, fmt.Errorf("Retrieval of subnets failed to resolve 2 qualified subnets. Subnets must "+
 			"contain the %s/%s tag with a value of shared or owned and the %s tag signifying it should be used for ALBs "+
 			"Additionally, there must be at least 2 subnets with unique availability zones as required by "+
 			"ALBs. Either tag subnets to meet this requirement or use the subnets annotation on the "+
 			"ingress resource to explicitly call out what subnets to use for ALB creation. The subnets "+
 			"that did resolve were %v.", tagNameCluster, clusterName, tagNameSubnetInternalELB,
-			log.Prettify(useableSubnets))
+			log.Prettify(out))
 	}
 
 	sort.Sort(out)

--- a/pkg/aws/albrgt/rgt.go
+++ b/pkg/aws/albrgt/rgt.go
@@ -3,6 +3,8 @@ package albrgt
 import (
 	"strings"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
+
 	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -34,6 +36,7 @@ type Resources struct {
 	Listeners     map[string]util.ELBv2Tags
 	ListenerRules map[string]util.ELBv2Tags
 	TargetGroups  map[string]util.ELBv2Tags
+	Subnets       map[string]util.EC2Tags
 }
 
 // GetResources looks up all ELBV2 (ALB) resources in AWS that are part of the cluster.
@@ -43,50 +46,92 @@ func (r *RGT) GetResources(clusterName *string) (*Resources, error) {
 		Listeners:     make(map[string]util.ELBv2Tags),
 		ListenerRules: make(map[string]util.ELBv2Tags),
 		TargetGroups:  make(map[string]util.ELBv2Tags),
+		Subnets:       make(map[string]util.EC2Tags),
 	}
 
-	params := resourcegroupstaggingapi.GetResourcesInput{
-		ResourceTypeFilters: []*string{
-			aws.String("elasticloadbalancing"),
+	paramSet := []*resourcegroupstaggingapi.GetResourcesInput{
+		&resourcegroupstaggingapi.GetResourcesInput{
+			ResourceTypeFilters: []*string{
+				aws.String("ec2"),
+			},
+			TagFilters: []*resourcegroupstaggingapi.TagFilter{
+				&resourcegroupstaggingapi.TagFilter{
+					Key:    aws.String("kubernetes.io/role/internal-elb"),
+					Values: []*string{aws.String("")},
+				},
+			},
 		},
-		TagFilters: []*resourcegroupstaggingapi.TagFilter{
-			&resourcegroupstaggingapi.TagFilter{
-				Key:    aws.String("kubernetes.io/cluster/" + *clusterName),
-				Values: []*string{aws.String("owned")},
+		&resourcegroupstaggingapi.GetResourcesInput{
+			ResourceTypeFilters: []*string{
+				aws.String("ec2"),
+			},
+			TagFilters: []*resourcegroupstaggingapi.TagFilter{
+				&resourcegroupstaggingapi.TagFilter{
+					Key:    aws.String("kubernetes.io/role/elb"),
+					Values: []*string{aws.String("")},
+				},
+			},
+		},
+		&resourcegroupstaggingapi.GetResourcesInput{
+			ResourceTypeFilters: []*string{
+				aws.String("elasticloadbalancing"),
+			},
+			TagFilters: []*resourcegroupstaggingapi.TagFilter{
+				&resourcegroupstaggingapi.TagFilter{
+					Key:    aws.String("kubernetes.io/cluster/" + *clusterName),
+					Values: []*string{aws.String("owned")},
+				},
 			},
 		},
 	}
 
-	p := request.Pagination{
-		EndPageOnSameToken: true,
-		NewRequest: func() (*request.Request, error) {
-			req, _ := r.GetResourcesRequest(&params)
-			return req, nil
-		},
-	}
+	for _, param := range paramSet {
+		p := request.Pagination{
+			EndPageOnSameToken: true,
+			NewRequest: func() (*request.Request, error) {
+				req, _ := r.GetResourcesRequest(param)
+				return req, nil
+			},
+		}
 
-	for p.Next() {
-		page := p.Page().(*resourcegroupstaggingapi.GetResourcesOutput)
-		for _, rtm := range page.ResourceTagMappingList {
-			switch {
-			case strings.Contains(*rtm.ResourceARN, ":loadbalancer/app/"):
-				resources.LoadBalancers[*rtm.ResourceARN] = rgtTagAsELBV2Tag(rtm.Tags)
-			case strings.Contains(*rtm.ResourceARN, ":listener/app/"):
-				resources.Listeners[*rtm.ResourceARN] = rgtTagAsELBV2Tag(rtm.Tags)
-			case strings.Contains(*rtm.ResourceARN, ":listener-rule/app/"):
-				resources.ListenerRules[*rtm.ResourceARN] = rgtTagAsELBV2Tag(rtm.Tags)
-			case strings.Contains(*rtm.ResourceARN, ":targetgroup/"):
-				resources.TargetGroups[*rtm.ResourceARN] = rgtTagAsELBV2Tag(rtm.Tags)
+		for p.Next() {
+			page := p.Page().(*resourcegroupstaggingapi.GetResourcesOutput)
+			for _, rtm := range page.ResourceTagMappingList {
+				switch {
+				case strings.Contains(*rtm.ResourceARN, ":loadbalancer/app/"):
+					resources.LoadBalancers[*rtm.ResourceARN] = rgtTagAsELBV2Tag(rtm.Tags)
+				case strings.Contains(*rtm.ResourceARN, ":listener/app/"):
+					resources.Listeners[*rtm.ResourceARN] = rgtTagAsELBV2Tag(rtm.Tags)
+				case strings.Contains(*rtm.ResourceARN, ":listener-rule/app/"):
+					resources.ListenerRules[*rtm.ResourceARN] = rgtTagAsELBV2Tag(rtm.Tags)
+				case strings.Contains(*rtm.ResourceARN, ":targetgroup/"):
+					resources.TargetGroups[*rtm.ResourceARN] = rgtTagAsELBV2Tag(rtm.Tags)
+				case strings.Contains(*rtm.ResourceARN, ":subnet/"):
+					resources.Subnets[*rtm.ResourceARN] = rgtTagAsEC2Tag(rtm.Tags)
+				}
 			}
+		}
+		if p.Err() != nil {
+			return nil, p.Err()
 		}
 	}
 
-	return resources, p.Err()
+	return resources, nil
 }
 
 func rgtTagAsELBV2Tag(in []*resourcegroupstaggingapi.Tag) (tags util.ELBv2Tags) {
 	for _, t := range in {
 		tags = append(tags, &elbv2.Tag{
+			Key:   t.Key,
+			Value: t.Value,
+		})
+	}
+	return tags
+}
+
+func rgtTagAsEC2Tag(in []*resourcegroupstaggingapi.Tag) (tags util.EC2Tags) {
+	for _, t := range in {
+		tags = append(tags, &ec2.Tag{
 			Key:   t.Key,
 			Value: t.Value,
 		})

--- a/pkg/aws/albrgt/rgt.go
+++ b/pkg/aws/albrgt/rgt.go
@@ -59,6 +59,10 @@ func (r *RGT) GetResources(clusterName *string) (*Resources, error) {
 					Key:    aws.String("kubernetes.io/role/internal-elb"),
 					Values: []*string{aws.String("")},
 				},
+				&resourcegroupstaggingapi.TagFilter{
+					Key:    aws.String("kubernetes.io/cluster/" + *clusterName),
+					Values: []*string{aws.String("owned"), aws.String("shared")},
+				},
 			},
 		},
 		&resourcegroupstaggingapi.GetResourcesInput{
@@ -70,6 +74,10 @@ func (r *RGT) GetResources(clusterName *string) (*Resources, error) {
 					Key:    aws.String("kubernetes.io/role/elb"),
 					Values: []*string{aws.String("")},
 				},
+				&resourcegroupstaggingapi.TagFilter{
+					Key:    aws.String("kubernetes.io/cluster/" + *clusterName),
+					Values: []*string{aws.String("owned"), aws.String("shared")},
+				},
 			},
 		},
 		&resourcegroupstaggingapi.GetResourcesInput{
@@ -79,7 +87,7 @@ func (r *RGT) GetResources(clusterName *string) (*Resources, error) {
 			TagFilters: []*resourcegroupstaggingapi.TagFilter{
 				&resourcegroupstaggingapi.TagFilter{
 					Key:    aws.String("kubernetes.io/cluster/" + *clusterName),
-					Values: []*string{aws.String("owned")},
+					Values: []*string{aws.String("owned"), aws.String("shared")},
 				},
 			},
 		},

--- a/pkg/aws/albrgt/rgt.go
+++ b/pkg/aws/albrgt/rgt.go
@@ -56,8 +56,7 @@ func (r *RGT) GetResources(clusterName *string) (*Resources, error) {
 			},
 			TagFilters: []*resourcegroupstaggingapi.TagFilter{
 				&resourcegroupstaggingapi.TagFilter{
-					Key:    aws.String("kubernetes.io/role/internal-elb"),
-					Values: []*string{aws.String("")},
+					Key: aws.String("kubernetes.io/role/internal-elb"),
 				},
 				&resourcegroupstaggingapi.TagFilter{
 					Key:    aws.String("kubernetes.io/cluster/" + *clusterName),
@@ -71,8 +70,7 @@ func (r *RGT) GetResources(clusterName *string) (*Resources, error) {
 			},
 			TagFilters: []*resourcegroupstaggingapi.TagFilter{
 				&resourcegroupstaggingapi.TagFilter{
-					Key:    aws.String("kubernetes.io/role/elb"),
-					Values: []*string{aws.String("")},
+					Key: aws.String("kubernetes.io/role/elb"),
 				},
 				&resourcegroupstaggingapi.TagFilter{
 					Key:    aws.String("kubernetes.io/cluster/" + *clusterName),


### PR DESCRIPTION
This PR leverages the common Kubernetes subnet tags to auto-detect internal and internet-facing subnets.