### PR TITLE
move helm controller values to root

### DIFF
--- a/alb-ingress-controller-helm/Chart.yaml
+++ b/alb-ingress-controller-helm/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 name: alb-ingress-controller-helm
 sources:
   - https://github.com/kubernetes-sigs/aws-alb-ingress-controller
-version: 0.0.11
+version: 0.1.0

--- a/alb-ingress-controller-helm/templates/deployment.yaml
+++ b/alb-ingress-controller-helm/templates/deployment.yaml
@@ -11,22 +11,22 @@ metadata:
 spec:
   template:
     metadata:
-    {{- if .Values.controller.podAnnotations }}
+    {{- if .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.controller.podAnnotations | indent 8}}
+{{ toYaml .Values.podAnnotations | indent 8}}
     {{- end }}
       labels:
         app: {{ template "name" . }}
         component: controller
         release: {{ .Release.Name }}
-      {{- if .Values.controller.podLabels }}
-{{ toYaml .Values.controller.podLabels | indent 8}}
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8}}
       {{- end }}
     spec:
       containers:
         - name: {{ template "name" . }}-controller
-          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
-          imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           args:
             - /server
             - --cluster-name={{ .Values.clusterName }}
@@ -42,7 +42,7 @@ spec:
           env:
             - name: AWS_REGION
               value: "{{ .Values.awsRegion }}"
-          {{- range $key, $value := .Values.controller.extraEnv }}
+          {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}
               value: "{{ $value }}"
           {{- end }}
@@ -65,8 +65,8 @@ spec:
               port: 10254
               scheme: HTTP
             initialDelaySeconds: 30
-            periodSeconds: {{ .Values.controller.readinessProbeInterval }}
-            timeoutSeconds: {{ .Values.controller.readinessProbeTimeout }}
+            periodSeconds: {{ .Values.readinessProbeInterval }}
+            timeoutSeconds: {{ .Values.readinessProbeTimeout }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -74,20 +74,20 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 60
-        {{- if .Values.controller.resources }}
+        {{- if .Values.resources }}
           resources:
-{{ toYaml .Values.controller.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 12 }}
         {{- end }}
         {{- if .Values.sidecarContainers }}
 {{ toYaml .Values.sidecarContainers | indent 8}}
         {{- end }}
-    {{- if .Values.controller.nodeSelector }}
+    {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.controller.nodeSelector | indent 8 }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.controller.tolerations }}
+    {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.controller.tolerations | indent 8 }}
+{{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       terminationGracePeriodSeconds: 60

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -14,47 +14,45 @@ awsRegion: us-west-1
 #
 clusterName: k8s
 
-controller:
-  image:
-    repository: quay.io/coreos/alb-ingress-controller
-    tag: "1.0-beta.5"
-    pullPolicy: IfNotPresent
+image:
+  repository: quay.io/coreos/alb-ingress-controller
+  tag: "1.0-beta.5"
+  pullPolicy: IfNotPresent
 
-  extraArgs: {}
-  extraEnv: {}
-    # AWS_ACCESS_KEY_ID: ""
-    # AWS_SECRET_ACCESS_KEY: ""
-    # AWS_DEBUG: false
-    # AWS_MAX_RETRIES: 20
-    # LOG_LEVEL: ""
+extraArgs: {}
+extraEnv: {}
+  # AWS_ACCESS_KEY_ID: ""
+  # AWS_SECRET_ACCESS_KEY: ""
+  # AWS_DEBUG: false
+  # AWS_MAX_RETRIES: 20
+  # LOG_LEVEL: ""
 
-  nodeSelector: {}
-    # node-role.kubernetes.io/node: "true"
-    # tier: cs
+nodeSelector: {}
+  # node-role.kubernetes.io/node: "true"
+  # tier: cs
 
-  tolerations: {}
-#    - key: "node-role.kubernetes.io/master"
-#      effect: NoSchedule
+tolerations: {}
+  #  - key: "node-role.kubernetes.io/master"
+  #    effect: NoSchedule
 
-  podAnnotations: {}
-    # iam.amazonaws.com/role: alb-ingress-controller
+podAnnotations: {}
+  # iam.amazonaws.com/role: alb-ingress-controller
 
-  podLabels: {}
+podLabels: {}
 
-  # How often (in seconds) to check controller readiness
-  readinessProbeInterval: 10
+# How often (in seconds) to check controller readiness
+readinessProbeInterval: 10
 
-  # How long to wait before timeout (in seconds) when checking controller readiness
-  readinessProbeTimeout: 1
+# How long to wait before timeout (in seconds) when checking controller readiness
+readinessProbeTimeout: 1
 
-  resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 100Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 100Mi
-
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 100Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 100Mi
 
 rbac:
   ## If true, create & use RBAC resources


### PR DESCRIPTION
Considering that the default backend is no longer required, move the controller values to the root.