### PR TITLE
ping golangci-lint version as specified in go mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clean:
 	rm -f server
 
 lint:
-	go get -v github.com/golangci/golangci-lint/cmd/golangci-lint
+	go install -v github.com/golangci/golangci-lint/cmd/golangci-lint
 	$(GOBIN)/golangci-lint run --deadline=10m
 
 unit-test:


### PR DESCRIPTION
Ping golangci-lint version as specified in go mod

(Their newest v1.13.x versions crashes lint, and brokens PR like https://github.com/kubernetes-sigs/aws-alb-ingress-controller/pull/827)