### PR TITLE
fix 2048 example

### DIFF
--- a/examples/2048/2048-ingress.yaml
+++ b/examples/2048/2048-ingress.yaml
@@ -6,13 +6,14 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/scheme: internet-facing
   labels:
     app: 2048-ingress
 spec:
   rules:
     - http:
         paths:
-          - path: /
+          - path: /*
             backend:
               serviceName: "service-2048"
               servicePort: 80


### PR DESCRIPTION
fix 2048 example
fix https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/635
Test done: d560e4e0-2048game-2048ingr-6fa0-2016523584.us-west-2.elb.amazonaws.com