### PR TITLE
use latest External DNS version 0.5.9

### DIFF
--- a/docs/examples/external-dns.yaml
+++ b/docs/examples/external-dns.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.2
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.9
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Just bumping the External DNS version (this file is referenced in the tutorial) to v0.5.9. This version contains numerous bugfixes and [is used in production by Zalando](https://github.com/zalando-incubator/kubernetes-on-aws/blob/dev/cluster/manifests/external-dns/deployment.yaml).

See https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.9 for changelog