### PR TITLE
Allow the target service to be type LoadBalancer or type NodePort

### DIFF
--- a/internal/ingress/backend/endpoint.go
+++ b/internal/ingress/backend/endpoint.go
@@ -57,8 +57,8 @@ func (resolver *endpointResolver) resolveInstance(ingress *extensions.Ingress, b
 	if err != nil {
 		return nil, err
 	}
-	if service.Spec.Type != corev1.ServiceTypeNodePort {
-		return nil, fmt.Errorf("%v service is not of type NodePort and target-type is instance", service.Name)
+	if service.Spec.Type != corev1.ServiceTypeNodePort && service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return nil, fmt.Errorf("%v service is not of type NodePort or LoadBalancer and target-type is instance", service.Name)
 	}
 	nodePort := servicePort.NodePort
 


### PR DESCRIPTION
LoadBalancer types also bind to a NodePort in order to route traffic into the cluster so we should be able to support both types here, not just NodePort.