### PR TITLE
Fix error message for internet LB

### DIFF
--- a/internal/alb/lb/loadbalancer.go
+++ b/internal/alb/lb/loadbalancer.go
@@ -418,7 +418,7 @@ func (controller *defaultController) clusterSubnets(ctx context.Context, scheme 
 			"Additionally, there must be at least 2 subnets with unique availability zones as required by "+
 			"ALBs. Either tag subnets to meet this requirement or use the subnets annotation on the "+
 			"ingress resource to explicitly call out what subnets to use for ALB creation. The subnets "+
-			"that did resolve were %v", aws.TagNameCluster, aws.TagNameSubnetInternalELB,
+			"that did resolve were %v", aws.TagNameCluster, key,
 			log.Prettify(out))
 	}
 


### PR DESCRIPTION
When using an internet-facing, the error message shows the wrong tag. The correct tag is defined in line 383, variable key.