### PR TITLE
Adding feature gate for WAF

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -105,7 +105,7 @@ func main() {
 	if options.ProfilingEnabled {
 		registerProfiler(mux)
 	}
-	registerHealthz(mux, &aws.HealthChecker{Cloud: cloud})
+	registerHealthz(mux, aws.NewHealthChecker(cloud))
 	registerMetrics(mux, reg)
 	registerHandlers(mux)
 	go startHTTPServer(options.HealthzPort, mux)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,14 +87,17 @@ func main() {
 
 	cc := cache.NewConfig(5 * time.Minute)
 	reg.MustRegister(cc.NewCacheCollector(collectors.PrometheusNamespace))
-	mc, err := metric.NewCollector(reg, options.config.IngressClass)
+	mc, err := metric.NewCollector(reg, options.ingressCTLConfig.IngressClass)
 	if err != nil {
 		glog.Fatal(err)
 	}
 	mc.Start()
 
-	cloud := aws.New(options.AWSAPIMaxRetries, options.AWSAPIDebug, options.config.ClusterName, mc, cc)
-	if err := controller.Initialize(&options.config, mgr, mc, cloud); err != nil {
+	cloud, err := aws.New(options.cloudConfig, options.ingressCTLConfig.ClusterName, mc, cc)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	if err := controller.Initialize(&options.ingressCTLConfig, mgr, mc, cloud); err != nil {
 		glog.Fatal(err)
 	}
 

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -17,22 +17,17 @@ limitations under the License.
 package main
 
 import (
-	"encoding/hex"
 	"flag"
 	"fmt"
-	"hash/crc32"
 	"os"
-	"strconv"
 	"time"
 
-	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/parser"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/aws"
 
-	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
-	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/controller/config"
-	ing_net "github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/net"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/net"
 	apiv1 "k8s.io/api/core/v1"
 )
 
@@ -44,8 +39,6 @@ const (
 	defaultSyncPeriod              = 30 * time.Second
 	defaultHealthCheckPeriod       = 1 * time.Minute
 	defaultHealthzPort             = 10254
-	defaultAWSAPIMaxRetries        = 10
-	defaultAWSAPIDebug             = false
 	defaultProfilingEnabled        = true
 )
 
@@ -64,126 +57,83 @@ type Options struct {
 	SyncPeriod        time.Duration
 	HealthCheckPeriod time.Duration
 	HealthzPort       int
+	ProfilingEnabled  bool
 
-	AWSAPIMaxRetries int
-	AWSAPIDebug      bool
-	ProfilingEnabled bool
+	// aws cloud specific configuration
+	cloudConfig aws.CloudConfig
 
-	config config.Configuration
+	// ingress controller specific configuration
+	ingressCTLConfig config.Configuration
+}
+
+func (options *Options) BindFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&options.ShowVersion, "version", false,
+		`Show release information about the AWS ALB Ingress controller and exit.`)
+	fs.StringVar(&options.APIServerHost, "apiserver-host", "",
+		`Address of the Kubernetes API server.
+		Takes the form "protocol://address:port". If not specified, it is assumed the
+		program runs inside a Kubernetes cluster and local discovery is attempted.`)
+	fs.StringVar(&options.KubeConfigFile, "kubeconfig", "",
+		`Path to a kubeconfig file containing authorization and API server information.`)
+	fs.BoolVar(&options.LeaderElection, "election", defaultLeaderElection,
+		`Whether we do leader election for ingress controller`)
+	fs.StringVar(&options.LeaderElectionID, "election-id", defaultLeaderElectionID,
+		`Namespace of leader-election configmap for ingress controller`)
+	fs.StringVar(&options.LeaderElectionNamespace, "election-namespace", defaultLeaderElectionNamespace,
+		`Namespace of leader-election configmap for ingress controller. If unspecified, the namespace of this controller pod will be used`)
+	fs.StringVar(&options.WatchNamespace, "watch-namespace", defaultWatchNamespace,
+		`Namespace the controller watches for updates to Kubernetes objects.
+		This includes Ingresses, Services and all configuration resources. All
+		namespaces are watched if this parameter is left empty.`)
+	fs.DurationVar(&options.SyncPeriod, "sync-period", defaultSyncPeriod,
+		`Period at which the controller forces the repopulation of its local object stores.`)
+	fs.DurationVar(&options.HealthCheckPeriod, "health-check-period", defaultHealthCheckPeriod,
+		`Period at which the controller executes AWS health checks for its healthz endpoint.`)
+	fs.IntVar(&options.HealthzPort, "healthz-port", defaultHealthzPort,
+		`Port to use for the healthz endpoint.`)
+	fs.BoolVar(&options.ProfilingEnabled, "profiling", defaultProfilingEnabled,
+		`Enable profiling via web interface host:port/debug/pprof/`)
+	options.cloudConfig.BindFlags(fs)
+	options.ingressCTLConfig.BindFlags(fs)
+
+	_ = fs.MarkDeprecated("aws-sync-period", `No longer used, will be removed in next release`)
+	_ = fs.MarkDeprecated("default-backend-service", `No longer used, will be removed in next release`)
+}
+
+func (options *Options) BindEnv() error {
+	if err := options.cloudConfig.BindEnv(); err != nil {
+		return err
+	}
+	if err := options.ingressCTLConfig.BindEnv(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (options *Options) Validate() error {
+	if !net.IsPortAvailable(options.HealthzPort) {
+		return fmt.Errorf("port %v is alreadt in use. Please check the flag --healthz-port", options.HealthzPort)
+	}
+	if err := options.ingressCTLConfig.Validate(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func getOptions() (*Options, error) {
 	options := &Options{}
-
-	flags := pflag.NewFlagSet("", pflag.ExitOnError)
-	flags.BoolVar(&options.ShowVersion, "version", false,
-		`Show release information about the AWS ALB Ingress controller and exit.`)
-	flags.StringVar(&options.APIServerHost, "apiserver-host", "",
-		`Address of the Kubernetes API server.
-		Takes the form "protocol://address:port". If not specified, it is assumed the
-		program runs inside a Kubernetes cluster and local discovery is attempted.`)
-	flags.StringVar(&options.KubeConfigFile, "kubeconfig", "",
-		`Path to a kubeconfig file containing authorization and API server information.`)
-	flags.BoolVar(&options.LeaderElection, "election", defaultLeaderElection,
-		`Whether we do leader election for ingress controller`)
-	flags.StringVar(&options.LeaderElectionID, "election-id", defaultLeaderElectionID,
-		`Namespace of leader-election configmap for ingress controller`)
-	flags.StringVar(&options.LeaderElectionNamespace, "election-namespace", defaultLeaderElectionNamespace,
-		`Namespace of leader-election configmap for ingress controller. If unspecified, the namespace of this controller pod will be used`)
-	flags.StringVar(&options.WatchNamespace, "watch-namespace", defaultWatchNamespace,
-		`Namespace the controller watches for updates to Kubernetes objects.
-		This includes Ingresses, Services and all configuration resources. All
-		namespaces are watched if this parameter is left empty.`)
-	flags.DurationVar(&options.SyncPeriod, "sync-period", defaultSyncPeriod,
-		`Period at which the controller forces the repopulation of its local object stores.`)
-	flags.DurationVar(&options.HealthCheckPeriod, "health-check-period", defaultHealthCheckPeriod,
-		`Period at which the controller executes AWS health checks for its healthz endpoint.`)
-	flags.IntVar(&options.HealthzPort, "healthz-port", defaultHealthzPort,
-		`Port to use for the healthz endpoint.`)
-	flags.IntVar(&options.AWSAPIMaxRetries, "aws-max-retries", defaultAWSAPIMaxRetries,
-		`Maximum number of times to retry the AWS API.`)
-	flags.BoolVar(&options.AWSAPIDebug, "aws-api-debug", defaultAWSAPIDebug,
-		`Enable debug logging of AWS API`)
-	flags.BoolVar(&options.ProfilingEnabled, "profiling", defaultProfilingEnabled,
-		`Enable profiling via web interface host:port/debug/pprof/`)
-	options.config.BindFlags(flags)
-
-	_ = flags.MarkDeprecated("aws-sync-period", `No longer used, will be removed in next release`)
-	_ = flags.MarkDeprecated("default-backend-service", `No longer used, will be removed in next release`)
+	fs := pflag.NewFlagSet("", pflag.ExitOnError)
+	options.BindFlags(fs)
 
 	_ = flag.Set("logtostderr", "true")
-	flags.AddGoFlagSet(flag.CommandLine)
-	_ = flags.Parse(os.Args)
-
-	err := configOptionsByEnvironmentVariables(options)
-	if err != nil {
-		return options, err
+	fs.AddGoFlagSet(flag.CommandLine)
+	_ = fs.Parse(os.Args)
+	if err := options.BindEnv(); err != nil {
+		return nil, err
 	}
-	err = validateOptions(options)
-
-	// TODO: I know, bad smell here:D
-	parser.AnnotationsPrefix = options.config.AnnotationPrefix
-	return options, err
-}
-
-// configOptionsByEnvironmentVariables deals with the legacy way of configuration by environment variables
-// TODO: completely remove this legacy configuration when we feels comfortable
-func configOptionsByEnvironmentVariables(options *Options) error {
-	if s, ok := os.LookupEnv("AWS_MAX_RETRIES"); ok {
-		glog.Warningf("Environment variable configuration is deprecated, switch to the --aws-max-retries flag.")
-		v, err := strconv.ParseInt(s, 0, 32)
-		if err != nil {
-			return fmt.Errorf("AWS_MAX_RETRIES environment variable must be an integer. Value was: %s", s)
-		}
-		options.AWSAPIMaxRetries = int(v)
-	}
-	if s, ok := os.LookupEnv("CLUSTER_NAME"); ok {
-		glog.Warningf("Environment variable configuration is deprecated, switch to the --cluster-name flag.")
-		options.config.ClusterName = s
-	}
-	if s, ok := os.LookupEnv("ALB_PREFIX"); ok {
-		glog.Warningf("Environment variable configuration is deprecated, switch to the --alb-name-prefix flag.")
-		options.config.ALBNamePrefix = s
-	}
-	if s, ok := os.LookupEnv("ALB_CONTROLLER_RESTRICT_SCHEME"); ok {
-		glog.Warningf("Environment variable configuration is deprecated, switch to the --restrict-scheme flag.")
-		v, err := strconv.ParseBool(s)
-		if err != nil {
-			return fmt.Errorf("ALB_CONTROLLER_RESTRICT_SCHEME environment variable must be either true or false. Value was: %s", s)
-		}
-		options.config.RestrictScheme = v
-	}
-	if s, ok := os.LookupEnv("ALB_CONTROLLER_RESTRICT_SCHEME_CONFIG_NAMESPACE"); ok {
-		glog.Warningf("Environment variable configuration is deprecated, switch to the --restrict-scheme-namespace flag.")
-		options.config.RestrictSchemeNamespace = s
-	}
-	return nil
-}
-
-func validateOptions(options *Options) error {
-	if options.config.DefaultTargetType == "pod" {
-		glog.Warningf("The target type parameter for 'pod' has changed to 'ip' to better match AWS APIs and documentation.")
-		options.config.DefaultTargetType = elbv2.TargetTypeEnumIp
-	}
-	if options.config.ClusterName == "" {
-		return fmt.Errorf("clusterName must be specified")
-	}
-	if len(options.config.ALBNamePrefix) > 12 {
-		return fmt.Errorf("ALBNamePrefix must be 12 characters or less")
-	}
-	if options.config.ALBNamePrefix == "" {
-		options.config.ALBNamePrefix = generateALBNamePrefix(options.config.ClusterName)
+	if err := options.Validate(); err != nil {
+		return nil, err
 	}
 
-	// check port collisions
-	if !ing_net.IsPortAvailable(options.HealthzPort) {
-		return fmt.Errorf("port %v is alreadt in use. Please check the flag --healthz-port", options.HealthzPort)
-	}
-	return nil
-}
-
-func generateALBNamePrefix(clusterName string) string {
-	hash := crc32.New(crc32.MakeTable(0xedb88320))
-	_, _ = hash.Write([]byte(clusterName))
-	return hex.EncodeToString(hash.Sum(nil))
+	return options, nil
 }

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -121,7 +121,10 @@ func (options *Options) Validate() error {
 }
 
 func getOptions() (*Options, error) {
-	options := &Options{}
+	options := &Options{
+		ingressCTLConfig: config.NewConfiguration(),
+	}
+
 	fs := pflag.NewFlagSet("", pflag.ExitOnError)
 	options.BindFlags(fs)
 

--- a/internal/alb/ls/listener_group.go
+++ b/internal/alb/ls/listener_group.go
@@ -3,6 +3,8 @@ package ls
 import (
 	"context"
 
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/albctx"
+
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/alb/rs"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/alb/tg"
@@ -65,6 +67,7 @@ func (controller *defaultGroupController) Reconcile(ctx context.Context, lbArn s
 	portsUnsed := sets.Int64KeySet(instancesByPort).Difference(portsInUse)
 	for port := range portsUnsed {
 		instance := instancesByPort[port]
+		albctx.GetLogger(ctx).Infof("deleting listener %v, arn: %v", aws.Int64Value(instance.Port), aws.StringValue(instance.ListenerArn))
 		if err := controller.cloud.DeleteListenersByArn(ctx, aws.StringValue(instance.ListenerArn)); err != nil {
 			return err
 		}
@@ -78,6 +81,7 @@ func (controller *defaultGroupController) Delete(ctx context.Context, lbArn stri
 		return err
 	}
 	for _, instance := range instancesByPort {
+		albctx.GetLogger(ctx).Infof("deleting listener %v, arn: %v", aws.Int64Value(instance.Port), aws.StringValue(instance.ListenerArn))
 		if err := controller.cloud.DeleteListenersByArn(ctx, aws.StringValue(instance.ListenerArn)); err != nil {
 			return err
 		}

--- a/internal/alb/ls/listener_test.go
+++ b/internal/alb/ls/listener_test.go
@@ -195,7 +195,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					Certificates: []*elbv2.Certificate{
 						{
 							CertificateArn: aws.String("certificateArn"),
-							IsDefault:      aws.Bool(true),
 						},
 					},
 					SslPolicy: aws.String("sslPolicy"),
@@ -260,7 +259,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				Certificates: []*elbv2.Certificate{
 					{
 						CertificateArn: aws.String("certificateArn"),
-						IsDefault:      aws.Bool(true),
 					},
 				},
 				SslPolicy: aws.String("sslPolicy"),
@@ -280,7 +278,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					Certificates: []*elbv2.Certificate{
 						{
 							CertificateArn: aws.String("certificateArn"),
-							IsDefault:      aws.Bool(true),
 						},
 					},
 					SslPolicy: aws.String("sslPolicy"),
@@ -350,7 +347,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					Certificates: []*elbv2.Certificate{
 						{
 							CertificateArn: aws.String("certificateArn"),
-							IsDefault:      aws.Bool(true),
 						},
 					},
 					SslPolicy: aws.String("sslPolicy"),
@@ -368,7 +364,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					Certificates: []*elbv2.Certificate{
 						{
 							CertificateArn: aws.String("certificateArn"),
-							IsDefault:      aws.Bool(true),
 						},
 					},
 					SslPolicy: aws.String("sslPolicy"),
@@ -389,7 +384,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					Certificates: []*elbv2.Certificate{
 						{
 							CertificateArn: aws.String("certificateArn"),
-							IsDefault:      aws.Bool(true),
 						},
 					},
 					SslPolicy: aws.String("sslPolicy"),
@@ -459,7 +453,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					Certificates: []*elbv2.Certificate{
 						{
 							CertificateArn: aws.String("certificateArn"),
-							IsDefault:      aws.Bool(true),
 						},
 					},
 					SslPolicy: aws.String("sslPolicy"),

--- a/internal/alb/sg/association.go
+++ b/internal/alb/sg/association.go
@@ -241,11 +241,7 @@ func (controller *associationController) deleteManagedInstanceSG(ctx context.Con
 }
 
 func (controller *associationController) findSGIDByName(sgName string) (*string, error) {
-	vpcID, err := controller.cloud.GetVPCID()
-	if err != nil {
-		return nil, err
-	}
-	sg, err := controller.cloud.GetSecurityGroupByName(*vpcID, sgName)
+	sg, err := controller.cloud.GetSecurityGroupByName(sgName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/alb/sg/lb_attachment.go
+++ b/internal/alb/sg/lb_attachment.go
@@ -88,12 +88,7 @@ func (controller *lbAttachmentController) Delete(ctx context.Context, attachment
 }
 
 func (controller *lbAttachmentController) getDefaultSecurityGroupID() (string, error) {
-	vpcID, err := controller.cloud.GetVPCID()
-	if err != nil {
-		return "", err
-	}
-
-	defaultSG, err := controller.cloud.GetSecurityGroupByName(*vpcID, "default")
+	defaultSG, err := controller.cloud.GetSecurityGroupByName("default")
 	if err != nil {
 		return "", err
 	}

--- a/internal/alb/sg/security_group.go
+++ b/internal/alb/sg/security_group.go
@@ -60,13 +60,7 @@ func (controller *securityGroupController) Delete(ctx context.Context, group *Se
 }
 
 func (controller *securityGroupController) reconcileByNewSGInstance(ctx context.Context, group *SecurityGroup) error {
-	// TODO: move these VPC calls into controller startup, and part of controller configuration
-	vpcID, err := controller.cloud.GetVPCID()
-	if err != nil {
-		return err
-	}
 	createSGOutput, err := controller.cloud.CreateSecurityGroupWithContext(ctx, &ec2.CreateSecurityGroupInput{
-		VpcId:       vpcID,
 		GroupName:   group.GroupName,
 		Description: aws.String("Instance SecurityGroup created by alb-ingress-controller"),
 	})
@@ -155,11 +149,7 @@ func (controller *securityGroupController) findExistingSGInstance(group *Securit
 		}
 	case group.GroupName != nil:
 		{
-			vpcID, err := controller.cloud.GetVPCID()
-			if err != nil {
-				return nil, err
-			}
-			instance, err := controller.cloud.GetSecurityGroupByName(aws.StringValue(vpcID), aws.StringValue(group.GroupName))
+			instance, err := controller.cloud.GetSecurityGroupByName(aws.StringValue(group.GroupName))
 			if err != nil {
 				return nil, err
 			}

--- a/internal/alb/sg/security_group_test.go
+++ b/internal/alb/sg/security_group_test.go
@@ -515,7 +515,6 @@ func TestReconcile(t *testing.T) {
 			},
 			CreateSecurityGroupCall: CreateSecurityGroupCall{
 				Input: &ec2.CreateSecurityGroupInput{
-					VpcId:       aws.String("vpc-id"),
 					GroupName:   aws.String("groupName"),
 					Description: aws.String("Instance SecurityGroup created by alb-ingress-controller"),
 				},
@@ -577,7 +576,6 @@ func TestReconcile(t *testing.T) {
 			},
 			CreateSecurityGroupCall: CreateSecurityGroupCall{
 				Input: &ec2.CreateSecurityGroupInput{
-					VpcId:       aws.String("vpc-id"),
 					GroupName:   aws.String("groupName"),
 					Description: aws.String("Instance SecurityGroup created by alb-ingress-controller"),
 				},
@@ -649,7 +647,6 @@ func TestReconcile(t *testing.T) {
 			},
 			CreateSecurityGroupCall: CreateSecurityGroupCall{
 				Input: &ec2.CreateSecurityGroupInput{
-					VpcId:       aws.String("vpc-id"),
 					GroupName:   aws.String("groupName"),
 					Description: aws.String("Instance SecurityGroup created by alb-ingress-controller"),
 				},
@@ -723,7 +720,6 @@ func TestReconcile(t *testing.T) {
 			},
 			CreateSecurityGroupCall: CreateSecurityGroupCall{
 				Input: &ec2.CreateSecurityGroupInput{
-					VpcId:       aws.String("vpc-id"),
 					GroupName:   aws.String("groupName"),
 					Description: aws.String("Instance SecurityGroup created by alb-ingress-controller"),
 				},
@@ -758,8 +754,7 @@ func TestReconcile(t *testing.T) {
 				cloud.On("GetSecurityGroupByID", *tc.GetSecurityGroupByIDCall.GroupID).Return(tc.GetSecurityGroupByIDCall.Instance, tc.GetSecurityGroupByIDCall.Err)
 			}
 			if tc.GetSecurityGroupByNameCall.GroupName != nil {
-				cloud.On("GetVPCID").Return(aws.String("vpc-id"), nil)
-				cloud.On("GetSecurityGroupByName", "vpc-id", *tc.GetSecurityGroupByNameCall.GroupName).Return(tc.GetSecurityGroupByNameCall.Instance, tc.GetSecurityGroupByNameCall.Err)
+				cloud.On("GetSecurityGroupByName", *tc.GetSecurityGroupByNameCall.GroupName).Return(tc.GetSecurityGroupByNameCall.Instance, tc.GetSecurityGroupByNameCall.Err)
 			}
 			if tc.RevokeSecurityGroupIngressCall.Input != nil {
 				cloud.On("RevokeSecurityGroupIngressWithContext", ctx, tc.RevokeSecurityGroupIngressCall.Input).Return(nil, tc.RevokeSecurityGroupIngressCall.Err)
@@ -881,8 +876,7 @@ func TestDelete(t *testing.T) {
 			cloud := &mocks.CloudAPI{}
 
 			if tc.GetSecurityGroupByNameCall.GroupName != nil {
-				cloud.On("GetVPCID").Return(aws.String("vpc-id"), nil)
-				cloud.On("GetSecurityGroupByName", "vpc-id", *tc.GetSecurityGroupByNameCall.GroupName).Return(tc.GetSecurityGroupByNameCall.Instance, tc.GetSecurityGroupByNameCall.Err)
+				cloud.On("GetSecurityGroupByName", *tc.GetSecurityGroupByNameCall.GroupName).Return(tc.GetSecurityGroupByNameCall.Instance, tc.GetSecurityGroupByNameCall.Err)
 			}
 			if tc.DeleteSecurityGroupByIDCall.GroupID != nil {
 				cloud.On("DeleteSecurityGroupByID", aws.StringValue(tc.DeleteSecurityGroupByIDCall.GroupID)).Return(tc.DeleteSecurityGroupByIDCall.Err)

--- a/internal/alb/tg/targetgroup.go
+++ b/internal/alb/tg/targetgroup.go
@@ -97,7 +97,6 @@ func (controller *defaultController) Reconcile(ctx context.Context, ingress *ext
 }
 
 func (controller *defaultController) newTGInstance(ctx context.Context, name string, serviceAnnos *annotations.Service) (*elbv2.TargetGroup, error) {
-	vpcID := controller.store.GetConfig().VpcID
 	resp, err := controller.cloud.CreateTargetGroupWithContext(ctx, &elbv2.CreateTargetGroupInput{
 		Name:                       aws.String(name),
 		HealthCheckPath:            serviceAnnos.HealthCheck.Path,
@@ -111,7 +110,6 @@ func (controller *defaultController) newTGInstance(ctx context.Context, name str
 		HealthyThresholdCount:      serviceAnnos.TargetGroup.HealthyThresholdCount,
 		UnhealthyThresholdCount:    serviceAnnos.TargetGroup.UnhealthyThresholdCount,
 		Port:                       aws.Int64(targetGroupDefaultPort),
-		VpcId:                      aws.String(vpcID),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/alb/tg/targetgroup_test.go
+++ b/internal/alb/tg/targetgroup_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/healthcheck"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/targetgroup"
-	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/controller/config"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/controller/store"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/mocks"
 	"github.com/stretchr/testify/assert"
@@ -20,10 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
-
-type GetConfigCall struct {
-	Config *config.Configuration
-}
 
 type GetIngressAnnotationsCall struct {
 	Key          string
@@ -110,7 +105,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 		Name                      string
 		Ingress                   extensions.Ingress
 		Backend                   extensions.IngressBackend
-		GetConfigCall             *GetConfigCall
 		GetIngressAnnotationsCall *GetIngressAnnotationsCall
 		GetServiceAnnotationsCall *GetServiceAnnotationsCall
 		NameTGCall                *NameTGCall
@@ -129,11 +123,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 			Name:    "Reconcile succeeds by creating instance",
 			Ingress: ingress,
 			Backend: ingressBackend,
-			GetConfigCall: &GetConfigCall{
-				Config: &config.Configuration{
-					VpcID: "vpcID",
-				},
-			},
 			GetIngressAnnotationsCall: &GetIngressAnnotationsCall{
 				Key:          "namespace/ingress",
 				IngressAnnos: &annotations.Ingress{},
@@ -201,7 +190,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					HealthyThresholdCount:      aws.Int64(8),
 					UnhealthyThresholdCount:    aws.Int64(5),
 					Port:                       aws.Int64(targetGroupDefaultPort),
-					VpcId:                      aws.String("vpcID"),
 				},
 				Instance: &elbv2.TargetGroup{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
@@ -545,11 +533,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 			Name:    "Reconcile succeeds when creating instance",
 			Ingress: ingress,
 			Backend: ingressBackend,
-			GetConfigCall: &GetConfigCall{
-				Config: &config.Configuration{
-					VpcID: "vpcID",
-				},
-			},
 			GetIngressAnnotationsCall: &GetIngressAnnotationsCall{
 				Key:          "namespace/ingress",
 				IngressAnnos: &annotations.Ingress{},
@@ -607,7 +590,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					HealthyThresholdCount:      aws.Int64(8),
 					UnhealthyThresholdCount:    aws.Int64(5),
 					Port:                       aws.Int64(targetGroupDefaultPort),
-					VpcId:                      aws.String("vpcID"),
 				},
 				Err: errors.New("CreateTargetGroup"),
 			},
@@ -989,9 +971,6 @@ func TestDefaultController_Reconcile(t *testing.T) {
 			}
 
 			mockStore := &store.MockStorer{}
-			if tc.GetConfigCall != nil {
-				mockStore.On("GetConfig").Return(tc.GetConfigCall.Config)
-			}
 			if tc.GetIngressAnnotationsCall != nil {
 				mockStore.On("GetIngressAnnotations", tc.GetIngressAnnotationsCall.Key).Return(tc.GetIngressAnnotationsCall.IngressAnnos, tc.GetIngressAnnotationsCall.Err)
 			}

--- a/internal/aws/acm.go
+++ b/internal/aws/acm.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acm"
 )
@@ -12,6 +14,9 @@ import (
 type ACMAPI interface {
 	// StatusACM validates ACM connectivity
 	StatusACM() func() error
+
+	// ACMAvailable whether ACM service is available
+	ACMAvailable() bool
 }
 
 // Status validates ACM connectivity
@@ -26,4 +31,10 @@ func (c *Cloud) StatusACM() func() error {
 		}
 		return nil
 	}
+}
+
+func (c *Cloud) ACMAvailable() bool {
+	resolver := endpoints.DefaultResolver()
+	_, err := resolver.EndpointFor(endpoints.AcmServiceID, c.region)
+	return err == nil
 }

--- a/internal/aws/cloud.go
+++ b/internal/aws/cloud.go
@@ -32,6 +32,7 @@ type CloudAPI interface {
 
 type Cloud struct {
 	vpcID       string
+	region      string
 	clusterName string
 
 	acm         acmiface.ACMAPI
@@ -68,6 +69,7 @@ func New(cfg CloudConfig, clusterName string, mc metric.Collector, cc *cache.Con
 	regionCfg := &aws.Config{Region: aws.String(cfg.Region)}
 	return &Cloud{
 		cfg.VpcID,
+		cfg.Region,
 		clusterName,
 		acm.New(awsSession, regionCfg),
 		ec2.New(awsSession, regionCfg),

--- a/internal/aws/cloud.go
+++ b/internal/aws/cloud.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/service/acm"
@@ -22,7 +24,6 @@ import (
 type CloudAPI interface {
 	ACMAPI
 	EC2API
-	EC2MetadataAPI
 	ELBV2API
 	IAMAPI
 	ResourceGroupsTaggingAPIAPI
@@ -30,30 +31,49 @@ type CloudAPI interface {
 }
 
 type Cloud struct {
+	vpcID       string
+	clusterName string
+
 	acm         acmiface.ACMAPI
 	ec2         ec2iface.EC2API
-	ec2metadata *ec2metadata.EC2Metadata
 	elbv2       elbv2iface.ELBV2API
 	iam         iamiface.IAMAPI
 	rgt         resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
 	wafregional wafregionaliface.WAFRegionalAPI
-	clusterName string
 }
 
 // Initialize the global AWS clients.
-// TODO, pass these aws clients instances to controller instead of global clients.
 // But due to huge number of aws clients, it's best to have one container AWS client that embed these aws clients.
-func New(AWSAPIMaxRetries int, AWSAPIDebug bool, clusterName string, mc metric.Collector, cc *cache.Config) CloudAPI {
-	awsSession := NewSession(&aws.Config{MaxRetries: aws.Int(AWSAPIMaxRetries)}, AWSAPIDebug, mc, cc)
+// TODO: remove clusterName dependency
+// TODO: remove mc dependency like https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/aws_metrics.go
+func New(cfg CloudConfig, clusterName string, mc metric.Collector, cc *cache.Config) (CloudAPI, error) {
+	awsSession := NewSession(&aws.Config{MaxRetries: aws.Int(cfg.APIMaxRetries)}, cfg.APIDebug, mc, cc)
+	metadata := ec2metadata.New(awsSession)
 
-	return &Cloud{
-		acm.New(awsSession),
-		ec2.New(awsSession),
-		ec2metadata.New(awsSession),
-		elbv2.New(awsSession),
-		iam.New(awsSession),
-		resourcegroupstaggingapi.New(awsSession),
-		wafregional.New(awsSession),
-		clusterName,
+	if len(cfg.VpcID) == 0 {
+		vpcID, err := GetVpcIDFromEC2Metadata(metadata)
+		if err != nil {
+			return nil, fmt.Errorf("failed to introspect vpcID from ec2Metadata due to %v, specify --aws-vpc-id instead if ec2Metadata is unavailable", err)
+		}
+		cfg.VpcID = vpcID
 	}
+	if len(cfg.Region) == 0 {
+		region, err := metadata.Region()
+		if err != nil {
+			return nil, fmt.Errorf("failed to introspect region from ec2Metadata due to %v, specify --aws-region instead if ec2Metadata is unavailable", err)
+		}
+		cfg.Region = region
+	}
+
+	regionCfg := &aws.Config{Region: aws.String(cfg.Region)}
+	return &Cloud{
+		cfg.VpcID,
+		clusterName,
+		acm.New(awsSession, regionCfg),
+		ec2.New(awsSession, regionCfg),
+		elbv2.New(awsSession, regionCfg),
+		iam.New(awsSession, regionCfg),
+		resourcegroupstaggingapi.New(awsSession, regionCfg),
+		wafregional.New(awsSession, regionCfg),
+	}, nil
 }

--- a/internal/aws/config.go
+++ b/internal/aws/config.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+)
+
+const (
+	defaultVpcID         = ""
+	defaultRegion        = ""
+	defaultAPIMaxRetries = 10
+	defaultAPIDebug      = false
+)
+
+// configuration for cloud
+type CloudConfig struct {
+	VpcID  string
+	Region string
+
+	APIMaxRetries int
+	APIDebug      bool
+}
+
+func (cfg *CloudConfig) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&cfg.VpcID, "aws-vpc-id", defaultVpcID,
+		`AWS VPC ID for the kubernetes cluster`)
+	fs.StringVar(&cfg.Region, "aws-region", defaultRegion,
+		`AWS Region for the kubernetes cluster`)
+	fs.IntVar(&cfg.APIMaxRetries, "aws-max-retries", defaultAPIMaxRetries,
+		`Maximum number of times to retry the AWS API.`)
+	fs.BoolVar(&cfg.APIDebug, "aws-api-debug", defaultAPIDebug,
+		`Enable debug logging of AWS API`)
+}
+
+func (cfg *CloudConfig) BindEnv() error {
+	if s, ok := os.LookupEnv("AWS_VPC_ID"); ok {
+		glog.Warningf("Environment variable configuration is deprecated, switch to the --aws-vpc-id flag.")
+		cfg.VpcID = s
+	}
+
+	if s, ok := os.LookupEnv("AWS_REGION"); ok {
+		glog.Warningf("Environment variable configuration is deprecated, switch to the --aws-region flag.")
+		cfg.Region = s
+	}
+
+	if s, ok := os.LookupEnv("AWS_MAX_RETRIES"); ok {
+		glog.Warningf("Environment variable configuration is deprecated, switch to the --aws-max-retries flag.")
+		v, err := strconv.ParseInt(s, 0, 32)
+		if err != nil {
+			return fmt.Errorf("AWS_MAX_RETRIES environment variable must be an integer. Value was: %s", s)
+		}
+		cfg.APIMaxRetries = int(v)
+	}
+	return nil
+}

--- a/internal/aws/ec2metadata.go
+++ b/internal/aws/ec2metadata.go
@@ -1,11 +1,19 @@
 package aws
 
-import "github.com/aws/aws-sdk-go/aws/ec2metadata"
+import (
+	"fmt"
 
-type EC2MetadataAPI interface {
-	GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error)
-}
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+)
 
-func (c *Cloud) GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
-	return c.ec2metadata.GetInstanceIdentityDocument()
+func GetVpcIDFromEC2Metadata(metadata *ec2metadata.EC2Metadata) (string, error) {
+	mac, err := metadata.GetMetadata("mac")
+	if err != nil {
+		return "", err
+	}
+	vpcID, err := metadata.GetMetadata(fmt.Sprintf("network/interfaces/macs/%s/vpc-id", mac))
+	if err != nil {
+		return "", err
+	}
+	return vpcID, nil
 }

--- a/internal/aws/elbv2.go
+++ b/internal/aws/elbv2.go
@@ -68,8 +68,12 @@ func (c *Cloud) ModifyTargetGroupAttributesWithContext(ctx context.Context, i *e
 	return c.elbv2.ModifyTargetGroupAttributesWithContext(ctx, i)
 }
 func (c *Cloud) CreateTargetGroupWithContext(ctx context.Context, i *elbv2.CreateTargetGroupInput) (*elbv2.CreateTargetGroupOutput, error) {
+	if i.VpcId == nil {
+		i.VpcId = aws.String(c.vpcID)
+	}
 	return c.elbv2.CreateTargetGroupWithContext(ctx, i)
 }
+
 func (c *Cloud) ModifyTargetGroupWithContext(ctx context.Context, i *elbv2.ModifyTargetGroupInput) (*elbv2.ModifyTargetGroupOutput, error) {
 	return c.elbv2.ModifyTargetGroupWithContext(ctx, i)
 }

--- a/internal/aws/healthcheck.go
+++ b/internal/aws/healthcheck.go
@@ -8,7 +8,19 @@ import (
 )
 
 type HealthChecker struct {
-	Cloud CloudAPI
+	healthCheckFuncs []func() error
+}
+
+// Constructs a new healthChecker
+func NewHealthChecker(cloud CloudAPI) *HealthChecker {
+	healthCheckFuncs := []func() error{cloud.StatusEC2(), cloud.StatusIAM()}
+	if cloud.ACMAvailable() {
+		healthCheckFuncs = append(healthCheckFuncs, cloud.StatusACM())
+	}
+
+	return &HealthChecker{
+		healthCheckFuncs: healthCheckFuncs,
+	}
 }
 
 var _ healthz.HealthzChecker = (*HealthChecker)(nil)
@@ -20,11 +32,7 @@ func (c *HealthChecker) Name() string {
 
 // TODO, validate the call health check frequency
 func (c *HealthChecker) Check(_ *http.Request) error {
-	for _, fn := range []func() error{
-		c.Cloud.StatusACM(),
-		c.Cloud.StatusEC2(),
-		c.Cloud.StatusIAM(),
-	} {
+	for _, fn := range c.healthCheckFuncs {
 		err := fn()
 		if err != nil {
 			glog.Errorf("Controller health check failed: %v", err.Error())

--- a/internal/aws/wafregional.go
+++ b/internal/aws/wafregional.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
 )
@@ -12,6 +14,9 @@ type WAFRegionalAPI interface {
 	GetWebACLSummary(ctx context.Context, resourceArn *string) (*waf.WebACLSummary, error)
 	AssociateWAF(ctx context.Context, resourceArn *string, webACLId *string) (*wafregional.AssociateWebACLOutput, error)
 	DisassociateWAF(ctx context.Context, resourceArn *string) (*wafregional.DisassociateWebACLOutput, error)
+
+	// WAFRegionalAvailable whether WAFRegional service are available.
+	WAFRegionalAvailable() bool
 }
 
 // WebACLExists checks whether the provided ID existing in AWS.
@@ -65,4 +70,10 @@ func (c *Cloud) DisassociateWAF(ctx context.Context, resourceArn *string) (*wafr
 	}
 
 	return result, nil
+}
+
+func (c *Cloud) WAFRegionalAvailable() bool {
+	resolver := endpoints.DefaultResolver()
+	_, err := resolver.EndpointFor(endpoints.WafRegionalServiceID, c.region)
+	return err == nil
 }

--- a/internal/ingress/backend/endpoint_test.go
+++ b/internal/ingress/backend/endpoint_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/controller/store"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/mocks"
@@ -408,19 +407,16 @@ func TestResolveWithModeIP(t *testing.T) {
 			},
 			expectedTargets: []*elbv2.TargetDescription{
 				{
-					Id:               aws.String(ip1),
-					Port:             aws.Int64(portHTTP),
-					AvailabilityZone: aws.String("all"),
+					Id:   aws.String(ip1),
+					Port: aws.Int64(portHTTP),
 				},
 				{
-					Id:               aws.String(ip2),
-					Port:             aws.Int64(portHTTP),
-					AvailabilityZone: aws.String("all"),
+					Id:   aws.String(ip2),
+					Port: aws.Int64(portHTTP),
 				},
 				{
-					Id:               aws.String(ip3),
-					Port:             aws.Int64(portHTTP),
-					AvailabilityZone: aws.String("all"),
+					Id:   aws.String(ip3),
+					Port: aws.Int64(portHTTP),
 				},
 			},
 			expectedError: false,
@@ -499,19 +495,16 @@ func TestResolveWithModeIP(t *testing.T) {
 			},
 			expectedTargets: []*elbv2.TargetDescription{
 				{
-					Id:               aws.String(ip1),
-					Port:             aws.Int64(portHTTPS),
-					AvailabilityZone: aws.String("all"),
+					Id:   aws.String(ip1),
+					Port: aws.Int64(portHTTPS),
 				},
 				{
-					Id:               aws.String(ip2),
-					Port:             aws.Int64(portHTTPS),
-					AvailabilityZone: aws.String("all"),
+					Id:   aws.String(ip2),
+					Port: aws.Int64(portHTTPS),
 				},
 				{
-					Id:               aws.String(ip3),
-					Port:             aws.Int64(portHTTPS),
-					AvailabilityZone: aws.String("all"),
+					Id:   aws.String(ip3),
+					Port: aws.Int64(portHTTPS),
 				},
 			},
 			expectedError: false,
@@ -570,8 +563,6 @@ func TestResolveWithModeIP(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cloud := &mocks.CloudAPI{}
-			cloud.On("GetVPCID").Return(aws.String("vpcid"), nil)
-			cloud.On("GetVPC", aws.String("vpcid")).Return(&ec2.Vpc{}, nil)
 
 			store := store.NewDummy()
 			store.GetServiceFunc = func(string) (*api_v1.Service, error) {

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -49,6 +49,15 @@ type Configuration struct {
 
 	// InternetFacingIngresses is an dynamic setting that can be updated by configMaps
 	InternetFacingIngresses map[string][]string
+
+	FeatureGate FeatureGate
+}
+
+// NewConfiguration constructs new Configuration obj.
+func NewConfiguration() Configuration {
+	return Configuration{
+		FeatureGate: NewFeatureGate(),
+	}
 }
 
 // BindFlags will bind the commandline flags to fields in config
@@ -75,6 +84,8 @@ func (cfg *Configuration) BindFlags(fs *pflag.FlagSet) {
 		`Restrict the scheme to internal except for whitelisted namespaces`)
 	fs.StringVar(&cfg.RestrictSchemeNamespace, "restrict-scheme-namespace", defaultRestrictSchemeNamespace,
 		`The namespace with the ConfigMap containing the allowed ingresses. Only respected when restrict-scheme is true.`)
+
+	cfg.FeatureGate.BindFlags(fs)
 }
 
 func (cfg *Configuration) BindEnv() error {

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -1,7 +1,15 @@
 package config
 
 import (
+	"encoding/hex"
+	"fmt"
+	"hash/crc32"
+	"os"
+	"strconv"
+
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/golang/glog"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/parser"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -25,9 +33,6 @@ var (
 type Configuration struct {
 	ClusterName string
 
-	// VpcID is the ID of worker node's VPC
-	VpcID string
-
 	// IngressClass is the ingress class that this controller will monitor for
 	IngressClass string
 
@@ -47,27 +52,77 @@ type Configuration struct {
 }
 
 // BindFlags will bind the commandline flags to fields in config
-func (config *Configuration) BindFlags(flags *pflag.FlagSet) {
-	flags.StringVar(&config.ClusterName, "cluster-name", "", `Kubernetes cluster name (required)`)
-	flags.StringVar(&config.IngressClass, "ingress-class", defaultIngressClass,
+func (cfg *Configuration) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&cfg.ClusterName, "cluster-name", "", `Kubernetes cluster name (required)`)
+	fs.StringVar(&cfg.IngressClass, "ingress-class", defaultIngressClass,
 		`Name of the ingress class this controller satisfies.
 		The class of an Ingress object is set using the annotation "kubernetes.io/ingress.class".
 		All ingress classes are satisfied if this parameter is left empty.`)
-	flags.StringVar(&config.AnnotationPrefix, "annotations-prefix", defaultAnnotationPrefix,
+	fs.StringVar(&cfg.AnnotationPrefix, "annotations-prefix", defaultAnnotationPrefix,
 		`Prefix of the Ingress annotations specific to the AWS ALB controller.`)
 
-	flags.StringVar(&config.ALBNamePrefix, "alb-name-prefix", defaultALBNamePrefix,
+	fs.StringVar(&cfg.ALBNamePrefix, "alb-name-prefix", defaultALBNamePrefix,
 		`Prefix to add to ALB resources (11 alphanumeric characters or less)`)
-	flags.StringToStringVar(&config.DefaultTags, "default-tags", defaultDefaultTags,
+	fs.StringToStringVar(&cfg.DefaultTags, "default-tags", defaultDefaultTags,
 		`Default tags to add to all ALBs`)
-	flags.StringVar(&config.DefaultTargetType, "target-type", defaultTargetType,
+	fs.StringVar(&cfg.DefaultTargetType, "target-type", defaultTargetType,
 		`Default target type to use for target groups, must be "instance" or "ip"`)
-	flags.StringVar(&config.DefaultBackendProtocol, "backend-protocol", defaultBackendProtocol,
+	fs.StringVar(&cfg.DefaultBackendProtocol, "backend-protocol", defaultBackendProtocol,
 		`Default target type to use for target groups, must be "instance" or "ip"`)
-	flags.Float32Var(&config.SyncRateLimit, "sync-rate-limit", defaultSyncRateLimit,
+	fs.Float32Var(&cfg.SyncRateLimit, "sync-rate-limit", defaultSyncRateLimit,
 		`Define the sync frequency upper limit`)
-	flags.BoolVar(&config.RestrictScheme, "restrict-scheme", defaultRestrictScheme,
+	fs.BoolVar(&cfg.RestrictScheme, "restrict-scheme", defaultRestrictScheme,
 		`Restrict the scheme to internal except for whitelisted namespaces`)
-	flags.StringVar(&config.RestrictSchemeNamespace, "restrict-scheme-namespace", defaultRestrictSchemeNamespace,
+	fs.StringVar(&cfg.RestrictSchemeNamespace, "restrict-scheme-namespace", defaultRestrictSchemeNamespace,
 		`The namespace with the ConfigMap containing the allowed ingresses. Only respected when restrict-scheme is true.`)
+}
+
+func (cfg *Configuration) BindEnv() error {
+	if s, ok := os.LookupEnv("CLUSTER_NAME"); ok {
+		glog.Warningf("Environment variable configuration is deprecated, switch to the --cluster-name flag.")
+		cfg.ClusterName = s
+	}
+	if s, ok := os.LookupEnv("ALB_PREFIX"); ok {
+		glog.Warningf("Environment variable configuration is deprecated, switch to the --alb-name-prefix flag.")
+		cfg.ALBNamePrefix = s
+	}
+	if s, ok := os.LookupEnv("ALB_CONTROLLER_RESTRICT_SCHEME"); ok {
+		glog.Warningf("Environment variable configuration is deprecated, switch to the --restrict-scheme flag.")
+		v, err := strconv.ParseBool(s)
+		if err != nil {
+			return fmt.Errorf("ALB_CONTROLLER_RESTRICT_SCHEME environment variable must be either true or false. Value was: %s", s)
+		}
+		cfg.RestrictScheme = v
+	}
+	if s, ok := os.LookupEnv("ALB_CONTROLLER_RESTRICT_SCHEME_CONFIG_NAMESPACE"); ok {
+		glog.Warningf("Environment variable configuration is deprecated, switch to the --restrict-scheme-namespace flag.")
+		cfg.RestrictSchemeNamespace = s
+	}
+	return nil
+}
+
+func (cfg *Configuration) Validate() error {
+	if cfg.DefaultTargetType == "pod" {
+		glog.Warningf("The target type parameter for 'pod' has changed to 'ip' to better match AWS APIs and documentation.")
+		cfg.DefaultTargetType = elbv2.TargetTypeEnumIp
+	}
+	if len(cfg.ClusterName) == 0 {
+		return fmt.Errorf("clusterName must be specified")
+	}
+	if len(cfg.ALBNamePrefix) > 12 {
+		return fmt.Errorf("ALBNamePrefix must be 12 characters or less")
+	}
+	if len(cfg.ALBNamePrefix) == 0 {
+		cfg.ALBNamePrefix = generateALBNamePrefix(cfg.ClusterName)
+	}
+
+	// TODO: I know, bad smell here:D
+	parser.AnnotationsPrefix = cfg.AnnotationPrefix
+	return nil
+}
+
+func generateALBNamePrefix(clusterName string) string {
+	hash := crc32.New(crc32.MakeTable(0xedb88320))
+	_, _ = hash.Write([]byte(clusterName))
+	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/internal/ingress/controller/config/dynamic.go
+++ b/internal/ingress/controller/config/dynamic.go
@@ -30,6 +30,9 @@ func (cfg *Configuration) BindDynamicSettings(mgr manager.Manager, c controller.
 			return err
 		}
 	}
+	if cfg.FeatureGate.Enabled(WAF) && !cloud.WAFRegionalAvailable() {
+		cfg.FeatureGate.Disable(WAF)
+	}
 
 	return nil
 }

--- a/internal/ingress/controller/config/features.go
+++ b/internal/ingress/controller/config/features.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/utils"
+	"github.com/spf13/pflag"
+)
+
+type Feature string
+
+const (
+	WAF Feature = "waf"
+)
+
+type FeatureGate interface {
+	// Enabled returns whether a feature is enabled
+	Enabled(feature Feature) bool
+
+	// Enable will enable a feature
+	Enable(feature Feature)
+
+	// Disable will disable a feature
+	Disable(feature Feature)
+
+	// BindFlags bind featureGate flags
+	BindFlags(fs *pflag.FlagSet)
+}
+
+var _ FeatureGate = (*defaultFeatureGate)(nil)
+var _ pflag.Value = (*defaultFeatureGate)(nil)
+
+type defaultFeatureGate struct {
+	featureState map[Feature]bool
+}
+
+// NewFeatureGate constructs new featureGate
+func NewFeatureGate() FeatureGate {
+	return &defaultFeatureGate{
+		featureState: map[Feature]bool{
+			WAF: true,
+		},
+	}
+}
+
+func (f *defaultFeatureGate) BindFlags(fs *pflag.FlagSet) {
+	fs.Var(f, "feature-gates", "A set of key=bool pairs enable/disable features")
+}
+
+func (f *defaultFeatureGate) Enabled(feature Feature) bool {
+	return f.featureState[feature]
+}
+
+func (f *defaultFeatureGate) Enable(feature Feature) {
+	f.featureState[feature] = true
+}
+
+func (f *defaultFeatureGate) Disable(feature Feature) {
+	f.featureState[feature] = false
+}
+
+func (f *defaultFeatureGate) String() string {
+	var featureSettings []string
+	for feature, enabled := range f.featureState {
+		featureSettings = append(featureSettings, fmt.Sprintf("%v=%v", feature, enabled))
+	}
+	return strings.Join(featureSettings, ",")
+}
+
+func (f *defaultFeatureGate) Set(value string) error {
+	settings, err := utils.SplitMapStringBool(value)
+	if err != nil {
+		return fmt.Errorf("failed to parse feature-gate settings due to %v", err)
+	}
+	for k, v := range settings {
+		_, ok := f.featureState[Feature(k)]
+		if !ok {
+			return fmt.Errorf("unknown feature: %v", k)
+		}
+		f.featureState[Feature(k)] = v
+	}
+	return nil
+}
+
+func (f *defaultFeatureGate) Type() string {
+	return "mapStringBool"
+}

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// SplitMapStringBool parse comma-separated string of key1=value1,key2=value2. value is either true or false
+func SplitMapStringBool(str string) (map[string]bool, error) {
+	result := make(map[string]bool)
+	for _, s := range strings.Split(str, ",") {
+		if len(s) == 0 {
+			continue
+		}
+		parts := strings.SplitN(s, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid mapStringBool: %v", s)
+		}
+		k := strings.TrimSpace(parts[0])
+		v, err := strconv.ParseBool(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return nil, fmt.Errorf("invalid mapStringBool: %v", s)
+		}
+		result[k] = v
+	}
+	return result, nil
+}

--- a/internal/utils/strings_test.go
+++ b/internal/utils/strings_test.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/magiconair/properties/assert"
+)
+
+func TestSplitMapStringBool(t *testing.T) {
+	for i, tc := range []struct {
+		Str            string
+		ExpectedOutput map[string]bool
+		ExpectedErr    error
+	}{
+		{
+			Str:            "",
+			ExpectedOutput: make(map[string]bool),
+			ExpectedErr:    nil,
+		},
+		{
+			Str:            "key=true",
+			ExpectedOutput: map[string]bool{"key": true},
+			ExpectedErr:    nil,
+		},
+		{
+			Str:            "key1=true,key2=false,key3=true",
+			ExpectedOutput: map[string]bool{"key1": true, "key2": false, "key3": true},
+			ExpectedErr:    nil,
+		},
+		{
+			Str:            "key1=true, key2=false,key3=true ",
+			ExpectedOutput: map[string]bool{"key1": true, "key2": false, "key3": true},
+			ExpectedErr:    nil,
+		},
+		{
+			Str:            "key1=true,key2=dummy",
+			ExpectedOutput: nil,
+			ExpectedErr:    errors.New("invalid mapStringBool: key2=dummy"),
+		},
+		{
+			Str:            "key1=true,key2",
+			ExpectedOutput: nil,
+			ExpectedErr:    errors.New("invalid mapStringBool: key2"),
+		},
+	} {
+		t.Run(fmt.Sprintf("case-%v", i), func(t *testing.T) {
+			output, err := SplitMapStringBool(tc.Str)
+			assert.Equal(t, output, tc.ExpectedOutput)
+			assert.Equal(t, err, tc.ExpectedErr)
+		})
+	}
+}

--- a/mocks/CloudAPI.go
+++ b/mocks/CloudAPI.go
@@ -4,7 +4,6 @@ package mocks
 
 import context "context"
 import ec2 "github.com/aws/aws-sdk-go/service/ec2"
-import ec2metadata "github.com/aws/aws-sdk-go/aws/ec2metadata"
 import elbv2 "github.com/aws/aws-sdk-go/service/elbv2"
 import mock "github.com/stretchr/testify/mock"
 import resourcegroupstaggingapi "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
@@ -441,27 +440,6 @@ func (_m *CloudAPI) GetClusterSubnets() (map[string]types.EC2Tags, error) {
 	return r0, r1
 }
 
-// GetInstanceIdentityDocument provides a mock function with given fields:
-func (_m *CloudAPI) GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
-	ret := _m.Called()
-
-	var r0 ec2metadata.EC2InstanceIdentityDocument
-	if rf, ok := ret.Get(0).(func() ec2metadata.EC2InstanceIdentityDocument); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(ec2metadata.EC2InstanceIdentityDocument)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetInstancesByIDs provides a mock function with given fields: _a0
 func (_m *CloudAPI) GetInstancesByIDs(_a0 []string) ([]*ec2.Instance, error) {
 	ret := _m.Called(_a0)
@@ -607,13 +585,13 @@ func (_m *CloudAPI) GetSecurityGroupByID(_a0 string) (*ec2.SecurityGroup, error)
 	return r0, r1
 }
 
-// GetSecurityGroupByName provides a mock function with given fields: _a0, _a1
-func (_m *CloudAPI) GetSecurityGroupByName(_a0 string, _a1 string) (*ec2.SecurityGroup, error) {
-	ret := _m.Called(_a0, _a1)
+// GetSecurityGroupByName provides a mock function with given fields: _a0
+func (_m *CloudAPI) GetSecurityGroupByName(_a0 string) (*ec2.SecurityGroup, error) {
+	ret := _m.Called(_a0)
 
 	var r0 *ec2.SecurityGroup
-	if rf, ok := ret.Get(0).(func(string, string) *ec2.SecurityGroup); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(string) *ec2.SecurityGroup); ok {
+		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ec2.SecurityGroup)
@@ -621,8 +599,8 @@ func (_m *CloudAPI) GetSecurityGroupByName(_a0 string, _a1 string) (*ec2.Securit
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(_a0, _a1)
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -715,52 +693,6 @@ func (_m *CloudAPI) GetTargetGroupByName(_a0 context.Context, _a1 string) (*elbv
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
 		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetVPC provides a mock function with given fields: _a0
-func (_m *CloudAPI) GetVPC(_a0 *string) (*ec2.Vpc, error) {
-	ret := _m.Called(_a0)
-
-	var r0 *ec2.Vpc
-	if rf, ok := ret.Get(0).(func(*string) *ec2.Vpc); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*ec2.Vpc)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(*string) error); ok {
-		r1 = rf(_a0)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetVPCID provides a mock function with given fields:
-func (_m *CloudAPI) GetVPCID() (*string, error) {
-	ret := _m.Called()
-
-	var r0 *string
-	if rf, ok := ret.Get(0).(func() *string); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*string)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/CloudAPI.go
+++ b/mocks/CloudAPI.go
@@ -16,6 +16,20 @@ type CloudAPI struct {
 	mock.Mock
 }
 
+// ACMAvailable provides a mock function with given fields:
+func (_m *CloudAPI) ACMAvailable() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // AssociateWAF provides a mock function with given fields: ctx, resourceArn, webACLId
 func (_m *CloudAPI) AssociateWAF(ctx context.Context, resourceArn *string, webACLId *string) (*wafregional.AssociateWebACLOutput, error) {
 	ret := _m.Called(ctx, resourceArn, webACLId)
@@ -1128,6 +1142,20 @@ func (_m *CloudAPI) UntagResourcesWithContext(_a0 context.Context, _a1 *resource
 	}
 
 	return r0, r1
+}
+
+// WAFRegionalAvailable provides a mock function with given fields:
+func (_m *CloudAPI) WAFRegionalAvailable() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
 }
 
 // WebACLExists provides a mock function with given fields: ctx, webACLId


### PR DESCRIPTION
Resolves #439 #720 #622

Changes: 
- Adding featureGate for WAF functionality. (User can use --feature-gates=waf=false to disable waf support in regions like China)
- Automatically detect WAF availability and disables WAF support if need to.

Test done:
- [x] Enable waf support with `--feature-gates=waf=true`, specify non-exists webACL via `alb.ingress.kubernetes.io/web-acl-id: non-exists`, get reconcile error.
- [x] Disable waf support with `--feature-gates=waf=false`, specify non-exists webACL via `alb.ingress.kubernetes.io/web-acl-id: non-exists`, reconcile successful.
- [x] Don't specify `--feature-gates` flag with k8s cluster in us-west-2, specify an webACL via `alb.ingress.kubernetes.io/web-acl-id: webACLID`, reconcile successful. (remove webACL/modify webACL also works)

Pending test:
- [ ] Don't specify `--feature-gates` flag with k8s cluster in regions WAF not available(e.g. china), ensure ingress reconcile successful.