### PR TITLE
fix controller crash when action annotation didn't exists

### DIFF
--- a/internal/ingress/annotations/action/main.go
+++ b/internal/ingress/annotations/action/main.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/errors"
+
 	extensions "k8s.io/api/extensions/v1beta1"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -34,6 +36,9 @@ func (a action) Parse(ing parser.AnnotationInterface) (interface{}, error) {
 	actions := make(map[string]*elbv2.Action)
 	annos, err := parser.GetStringAnnotations("actions", ing)
 	if err != nil {
+		if errors.IsMissingAnnotations(err) {
+			return &Config{}, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Changes done:
fix controller crash when action annotation didn't exists but referenced by ingress spec.

Test done:
1. create ingress spec reference action without specify action annotation, observed logs below instead of crash:
failed to reconcile listeners due to failed to reconcile rules due to backend with `servicePort: use-annotation` was configured with `serviceName: ssl-redirect` but an action annotation for ssl-redirect is not set

Thoughts:
we should use pointer rarely. Only use pointer to represent optional semantic(or the copy operation is `indeed` heavy).  Also, client code should check for nil, if there is optional semantic. (I'd like java's Optional =.=)