### PR TITLE
fix(docs): Updated link to example iam-policy that was moved per #701.

### DIFF
--- a/docs/guide/walkthrough.md
+++ b/docs/guide/walkthrough.md
@@ -305,7 +305,7 @@ If you want to use kube2iam to provide the AWS credentials you'll
 - update the alb-ingress-controller.yaml
 
 1.  configure the proper policy
-    The policy to be used can be fetched from https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/examples/iam-policy.json
+    The policy to be used can be fetched from https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/examples/iam-policy.json
 
 1.  configure the proper role and create the trust relationship
     You have to find which role is associated woth your K8S nodes. Once you found take note of the full arn:


### PR DESCRIPTION
Was following the walkthrough guide for configuration of kube2iam and found this link to be stale per #701.