### PR TITLE
migrate to ECR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,5 @@ script:
 after_success:
   - export COMMIT=`echo $TRAVIS_COMMIT | head -c 7`
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
-  - export REPO=quay.io/coreos/alb-ingress-controller
-  - export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
-  - docker build --pull -f Dockerfile -t $REPO:$COMMIT .
-  - docker tag $REPO:$COMMIT $REPO:$TAG
-  - docker push $REPO
   - /tmp/helm lint --strict alb-ingress-controller-helm/
   - if [ "$TRAVIS_BRANCH" = "master" ]; then ./helm_push.sh; fi

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 all: container
 
 TAG?=v1.0.0
-PREFIX?=quay.io/coreos/alb-ingress-controller
+PREFIX?=894847497797.dkr.ecr.us-west-2.amazonaws.com/aws-alb-ingress-controller
 ARCH?=amd64
 OS?=linux
 PKG=github.com/kubernetes-sigs/aws-alb-ingress-controller
@@ -40,7 +40,7 @@ server: cmd/main.go
 container: server
 	docker build --pull -t $(PREFIX):$(TAG) .
 
-push: push
+push:
 	docker push $(PREFIX):$(TAG)
 
 clean:

--- a/alb-ingress-controller-helm/Chart.yaml
+++ b/alb-ingress-controller-helm/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 name: alb-ingress-controller-helm
 sources:
   - https://github.com/kubernetes-sigs/aws-alb-ingress-controller
-version: 0.1.2
+version: 0.1.3

--- a/alb-ingress-controller-helm/README.md
+++ b/alb-ingress-controller-helm/README.md
@@ -1,6 +1,6 @@
-# alb-ingress-controller
+# aws-alb-ingress-controller
 
-[alb-ingress-controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller) satisfies Kubernetes ingress resources by provisioning Application Load Balancers.
+[aws-alb-ingress-controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller) satisfies Kubernetes ingress resources by provisioning Application Load Balancers.
 
 ## TL;DR:
 
@@ -43,24 +43,25 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the alb-ingress-controller chart and their default values.
 
