### PR TITLE
Update iam-policy.json.

### DIFF
--- a/examples/iam-policy.json
+++ b/examples/iam-policy.json
@@ -3,7 +3,7 @@
   "Statement": [
     {
       "Effect": "Allow",
-      "Action": ["acm:DescribeCertificate", "acm:ListCertificates"],
+      "Action": ["acm:DescribeCertificate", "acm:ListCertificates", "acm:GetCertificate"],
       "Resource": "*"
     },
     {


### PR DESCRIPTION
Without action `"acm:GetCertificate"` alb creation fails in case you have `alb.ingress.kubernetes.io/certificate-arn` declared.
The error is:
 ```  ERROR   26s (x2 over 1m)  ingress-controller  Error parsing annotations: ACM certificate ARN does not exist. ARN: arn:aws:acm:us-east-1:{acount_id}/certificate/{certificate_id} ```.
This produced on a managed AWS EKS Cluster.