### PR TITLE
Validate node's providerID in case it's empty

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,6 +8,10 @@ If you'd prefer an end-to-end walkthrough (example) of setup instead, see [the e
 
 This section details what must be setup in order for the controller to run.
 
+### Kubelet
+
+The [kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) must be run with `--cloud-provider=aws`. This populates the EC2 instance ID in each node's spec.
+
 ### Role Permissions
 
 Adequate roles and policies must be configured in AWS and available to the node(s) running the controller. How access is granted is up to you. Some will attach the needed rights to node's role in AWS. Others will use projects like [kube2iam](https://github.com/jtblin/kube2iam).


### PR DESCRIPTION
When the kubelet is not run with `--cloud-provider=aws`, the value of `node.Spec.ProviderID` is `""`. I found this to be the case in our cluster since we didn't need persistent volume support right away and were running without the cloud provider enabled.

In the absence of this validation, the error is fairly hard to identify. The result is a call to `IsNodeHealthy` with an empty string as the instance ID which calls `ec2:DescribeInstanceStatus` with the same input. Amazon rejects that request with a 400. 

I've also added a short section to the setup docs mentioning that the cloud provider is required.