### PR TITLE
change security-group-inbound-cidr to just inbound-cidr

### DIFF
--- a/docs/api/ingress.md
+++ b/docs/api/ingress.md
@@ -47,7 +47,7 @@ alb.ingress.kubernetes.io/healthcheck-timeout-seconds
 alb.ingress.kubernetes.io/healthy-threshold-count
 alb.ingress.kubernetes.io/unhealthy-threshold-count
 alb.ingress.kubernetes.io/listen-ports
-alb.ingress.kubernetes.io/security-group-inbound-cidrs
+alb.ingress.kubernetes.io/inbound-cidrs
 alb.ingress.kubernetes.io/target-type
 alb.ingress.kubernetes.io/scheme
 alb.ingress.kubernetes.io/security-groups
@@ -82,7 +82,7 @@ alb.ingress.kubernetes.io/actions.<ACTION NAME>
 
 - **listen-ports**: Defines the ports the ALB will expose. It defaults to `[{"HTTP": 80}]` unless a certificate ARN is defined, then it is `[{"HTTPS": 443}]`. Uses a format as follows '[{"HTTP":8080,"HTTPS": 443}]'.
 
-- **security-group-inbound-cidrs**: Defines the CIDR whitelist for ingress traffic to ALB. It defaults to `0.0.0.0/0`.(Will be ignored if **security-groups** is specified)
+- **inbound-cidrs**: Defines the CIDR whitelist for ingress traffic to ALB. It defaults to `0.0.0.0/0`.(Will be ignored if **security-groups** is specified)
 
 - **target-type**: Defines if the EC2 instance ID or the pod IP are used in the managed Target Groups. Defaults to `instance`. Valid options are `instance` and `ip`. With `instance` the Target Group targets are `<ec2 instance id>:<node port>`, for `ip` the targets are `<pod ip>:<pod port>`. `ip` is to be used when the pod network is routable and can be reached by the ALB.
 

--- a/internal/ingress/annotations/loadbalancer/main.go
+++ b/internal/ingress/annotations/loadbalancer/main.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"strings"
 
+	"github.com/golang/glog"
+
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/aws"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/parser"
@@ -202,8 +204,14 @@ func parsePorts(ing parser.AnnotationInterface) ([]PortData, error) {
 }
 
 func parseCidrs(ing parser.AnnotationInterface) (out []string, err error) {
-	raw := parser.GetStringSliceAnnotation("security-group-inbound-cidrs", ing)
-	for _, inboundCidr := range raw {
+	cidrConfig := parser.GetStringSliceAnnotation("security-group-inbound-cidrs", ing)
+	if len(cidrConfig) != 0 {
+		glog.Warningf("`security-group-inbound-cidrs` annotation is deprecated, use `inbound-cidrs` instead")
+	} else {
+		cidrConfig = parser.GetStringSliceAnnotation("inbound-cidrs", ing)
+	}
+
+	for _, inboundCidr := range cidrConfig {
 		ip, _, err := net.ParseCIDR(inboundCidr)
 		if err != nil {
 			return out, err


### PR DESCRIPTION
Changes:
* change `security-group-inbound-cidrs` annotation to `inbound-cidrs`

Test done:
* use security-group-inbound-cidrs, the cidrs will take effect, with deprecation warning.
* use inbound-cidrs, the cidrs will take effect
