### PR TITLE
Allow non-NodePort services when we use the pod target type

### DIFF
--- a/pkg/alb/lb/loadbalancer.go
+++ b/pkg/alb/lb/loadbalancer.go
@@ -39,7 +39,7 @@ type NewDesiredLoadBalancerOptions struct {
 	CommonTags            util.ELBv2Tags
 	IngressRules          []extensions.IngressRule
 	Resources             *albrgt.Resources
-	GetServiceNodePort    func(string, int32) (*int64, error)
+	GetServiceNodePort    func(string, string, int32) (*int64, error)
 	GetServiceAnnotations func(string, string) (*map[string]string, error)
 	TargetsFunc           func(*string, string, string, *int64) albelbv2.TargetDescriptions
 }

--- a/pkg/albingress/albingress.go
+++ b/pkg/albingress/albingress.go
@@ -55,7 +55,7 @@ type NewALBIngressFromIngressOptions struct {
 	ExistingIngress       *ALBIngress
 	ClusterName           string
 	ALBNamePrefix         string
-	GetServiceNodePort    func(string, int32) (*int64, error)
+	GetServiceNodePort    func(string, string, int32) (*int64, error)
 	GetServiceAnnotations func(string, string) (*map[string]string, error)
 	TargetsFunc           func(*string, string, string, *int64) albelbv2.TargetDescriptions
 	Recorder              record.EventRecorder

--- a/pkg/albingress/albingress_test.go
+++ b/pkg/albingress/albingress_test.go
@@ -65,7 +65,7 @@ func TestNewALBIngressFromIngress(t *testing.T) {
 				Name:        "testIngress",
 			},
 		},
-		GetServiceNodePort: func(s string, i int32) (*int64, error) {
+		GetServiceNodePort: func(s, t string, i int32) (*int64, error) {
 			nodePort := int64(8000)
 			return &nodePort, nil
 		},

--- a/pkg/albingress/albingresses.go
+++ b/pkg/albingress/albingresses.go
@@ -24,7 +24,7 @@ type NewALBIngressesFromIngressesOptions struct {
 	ALBIngresses          ALBIngresses
 	IngressClass          string
 	DefaultIngressClass   string
-	GetServiceNodePort    func(string, int32) (*int64, error)
+	GetServiceNodePort    func(string, string, int32) (*int64, error)
 	GetServiceAnnotations func(string, string) (*map[string]string, error)
 	TargetsFunc           func(*string, string, string, *int64) albelbv2.TargetDescriptions
 	AnnotationFactory     annotations.AnnotationFactory

--- a/pkg/controller/alb-controller_test.go
+++ b/pkg/controller/alb-controller_test.go
@@ -278,17 +278,17 @@ func TestALBController_GetServiceNodePort(t *testing.T) {
 		},
 	}
 
-	np, err := ac.GetServiceNodePort("service1", 4002)
+	np, err := ac.GetServiceNodePort("service1", "instance", 4002)
 	if *np != 8020 {
 		t.Errorf("Expected node port for service1 to be 8020")
 	}
 
-	np, err = ac.GetServiceNodePort("service1", 4000)
+	np, err = ac.GetServiceNodePort("service1", "instance", 4000)
 	if *np != 8000 {
 		t.Errorf("Expected node port for service1 to be 8000")
 	}
 
-	np, err = ac.GetServiceNodePort("service2", 4001)
+	np, err = ac.GetServiceNodePort("service2", "instance", 4001)
 	if np != nil {
 		t.Error("Expected nil as service2 is not a node port service")
 	}
@@ -296,7 +296,7 @@ func TestALBController_GetServiceNodePort(t *testing.T) {
 		t.Errorf("Expected error as service2 is not a node port service")
 	}
 
-	np, err = ac.GetServiceNodePort("service1", 4001)
+	np, err = ac.GetServiceNodePort("service1", "instance", 4001)
 	if np != nil {
 		t.Errorf("Expected nil as service1 is not listening on backend port 4001")
 	}
@@ -304,7 +304,7 @@ func TestALBController_GetServiceNodePort(t *testing.T) {
 		t.Errorf("Expected failure as service1 is not listening on backend port 4001")
 	}
 
-	np, err = ac.GetServiceNodePort("service3", 5000)
+	np, err = ac.GetServiceNodePort("service3", "instance", 5000)
 	if np != nil {
 		t.Errorf("Expected nil as service3 does not exist")
 	}


### PR DESCRIPTION
Resolves #463 