### PR TITLE
#797 Add a forward actions annotation to allow forwarding to external target groups

### DIFF
--- a/docs/guide/tasks/migrate_legacy_apps.md
+++ b/docs/guide/tasks/migrate_legacy_apps.md
@@ -1,0 +1,42 @@
+# Migrating From Legacy Apps with Manually Configured Target Groups
+
+Many organizations are decomposing old legacy apps into smaller services and components. 
+
+During the transition they may be running a hybrid ecosystem with some parts of the app running in ec2 instances, 
+some in Kubernetes microservices, and possibly even some in serverless environments like Lambda. 
+
+The existing clients of the application expect all endpoints under one DNS entry and it's desirable to be able
+to route traffic at the ALB to services running outside the Kubernetes cluster. 
+
+The actions annotation allows the definition of a forward rule to a previously configured target group. 
+Learn more about the actions annotation at
+[`alb.ingress.kubernetes.io/actions.${action-name}`](../ingress/annotation.md#actions)
+
+## Example Ingress Manifest
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  namespace: testcase
+  name: echoserver
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/actions.legacy-app: '{"Type": "forward", "TargetGroupArn": "legacy-tg-arn"}'
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /v1/endpoints
+            backend:
+              serviceName: legacy-app
+              servicePort: use-annotation
+          - path: /normal-path
+            backend:
+              serviceName: echoserver
+              servicePort: 80
+```
+
+!!!note
+    The `TargetGroupArn` must be set and the user is responsible for configuring the Target group in AWS before applying
+    the forward rule.    
+

--- a/internal/ingress/annotations/action/main.go
+++ b/internal/ingress/annotations/action/main.go
@@ -61,10 +61,10 @@ func (a action) Parse(ing parser.AnnotationInterface) (interface{}, error) {
 			if data.RedirectConfig == nil {
 				return nil, fmt.Errorf("%v is type redirect but did not include a valid RedirectConfig configuration", serviceName)
 			}
-        case "forward":
-            if data.TargetGroupArn == nil {
-                return nil, fmt.Errorf("%v is type forward but did not include a valid TargetGroupArn configuration", serviceName)
-            }
+		case "forward":
+			if data.TargetGroupArn == nil {
+				return nil, fmt.Errorf("%v is type forward but did not include a valid TargetGroupArn configuration", serviceName)
+			}
 		default:
 			return nil, fmt.Errorf("an invalid action type %v was configured in %v", *data.Type, serviceName)
 		}
@@ -163,7 +163,7 @@ func Dummy() *Config {
 				},
 			}),
 			"forward": setDefaults(&elbv2.Action{
-				Type: aws.String(elbv2.ActionTypeEnumForward),
+				Type:           aws.String(elbv2.ActionTypeEnumForward),
 				TargetGroupArn: aws.String("legacy-tg-arn"),
 			}),
 		},

--- a/internal/ingress/annotations/action/main.go
+++ b/internal/ingress/annotations/action/main.go
@@ -61,6 +61,10 @@ func (a action) Parse(ing parser.AnnotationInterface) (interface{}, error) {
 			if data.RedirectConfig == nil {
 				return nil, fmt.Errorf("%v is type redirect but did not include a valid RedirectConfig configuration", serviceName)
 			}
+        case "forward":
+            if data.TargetGroupArn == nil {
+                return nil, fmt.Errorf("%v is type forward but did not include a valid TargetGroupArn configuration", serviceName)
+            }
 		default:
 			return nil, fmt.Errorf("an invalid action type %v was configured in %v", *data.Type, serviceName)
 		}
@@ -157,6 +161,10 @@ func Dummy() *Config {
 					StatusCode:  aws.String("503"),
 					MessageBody: aws.String("message body"),
 				},
+			}),
+			"forward": setDefaults(&elbv2.Action{
+				Type: aws.String(elbv2.ActionTypeEnumForward),
+				TargetGroupArn: aws.String("legacy-tg-arn"),
 			}),
 		},
 	}

--- a/internal/ingress/annotations/action/main_test.go
+++ b/internal/ingress/annotations/action/main_test.go
@@ -22,6 +22,7 @@ func TestIngressActions(t *testing.T) {
 	"StatusCode":"503", "MessageBody":"message body"}}`
 	data[parser.GetAnnotationWithPrefix("actions.redirect-action")] = `{"Type": "redirect", "RedirectConfig": {"Protocol":"HTTPS",
   "Port":"443", "Host":"#{host}", "Path": "/#{path}", "Query": "#{query}", "StatusCode": "HTTP_301"}}`
+    data[parser.GetAnnotationWithPrefix("actions.forward")] = `{"Type": "forward", "TargetGroupArn": "legacy-tg-arn"}`
 	ing.SetAnnotations(data)
 
 	ai, err := NewParser(mockBackend{}).Parse(ing)

--- a/internal/ingress/annotations/action/main_test.go
+++ b/internal/ingress/annotations/action/main_test.go
@@ -22,7 +22,7 @@ func TestIngressActions(t *testing.T) {
 	"StatusCode":"503", "MessageBody":"message body"}}`
 	data[parser.GetAnnotationWithPrefix("actions.redirect-action")] = `{"Type": "redirect", "RedirectConfig": {"Protocol":"HTTPS",
   "Port":"443", "Host":"#{host}", "Path": "/#{path}", "Query": "#{query}", "StatusCode": "HTTP_301"}}`
-    data[parser.GetAnnotationWithPrefix("actions.forward")] = `{"Type": "forward", "TargetGroupArn": "legacy-tg-arn"}`
+	data[parser.GetAnnotationWithPrefix("actions.forward")] = `{"Type": "forward", "TargetGroupArn": "legacy-tg-arn"}`
 	ing.SetAnnotations(data)
 
 	ai, err := NewParser(mockBackend{}).Parse(ing)


### PR DESCRIPTION
@M00nF1sh made a simple and elegant suggestion for how to implement a solution for a use case I outlined in https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/797 . This PR attempts to follow the guidance in that issue. I have locally run `make test` and `make lint` successfully. 

I've signed the CLA as an individual, but have been working on this as part of my day job at Zymergen, and am working with our legal department to get our company to sign and add me as an authorized contributor. I don't anticipate any snags, but probably should hold off on merging.

* Added a new case statement to allow for actions annotations of type `forward`
* Added a new docs/guide/tasks/migrate_legacy_apps.md to document the use case an present an example of how to use it
* Added a dummy forward annotation to the unit test, which should assure happy path, but would be up for suggestions on other good assertions.