### PR TITLE
fix security_alert and broken docs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 mkdocs = "*"
 mkdocs-material = "*"
+pyyaml = ">=4.2b1"
 
 [dev-packages]
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,0 +1,1 @@
+../code-of-conduct.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,1 @@
-README.md
+../README.md


### PR DESCRIPTION
Changes done:
1. fix security alert from github about pyyaml version
1. fix broken docs by #792 (made several symbol link instead of clone to support it)

Test done:
1. make docs-deploy