### PR TITLE
Move template files from docs/ to root

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing Guidelines
+
+Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://github.com/kubernetes/community)! The Kubernetes community abides by the CNCF [code of conduct](code-of-conduct.md). Here is an excerpt:
+
+_As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
+
+## Getting Started
+
+[`BUILDING.md`](/docs/BUILDING.md) has instructions on how to build the project.
+We also have more documentation on how to get started contributing here:
+
+- [Contributor License Agreement](https://git.k8s.io/community/CLA.md) Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
+- [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](http://git.k8s.io/community/contributors/guide#contributing)
+- [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet.md) - Common resources for existing developers
+
+## Mentorship
+
+- [Mentoring Initiatives](https://git.k8s.io/community/mentoring) - We have a diverse set of mentorship programs available that are always looking for volunteers!
+
+## Contact Information
+
+- [Slack channel](https://kubernetes.slack.com/messages/sig-aws)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-aws)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ To get started with the controller, see our [walkthrough](https://kubernetes-sig
 
 For details on building this project, see [BUILDING.md](BUILDING.md).
 
+## Community, discussion, contribution, and support
+
+Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).
+
+You can reach the maintainers of this project at:
+
+- [Slack channel](https://kubernetes.slack.com/messages/sig-aws)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-aws)
+
+### Code of conduct
+
+Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).
+
 ## License
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fcoreos%2Falb-ingress-controller.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fcoreos%2Falb-ingress-controller?ref=badge_large)

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-**Kubernetes Community Code of Conduct**
-
-Kubernetes follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,9 +1,0 @@
-# Contributing
-
-Thanks for taking the time to join our community and start contributing!
-
-The [Contributor Guide](https://git.k8s.io/community/contributors/guide/README.md)
-provides detailed instructions on how to get your ideas and bug fixes seen and accepted.
-
-Please remember to sign the [CNCF CLA](https://git.k8s.io/community/CLA.md) and
-read and observe the [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
Ref: https://github.com/kubernetes/steering/issues/28 and https://github.com/kubernetes/community/issues/3053

The template files need to be at the root of the repo. The content is as per https://github.com/kubernetes/kubernetes-template-project.

/assign @andrewtandoc @bigkraig @M00nF1sh
