### PR TITLE
1. Fix issues with targetgroup

### DIFF
--- a/internal/albingress/albingresses.go
+++ b/internal/albingress/albingresses.go
@@ -133,6 +133,8 @@ func (a ALBIngresses) RemovedIngresses(newList ALBIngresses) ALBIngresses {
 			// no longer relevant to the ALBController.
 			if ingress.loadBalancer != nil {
 				ingress.stripDesiredState()
+				ingress.resetBackoff()
+				ingress.valid = true
 				deleteableIngress = append(deleteableIngress, ingress)
 			}
 		}


### PR DESCRIPTION
Purpose:
1. Fix https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/363
1. Fix https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/536(reproduce: delete service before ingress)
1. Fix https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/603(reproduce: delete namespace before ingress)

Test done:
1. test cases for above issues.
1. various manual test regarding to tg creation/delete/modification and it's relation with securityGroup attachment.