### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - GO111MODULE=on
 
 go:
-  - master
+  - "1.11.1"
 
 services:
   - docker


### PR DESCRIPTION
Fix travis build as info in https://github.com/golang/go/issues/27925
For now, let's use 1.11.1 in travis since it's the newest version on mac(we don't want to break mac build).

Once golang releases a new version that contains https://github.com/golang/go/commit/1bca6cecc627cd708c6c5440eb14f84a99d5324b, we can change back to master