### PR TITLE
Add kustomization.yaml

### DIFF
--- a/docs/examples/alb-ingress-controller.yaml
+++ b/docs/examples/alb-ingress-controller.yaml
@@ -21,7 +21,8 @@ spec:
         app: alb-ingress-controller
     spec:
       containers:
-        - args:
+        - name: alb-ingress-controller
+          # args:
             # Limit the namespace where this ALB Ingress Controller deployment will
             # resolve ingress resources. If left commented, all namespaces are used.
             # - --watch-namespace=your-k8s-namespace
@@ -29,12 +30,13 @@ spec:
             # Setting the ingress-class flag below ensures that only ingress resources with the
             # annotation kubernetes.io/ingress.class: "alb" are respected by the controller. You may
             # choose any class you'd like for this controller to respect.
-            - --ingress-class=alb
+            # - --ingress-class=alb
 
+            # REQUIRED
             # Name of your cluster. Used when naming resources created
             # by the ALB Ingress Controller, providing distinction between
             # clusters.
-            - --cluster-name=devCluster
+            # - --cluster-name=devCluster
 
             # AWS VPC ID this ingress controller will use to create AWS resources.
             # If unspecified, it will be discovered from ec2metadata.
@@ -51,7 +53,7 @@ spec:
             # Maximum number of times to retry the aws calls.
             # defaults to 10.
             # - --aws-max-retries=10
-          env:
+          # env:
             # AWS key id for authenticating with the AWS API.
             # This is only here for examples. It's recommended you instead use
             # a project like kube2iam for granting access.

--- a/docs/examples/alb-ingress-controller.yaml
+++ b/docs/examples/alb-ingress-controller.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: alb-ingress-controller
-          # args:
+          args:
             # Limit the namespace where this ALB Ingress Controller deployment will
             # resolve ingress resources. If left commented, all namespaces are used.
             # - --watch-namespace=your-k8s-namespace
@@ -30,7 +30,7 @@ spec:
             # Setting the ingress-class flag below ensures that only ingress resources with the
             # annotation kubernetes.io/ingress.class: "alb" are respected by the controller. You may
             # choose any class you'd like for this controller to respect.
-            # - --ingress-class=alb
+            - --ingress-class=alb
 
             # REQUIRED
             # Name of your cluster. Used when naming resources created

--- a/docs/examples/alb-ingress-controller.yaml
+++ b/docs/examples/alb-ingress-controller.yaml
@@ -47,7 +47,7 @@ spec:
             # If unspecified, it will be discovered from ec2metadata.
             # - --aws-vpc-id=vpc-xxxxxx
 
-            # AWS region this ingress controller will operate in. 
+            # AWS region this ingress controller will operate in.
             # If unspecified, it will be discovered from ec2metadata.
             # List of regions: http://docs.aws.amazon.com/general/latest/gr/rande.html#vpc_region
             # - --aws-region=us-west-1
@@ -64,7 +64,7 @@ spec:
             # a project like kube2iam for granting access.
             #- name: AWS_ACCESS_KEY_ID
             #  value: KEYVALUE
-            
+
             # AWS key secret for authenticating with the AWS API.
             # This is only here for examples. It's recommended you instead use
             # a project like kube2iam for granting access.
@@ -80,5 +80,5 @@ spec:
       restartPolicy: Always
       securityContext: {}
       terminationGracePeriodSeconds: 30
-      serviceAccountName: alb-ingress
-      serviceAccount: alb-ingress
+      serviceAccountName: alb-ingress-controller
+      serviceAccount: alb-ingress-controller

--- a/docs/examples/alb-ingress-controller.yaml
+++ b/docs/examples/alb-ingress-controller.yaml
@@ -12,18 +12,11 @@ metadata:
   # namespace scope, see --watch-namespace.
   namespace: kube-system
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: alb-ingress-controller
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: alb-ingress-controller
     spec:
@@ -72,13 +65,4 @@ spec:
             #  value: SECRETVALUE
           # Repository location of the ALB Ingress Controller.
           image: docker.io/amazon/aws-alb-ingress-controller:v1.1.0
-          imagePullPolicy: Always
-          name: server
-          resources: {}
-          terminationMessagePath: /dev/termination-log
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-      securityContext: {}
-      terminationGracePeriodSeconds: 30
       serviceAccountName: alb-ingress-controller
-      serviceAccount: alb-ingress-controller

--- a/docs/examples/kustomization.yaml
+++ b/docs/examples/kustomization.yaml
@@ -1,0 +1,8 @@
+commonLabels:
+  app: alb-ingress-controller
+
+namespace: kube-system
+
+resources:
+- alb-ingress-controller.yaml
+- rbac-role.yaml

--- a/docs/examples/rbac-role.yaml
+++ b/docs/examples/rbac-role.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -48,7 +49,7 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress
+    name: alb-ingress-controller
     namespace: kube-system
 ---
 apiVersion: v1
@@ -56,5 +57,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app: alb-ingress-controller
-  name: alb-ingress
+  name: alb-ingress-controller
   namespace: kube-system
+...


### PR DESCRIPTION
Added a `kustomization.yaml` file to enable installation via [kustomize](https://github.com/kubernetes-sigs/kustomize). Also tweaked the existing manifests to make the container & service account names consistent with the other resources.

Finally, removed or commented fields in the Deployment that are defaulted by the cluster (e.g. replicas, dnsPolicy, restartPolicy) or deprecated (serviceAccount). While not strictly necessary, it does make it somewhat easier to create kustomize overlays.

Closes #815 