### PR TITLE
Leverage the EC2 state when building a list of cluster nodes

### DIFF
--- a/internal/alb/tg/targetgroup.go
+++ b/internal/alb/tg/targetgroup.go
@@ -53,6 +53,7 @@ func NewDesiredTargetGroup(o *NewDesiredTargetGroupOptions) *TargetGroup {
 
 	n := fmt.Sprintf("%s-%s", o.SvcName, hex.EncodeToString(hasher.Sum(nil)))
 	id := fmt.Sprintf("%.12s-%.19s", o.Store.GetConfig().ALBNamePrefix, n)
+	id = strings.TrimRight(id, "-")
 
 	// TODO: Quick fix as we can't have the loadbalancer and target groups share pointers to the same
 	// tags. Each modify tags individually and can cause bad side-effects.
@@ -439,7 +440,6 @@ func (t *TargetGroup) registerTargets(additions albelbv2.TargetDescriptions, rOp
 
 	if _, err := albelbv2.ELBV2svc.RegisterTargets(in); err != nil {
 		// Flush the cached health of the TG so that on the next iteration it will get fresh data, these change often
-		albelbv2.ELBV2svc.CacheDelete(albelbv2.DescribeTargetGroupTargetsForArnCache, *t.CurrentARN())
 		return err
 	}
 

--- a/internal/alb/tg/targetgroups.go
+++ b/internal/alb/tg/targetgroups.go
@@ -172,15 +172,6 @@ func NewDesiredTargetGroups(o *NewDesiredTargetGroupsOptions) (TargetGroups, err
 			// If this target group is already defined, copy the current state to our new TG
 			if i, _ := o.ExistingTargetGroups.FindById(targetGroup.ID); i >= 0 {
 				output[i].copyDesiredState(targetGroup)
-
-				// If there is a current TG ARN we can use it to purge the desired targets of unready instances
-				if output[i].CurrentARN() != nil && *tgAnnotations.TargetGroup.TargetType == "instance" {
-					desired, err := albelbv2.ELBV2svc.DescribeTargetGroupTargetsForArn(output[i].CurrentARN(), output[i].targets.desired)
-					if err != nil {
-						return nil, err
-					}
-					output[i].targets.desired = desired
-				}
 			} else {
 				output = append(output, targetGroup)
 			}

--- a/internal/aws/albelbv2/dummy.go
+++ b/internal/aws/albelbv2/dummy.go
@@ -34,7 +34,7 @@ func (d *Dummy) UpdateTags(arn *string, old util.ELBv2Tags, new util.ELBv2Tags) 
 func (d *Dummy) RemoveTargetGroup(arn *string) error { return nil }
 
 // DescribeTargetGroupTargetsForArn ...
-func (d *Dummy) DescribeTargetGroupTargetsForArn(arn *string, targets ...TargetDescriptions) (TargetDescriptions, error) {
+func (d *Dummy) DescribeTargetGroupTargetsForArn(arn *string) (TargetDescriptions, error) {
 	return nil, nil
 }
 

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/aws/albec2"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/aws/albelbv2"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -623,6 +624,9 @@ func (s *k8sStore) GetTargets(mode *string, namespace string, svc string, port *
 
 	if *mode == "instance" {
 		for _, node := range s.ListNodes() {
+			if !albec2.EC2svc.IsNodeHealthy(s.GetNodeInstanceId(node)) {
+				continue
+			}
 			result = append(result,
 				&elbv2.TargetDescription{
 					Id:   aws.String(s.GetNodeInstanceId(node)),

--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -223,6 +223,10 @@ func runUpdate(ing *extensions.Ingress, client clientset.Interface, rc *ingress.
 			return true, nil
 		}
 
+		if len(current) == 0 {
+			return nil, nil
+		}
+
 		ingClient := client.ExtensionsV1beta1().Ingresses(ing.Namespace)
 
 		currIng, err := ingClient.Get(ing.Name, metav1.GetOptions{})


### PR DESCRIPTION
Since an EC2 instance can be removed long before its removed from Kubernetes, check the EC2 state before adding it to our potential targets.