-| Parameter                 | Description                                                                                                    | Default                                        |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| `awsRegion`               | (REQUIRED) AWS region in which this ingress controller will operate                                            | `us-west-1`                                    |
-| `clusterName`             | (REQUIRED) Resources created by the ALB Ingress controller will be prefixed with this string                   | `k8s`                                          |
-| `image.repository`        | controller container image repository                                                                          | `quay.io/coreos/alb-ingress-controller`        |
-| `image.tag`               | controller container image tag                                                                                 | `v1.0.0`                                   |
-| `image.pullPolicy`        | controller container image pull policy                                                                         | `IfNotPresent`                                 |
-| `extraEnv`                | map of environment variables to be injected into the controller pod                                            | `{}`                                           |
-| `nodeSelector`            | node labels for controller pod assignment                                                                      | `{}`                                           |
-| `tolerations`             | controller pod toleration for taints                                                                           | `{}`                                           |
-| `podAnnotations`          | annotations to be added to controller pod                                                                      | `{}`                                           |
-| `podLabels`               | labels to be added to controller pod                                                                           | `{}`                                           |
-| `resources`               | controller pod resource requests & limits                                                                      | `{}`                                           |
-| `rbac.create`             | If true, create & use RBAC resources                                                                           | `true`                                         |
-| `rbac.serviceAccountName` | ServiceAccount ALB ingress controller will use (ignored if rbac.create=true)                                   | `default`                                      |
-| `scope.ingressClass`      | If provided, the ALB ingress controller will only act on Ingress resources annotated with this class           | `alb`                                          |
-| `scope.singleNamespace`   | If true, the ALB ingress controller will only act on Ingress resources in a single namespace                   | `false` (watch all namespaces)                 |
-| `scope.watchNamespace`    | If scope.singleNamespace=true, the ALB ingress controller will only act on Ingress resources in this namespace | `""` (namespace of the ALB ingress controller) |
+| Parameter                 | Description                                                                                                    | Default                                                                  |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------|
+| `clusterName`             | (REQUIRED) Resources created by the ALB Ingress controller will be prefixed with this string                   | `k8s`                                                                    |
+| `awsRegion`               | AWS region of k8s cluster, required if ec2metadata is unavailable from controller pod                          | N/A                                                                      |
+| `awsVpcID`                | AWS VPC ID of k8s cluster, required if ec2metadata is unavailable from controller pod                          | N/A                                                                      |
+| `image.repository`        | controller container image repository                                                                          | `894847497797.dkr.ecr.us-west-2.amazonaws.com/aws-alb-ingress-controller`|
+| `image.tag`               | controller container image tag                                                                                 | `v1.0.0`                                                                 |
+| `image.pullPolicy`        | controller container image pull policy                                                                         | `IfNotPresent`                                                           |
+| `extraEnv`                | map of environment variables to be injected into the controller pod                                            | `{}`                                                                     |
+| `nodeSelector`            | node labels for controller pod assignment                                                                      | `{}`                                                                     |
+| `tolerations`             | controller pod toleration for taints                                                                           | `{}`                                                                     |
+| `podAnnotations`          | annotations to be added to controller pod                                                                      | `{}`                                                                     |
+| `podLabels`               | labels to be added to controller pod                                                                           | `{}`                                                                     |
+| `resources`               | controller pod resource requests & limits                                                                      | `{}`                                                                     |
+| `rbac.create`             | If true, create & use RBAC resources                                                                           | `true`                                                                   |
+| `rbac.serviceAccountName` | ServiceAccount ALB ingress controller will use (ignored if rbac.create=true)                                   | `default`                                                                |
+| `scope.ingressClass`      | If provided, the ALB ingress controller will only act on Ingress resources annotated with this class           | `alb`                                                                    |
+| `scope.singleNamespace`   | If true, the ALB ingress controller will only act on Ingress resources in a single namespace                   | `false` (watch all namespaces)                                           |
+| `scope.watchNamespace`    | If scope.singleNamespace=true, the ALB ingress controller will only act on Ingress resources in this namespace | `""` (namespace of the ALB ingress controller)                           |
 
 ```console
 $ helm registry install quay.io/coreos/alb-ingress-controller-helm --name=my-release --set clusterName=mycluster

--- a/alb-ingress-controller-helm/templates/deployment.yaml
+++ b/alb-ingress-controller-helm/templates/deployment.yaml
@@ -28,8 +28,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           args:
-            - /server
             - --cluster-name={{ .Values.clusterName }}
+          {{- if .Values.awsRegion }}
+            - --aws-region={{ .Values.awsRegion }}
+          {{- end }}
+          {{- if .Values.awsVpcID }}
+            - --aws-vpc-id={{ .Values.awsVpcID }}
+          {{- end }}
           {{- if .Values.scope.ingressClass }}
             - --ingress-class={{ .Values.scope.ingressClass }}
           {{- end }}
@@ -40,22 +45,10 @@ spec:
             - --{{ $key }}={{ $value }}
           {{- end }}
           env:
-            - name: AWS_REGION
-              value: "{{ .Values.awsRegion }}"
           {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}
               value: "{{ $value }}"
           {{- end }}
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
           ports:
             - containerPort: 10254
               protocol: TCP

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -4,18 +4,18 @@
 # overrides the chart name.
 nameOverride: alb-ingress-controller
 
-## AWS region in which this ingress controller will operate
-## REQUIRED
-#
-awsRegion: us-west-1
-
 ## Resources created by the ALB Ingress controller will be prefixed with this string
 ## REQUIRED
-#
 clusterName: k8s
 
+## AWS region of k8s cluster, required if ec2metadata is unavailable from controller pod
+awsRegion: ""
+
+## VPC ID of k8s cluster, required if ec2metadata is unavailable from controller pod
+awsVpcID: ""
+
 image:
-  repository: quay.io/coreos/alb-ingress-controller
+  repository: 894847497797.dkr.ecr.us-west-2.amazonaws.com/aws-alb-ingress-controller
   tag: "v1.0.0"
   pullPolicy: IfNotPresent
 

--- a/docs/examples/alb-ingress-controller.yaml
+++ b/docs/examples/alb-ingress-controller.yaml
@@ -71,7 +71,7 @@ spec:
             #- name: AWS_SECRET_ACCESS_KEY
             #  value: SECRETVALUE
           # Repository location of the ALB Ingress Controller.
-          image: quay.io/coreos/alb-ingress-controller:v1.0.0
+          image: 894847497797.dkr.ecr.us-west-2.amazonaws.com/aws-alb-ingress-controller:v1.0.0
           imagePullPolicy: Always
           name: server
           resources: {}


### PR DESCRIPTION
Changed done:
1. Migrate from image quay.io into dedicated ECR account(also, image name is changed from **alb-ingress-controller** to **aws-alb-ingress-controller**
1. Add support for specifying awsVpcID for helm chart
1. Make awsRegion to be optional

Testing done:
* helm install alb-ingress-controller-helm/ 
* helm install alb-ingress-controller-helm/  --set awsRegion=us-west-2 awsVpcID=vpc-xxxxx

Future work:
* setup codeBuild pipeline to automated the build & release process. 