### PR TITLE
Generate target group IDs with hashed LB scheme

### DIFF
--- a/internal/alb/tg/targetgroup.go
+++ b/internal/alb/tg/targetgroup.go
@@ -46,15 +46,7 @@ type NewDesiredTargetGroupOptions struct {
 
 // NewDesiredTargetGroup returns a new targetgroup.TargetGroup based on the parameters provided.
 func NewDesiredTargetGroup(o *NewDesiredTargetGroupOptions) *TargetGroup {
-	hasher := md5.New()
-	hasher.Write([]byte(o.LoadBalancerID))
-	hasher.Write([]byte(o.SvcName))
-	hasher.Write([]byte(o.SvcPort.String()))
-	hasher.Write([]byte(fmt.Sprintf("%d", o.TargetPort)))
-	hasher.Write([]byte(*o.Annotations.TargetGroup.BackendProtocol))
-	hasher.Write([]byte(*o.Annotations.TargetGroup.TargetType))
-
-	id := fmt.Sprintf("%.12s-%.19s", o.Store.GetConfig().ALBNamePrefix, hex.EncodeToString(hasher.Sum(nil)))
+	id := o.generateID()
 
 	tgTags := o.CommonTags.Copy()
 	tgTags = append(tgTags, &elbv2.Tag{
@@ -92,6 +84,22 @@ func NewDesiredTargetGroup(o *NewDesiredTargetGroupOptions) *TargetGroup {
 		},
 		attributes: attributes{desired: o.Annotations.TargetGroup.Attributes},
 	}
+}
+
+func (o *NewDesiredTargetGroupOptions) generateID() string {
+	hasher := md5.New()
+	hasher.Write([]byte(o.LoadBalancerID))
+	hasher.Write([]byte(o.SvcName))
+	hasher.Write([]byte(o.SvcPort.String()))
+	hasher.Write([]byte(fmt.Sprintf("%d", o.TargetPort)))
+	lbCfg := o.Annotations.LoadBalancer
+	if lbCfg != nil {
+		hasher.Write([]byte(aws.StringValue(lbCfg.Scheme)))
+	}
+	hasher.Write([]byte(aws.StringValue(o.Annotations.TargetGroup.BackendProtocol)))
+	hasher.Write([]byte(aws.StringValue(o.Annotations.TargetGroup.TargetType)))
+
+	return fmt.Sprintf("%.12s-%.19s", o.Store.GetConfig().ALBNamePrefix, hex.EncodeToString(hasher.Sum(nil)))
 }
 
 type NewDesiredTargetGroupFromBackendOptions struct {

--- a/internal/alb/tg/targetgroup_test.go
+++ b/internal/alb/tg/targetgroup_test.go
@@ -1,0 +1,77 @@
+package tg
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/loadbalancer"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/targetgroup"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/controller/config"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/controller/store"
+	"testing"
+)
+
+func Test_generateID(t *testing.T) {
+	var tests = []struct {
+		name string
+		opts *NewDesiredTargetGroupOptions
+		want string
+	}{
+		{
+			"plain",
+			&NewDesiredTargetGroupOptions{
+				Store: store.NewDummy(),
+				Annotations: annotations.NewServiceDummy(),
+			},
+			"alb-92ed2e2b69f211d4078",
+		}, {
+			"with ALB name prefix",
+			&NewDesiredTargetGroupOptions{
+				Store: store.NewDummy().SetConfig(&config.Configuration{
+					ALBNamePrefix: "foobar",
+				}),
+				Annotations: annotations.NewServiceDummy(),
+			},
+			"foobar-92ed2e2b69f211d4078",
+		}, {
+			"with lb scheme internet-facing",
+			&NewDesiredTargetGroupOptions{
+				Store: &store.Dummy{},
+				Annotations: &annotations.Service{
+					LoadBalancer: &loadbalancer.Config{
+						Scheme: aws.String(elbv2.LoadBalancerSchemeEnumInternetFacing),
+					},
+					TargetGroup: &targetgroup.Config{
+						BackendProtocol: aws.String(elbv2.ProtocolEnumHttps),
+						TargetType:      aws.String(elbv2.TargetTypeEnumIp),
+					},
+				},
+			},
+			"alb-87a2e9e36f52bfd9690",
+		}, {
+			"with lb scheme internal",
+			&NewDesiredTargetGroupOptions{
+				Store: &store.Dummy{},
+				Annotations: &annotations.Service{
+					LoadBalancer: &loadbalancer.Config{
+						Scheme: aws.String(elbv2.LoadBalancerSchemeEnumInternal),
+					},
+					TargetGroup: &targetgroup.Config{
+						BackendProtocol: aws.String(elbv2.ProtocolEnumHttps),
+						TargetType:      aws.String(elbv2.TargetTypeEnumIp),
+					},
+				},
+			},
+			"alb-f03287dfdae0195a939",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			have := test.opts.generateID()
+			if test.want != have {
+				t.Errorf("Expected '%s', got '%s'", test.want, have)
+			}
+		})
+	}
+}

--- a/internal/ingress/controller/store/dummy.go
+++ b/internal/ingress/controller/store/dummy.go
@@ -76,8 +76,9 @@ func (d Dummy) GetConfig() *config.Configuration {
 }
 
 // SetConfig ...
-func (d *Dummy) SetConfig(c *config.Configuration) {
+func (d *Dummy) SetConfig(c *config.Configuration) *Dummy {
 	d.cfg = c
+	return d
 }
 
 // GetInstanceIDFromPodIP ...


### PR DESCRIPTION
This way we can have two instances of alb-ingress-controller running, one taking care of public ingresses, and another taking care of internal ones.