### PR TITLE
wait readiness delay for liveness to start

### DIFF
--- a/alb-ingress-controller-helm/Chart.yaml
+++ b/alb-ingress-controller-helm/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 name: alb-ingress-controller-helm
 sources:
   - https://github.com/kubernetes-sigs/aws-alb-ingress-controller
-version: 0.1.0
+version: 0.1.1

--- a/alb-ingress-controller-helm/templates/deployment.yaml
+++ b/alb-ingress-controller-helm/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
               path: /healthz
               port: 10254
               scheme: HTTP
-            initialDelaySeconds: 30
+            initialDelaySeconds: {{ add 30 .Values.readinessProbeTimeout }}
             periodSeconds: 60
         {{- if .Values.resources }}
           resources:


### PR DESCRIPTION
Currently the liveness probe will start before the readiness probe has completed. This will ensure at least the readiness probe timeout is finished before starting the liveness probe.