### PR TITLE
Fix kubectl apply command for echoserver

### DIFF
--- a/docs/guide/walkthrough/echoserver.md
+++ b/docs/guide/walkthrough/echoserver.md
@@ -102,7 +102,7 @@ In this walkthrough, you'll
     ```bash
     kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.0.0/docs/examples/echoservice/echoserver-namespace.yaml &&\
     kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.0.0/docs/examples/echoservice/echoserver-service.yaml &&\
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.0.0/docs/examples/echoservice/echoserver-deployment.yaml &&\
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.0.0/docs/examples/echoservice/echoserver-deployment.yaml
     ```
 
 1.  List all the resources to ensure they were created.


### PR DESCRIPTION
Just a small update to the docs for the echoserver.

The first step in
https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-the-echoserver-resources
has an extra `&&\` which forces you to edit the command after
copy/pasting.