### PR TITLE
Documentation Fixes & Remove helm repo plugin

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [packages]
 mkdocs = "*"
 mkdocs-material = "*"
-mkdocs-helm = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -85,14 +85,6 @@
             "index": "pypi",
             "version": "==1.0.4"
         },
-        "mkdocs-helm": {
-            "hashes": [
-                "sha256:acef424d4624c0b91ea611a34a8ea77725595bb2f4d1350c137c7850bd65ef12",
-                "sha256:fd15fe768b687c95b6efae47d2836475f75ff887cc2492c9565e1c71611486e6"
-            ],
-            "index": "pypi",
-            "version": "==1.0.2"
-        },
         "mkdocs-material": {
             "hashes": [
                 "sha256:037712dd7e2128a9b596943bcd92ebc9ad28800906dcee447e2fc008dd9dbbff",

--- a/docs/guide/ingress/annotation.md
+++ b/docs/guide/ingress/annotation.md
@@ -31,9 +31,9 @@ You can add kubernetes annotations to ingress and service objects to customize t
 |[alb.ingress.kubernetes.io/security-groups](#security-groups)|stringList|N/A|ingress|
 |[alb.ingress.kubernetes.io/ssl-policy](#ssl-policy)|string|ELBSecurityPolicy-2016-08|ingress|
 |[alb.ingress.kubernetes.io/subnets](#subnets)|stringList|N/A|ingress|
-|[alb.ingress.kubernetes.io/success-codes](#success-codes)|string|'200'|ingress|
+|[alb.ingress.kubernetes.io/success-codes](#success-codes)|string|'200'|ingress,service|
 |[alb.ingress.kubernetes.io/tags](#tags)|stringMap|N/A|ingress|
-|[alb.ingress.kubernetes.io/target-group-attributes](#target-group-attributes)|stringMap|N/A|ingress|
+|[alb.ingress.kubernetes.io/target-group-attributes](#target-group-attributes)|stringMap|N/A|ingress,service|
 |[alb.ingress.kubernetes.io/target-type](#target-type)|instance \| ip|instance|ingress,service|
 |[alb.ingress.kubernetes.io/unhealthy-threshold-count](#unhealthy-threshold-count)|integer|'2'|ingress,service|
 
@@ -284,6 +284,10 @@ Custom attributes to LoadBalancers and TargetGroups can be controlled with follo
         - set the deregistration delay to 30 seconds
             ```
             alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
+            ```
+        - enable sticky sessions
+            ```
+            alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=60
             ```
 
 ## Resource Tags

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,8 +26,6 @@ nav:
   - Roadmap: 'ROADMAP.md'
 plugins:
 - search
-- helm-repo:
-    chart: alb-ingress-controller-helm
 theme:
   name: material
   feature:


### PR DESCRIPTION
Changes done:
1. Remove the unneeded helm repo plugin
1. Adding example for enable sticky sessions(fix https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/784)