### PR TITLE
Update examples to be NodePort to be available to all k8s setup on AWS

### DIFF
--- a/docs/examples/2048/2048-service.yaml
+++ b/docs/examples/2048/2048-service.yaml
@@ -8,5 +8,6 @@ spec:
     - port: 80
       targetPort: 80
       protocol: TCP
+  type: NodePort
   selector:
     app: "2048"

--- a/docs/examples/echoservice/echoserver-service.yaml
+++ b/docs/examples/echoservice/echoserver-service.yaml
@@ -8,5 +8,6 @@ spec:
     - port: 80
       targetPort: 8080
       protocol: TCP
+  type: NodePort
   selector:
     app: echoserver


### PR DESCRIPTION
Fix inconsistent introduced by my https://github.com/kubernetes-sigs/aws-alb-ingress-controller/pull/741