### PR TITLE
cut v1.0.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 
 all: container
 
-TAG?=1.0-beta.7
+TAG?=v1.0.0
 PREFIX?=quay.io/coreos/alb-ingress-controller
 ARCH?=amd64
 OS?=linux

--- a/alb-ingress-controller-helm/Chart.yaml
+++ b/alb-ingress-controller-helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.0-beta.7
+appVersion: v1.0.0
 description: The ALB Ingress Controller satisfies Kubernetes ingress resources by provisioning Application Load Balancers.
 engine: gotpl
 home: https://github.com/kubernetes-sigs/aws-alb-ingress-controller

--- a/alb-ingress-controller-helm/README.md
+++ b/alb-ingress-controller-helm/README.md
@@ -48,7 +48,7 @@ The following tables lists the configurable parameters of the alb-ingress-contro
 | `awsRegion`               | (REQUIRED) AWS region in which this ingress controller will operate                                            | `us-west-1`                                    |
 | `clusterName`             | (REQUIRED) Resources created by the ALB Ingress controller will be prefixed with this string                   | `k8s`                                          |
 | `image.repository`        | controller container image repository                                                                          | `quay.io/coreos/alb-ingress-controller`        |
-| `image.tag`               | controller container image tag                                                                                 | `1.0-beta.7`                                   |
+| `image.tag`               | controller container image tag                                                                                 | `v1.0.0`                                   |
 | `image.pullPolicy`        | controller container image pull policy                                                                         | `IfNotPresent`                                 |
 | `extraEnv`                | map of environment variables to be injected into the controller pod                                            | `{}`                                           |
 | `nodeSelector`            | node labels for controller pod assignment                                                                      | `{}`                                           |

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -16,7 +16,7 @@ clusterName: k8s
 
 image:
   repository: quay.io/coreos/alb-ingress-controller
-  tag: "1.0-beta.7"
+  tag: "v1.0.0"
   pullPolicy: IfNotPresent
 
 extraArgs: {}

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -36,7 +36,7 @@ const (
 	defaultLeaderElectionID        = "ingress-controller-leader-alb"
 	defaultLeaderElectionNamespace = ""
 	defaultWatchNamespace          = apiv1.NamespaceAll
-	defaultSyncPeriod              = 30 * time.Second
+	defaultSyncPeriod              = 60 * time.Minute
 	defaultHealthCheckPeriod       = 1 * time.Minute
 	defaultHealthzPort             = 10254
 	defaultProfilingEnabled        = true

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 
 # AWS ALB Ingress Controller
 
-**NOTE:** This controller is in beta state as we attempt to move to our first 1.0 release. The current image version is `1.0-beta.7`. Please file any issues you find and note the version used.
+**NOTE:** The current image version is `v1.0.0`. Please file any issues you find and note the version used.
 
 The AWS ALB Ingress Controller satisfies Kubernetes [ingress resources](https://kubernetes.io/docs/user-guide/ingress) by provisioning [Application Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html).
 

--- a/docs/examples/alb-ingress-controller.yaml
+++ b/docs/examples/alb-ingress-controller.yaml
@@ -71,7 +71,7 @@ spec:
             #- name: AWS_SECRET_ACCESS_KEY
             #  value: SECRETVALUE
           # Repository location of the ALB Ingress Controller.
-          image: quay.io/coreos/alb-ingress-controller:1.0.0
+          image: quay.io/coreos/alb-ingress-controller:v1.0.0
           imagePullPolicy: Always
           name: server
           resources: {}


### PR DESCRIPTION
1. Cutting v1.0.0 release(we decided to change to use semantic version to align with go community)
2. Change default force sync time to 60 minutes(from 30 seconds)