### PR TITLE
Avoid deprecated SharedInformerFactory API

### DIFF
--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -219,7 +219,9 @@ func New(cfg *config.Configuration, updateCh *channels.RingChannel) Storer {
 	store.listers.ServiceAnnotation.Store = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
 	// create informers factory, enable and assign required informers
-	infFactory := informers.NewFilteredSharedInformerFactory(cfg.Client, cfg.ResyncPeriod, cfg.Namespace, func(*metav1.ListOptions) {})
+	infFactory := informers.NewSharedInformerFactoryWithOptions(cfg.Client, cfg.ResyncPeriod,
+		informers.WithNamespace(cfg.Namespace),
+		informers.WithTweakListOptions(func(*metav1.ListOptions){}))
 
 	store.informers.Ingress = infFactory.Extensions().V1beta1().Ingresses().Informer()
 	store.listers.Ingress.Store = store.informers.Ingress.GetStore()


### PR DESCRIPTION
`NewFilteredSharedInformerFactory` has been deprecated, with `NewSharedInformerFactoryWithOptions` taking its place with no change in behavior.

This is a tiny PR just to test the waters and make sure I've done all the setup and paperwork required to contribute to the project.

Also, hello and thank you so much for alb-ingress-controller. It's exactly what I've been looking for! 👋