### PR TITLE
Return targets details in targets Reconcile() function.

### DIFF
--- a/internal/alb/tg/targets.go
+++ b/internal/alb/tg/targets.go
@@ -99,6 +99,9 @@ func (c *targetsController) Reconcile(ctx context.Context, t *Targets) error {
 		}
 		// TODO add Delete events ?
 	}
+
+	t.Targets = desired;
+
 	return nil
 }
 


### PR DESCRIPTION
This fixes a bug #681 where managed SG was not getting correctly associated to supporting ENI's because the target details were not available..