### PR TITLE
fix empty path handling

### DIFF
--- a/internal/alb/rs/rules.go
+++ b/internal/alb/rs/rules.go
@@ -158,6 +158,8 @@ func (c *defaultController) getDesiredRules(listener *elbv2.Listener, ingress *e
 
 			if path.Path != "" {
 				elbRule.Conditions = append(elbRule.Conditions, condition("path-pattern", path.Path))
+			} else {
+				elbRule.Conditions = append(elbRule.Conditions, condition("path-pattern", "/*"))
 			}
 
 			if createsRedirectLoop(listener, elbRule) {


### PR DESCRIPTION
Changes done:
1. When ingress path is empty, we'll make the rule to be '/*', which aligns the ingress spec of "catch all traffic"
- This is required since there should be at least one condition for ALB rules.
- This is required if you modify the rules with specify condition, the condition will not be override. (e.g. remove host/path from ingress spec, the host/path condition won't be modified in ALB rule).

Tests done:
1. Create ingress without path => ALB rule with "/*" are created.
1. 
    - Create ingress with hostname/path => ALB rule with host/condition are created.
    - Remove host/path from ingress => ALB rule modified to have only "/*" path condition



