### PR TITLE
Revert to previous image tag

### DIFF
--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -16,7 +16,7 @@ clusterName: k8s
 
 image:
   repository: quay.io/coreos/alb-ingress-controller
-  tag: "1.0-beta.5"
+  tag: "1.0-beta.4"
   pullPolicy: IfNotPresent
 
 extraArgs: {}


### PR DESCRIPTION
The `1.0-beta.5` tag doesn't exist upstream. Revert this change for now.

Fixes #493 