### PR TITLE
Add DescribeSSLPolicies to iam-policy.json

### DIFF
--- a/examples/iam-policy.json
+++ b/examples/iam-policy.json
@@ -40,6 +40,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeLoadBalancerAttributes",
         "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeSSLPolicies",
         "elasticloadbalancing:DescribeTags",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetGroupAttributes",


### PR DESCRIPTION
Add `elasticloadbalancing:DescribeSSLPolicies` to work with the `alb.ingress.kubernetes.io/ssl-policy` annotation