### PR TITLE
Auto-add certs from ACM by hostname if none are specified via annotation

### DIFF
--- a/internal/alb/ls/listener.go
+++ b/internal/alb/ls/listener.go
@@ -232,6 +232,8 @@ func (controller *defaultController) buildListenerConfig(ctx context.Context, op
 				return config, errors.Errorf("missing certificates annotation %v could not find any matching certificates from ACM to auto-load",
 					parser.GetAnnotationWithPrefix(AnnotationCertificateARN))
 			}
+
+			albctx.GetLogger(ctx).Infof("Auto-detected and added %d certificates to listener", len(certs))
 			certificateARNs = certs
 		}
 		config.DefaultCertificate = []*elbv2.Certificate{
@@ -277,7 +279,7 @@ func inferCertARNs(acmsvc aws.ACMAPI, ingress *extensions.Ingress, logger *log.L
 	for _, c := range certs {
 		for _, h := range ingressHosts {
 			if domainMatchesHost(aws.StringValue(c.DomainName), h) {
-				logger.Debugf("Domain name '%s', matches TLS host '%v', adding to Listener", aws.StringValue(c.DomainName), h)
+				logger.Infof("Domain name '%s', matches TLS host '%v', adding to Listener", aws.StringValue(c.DomainName), h)
 				if !seen[aws.StringValue(c.CertificateArn)] {
 					certArns = append(certArns, aws.StringValue(c.CertificateArn))
 					seen[aws.StringValue(c.CertificateArn)] = true

--- a/internal/alb/ls/listener.go
+++ b/internal/alb/ls/listener.go
@@ -228,6 +228,10 @@ func (controller *defaultController) buildListenerConfig(ctx context.Context, op
 				return config, errors.Errorf("missing certificates annotation %v and could not auto-load certificates from ACM: %v",
 					parser.GetAnnotationWithPrefix(AnnotationCertificateARN), err)
 			}
+			if len(certs) == 0 {
+				return config, errors.Errorf("missing certificates annotation %v could not find any matching certificates from ACM to auto-load",
+					parser.GetAnnotationWithPrefix(AnnotationCertificateARN))
+			}
 			certificateARNs = certs
 		}
 		config.DefaultCertificate = []*elbv2.Certificate{

--- a/internal/alb/ls/listener_test.go
+++ b/internal/alb/ls/listener_test.go
@@ -3,9 +3,11 @@ package ls
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/alb/tg"
@@ -15,6 +17,7 @@ import (
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/auth"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/mocks"
 	mock_auth "github.com/kubernetes-sigs/aws-alb-ingress-controller/mocks/aws-alb-ingress-controller/ingress/auth"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/util/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	extensions "k8s.io/api/extensions/v1beta1"
@@ -900,5 +903,309 @@ func TestDefaultController_Reconcile(t *testing.T) {
 			cloud.AssertExpectations(t)
 			mockRulesController.AssertExpectations(t)
 		})
+	}
+}
+
+func Test_domainMatchesHost(t *testing.T) {
+	var tests = []struct {
+		domain string
+		host   string
+		want   bool
+	}{
+		{"example.com", "example.com", true},
+		{"example.com", "exampl0.com", false},
+
+		// wildcards
+		{"*.example.com", "foo.example.com", true},
+		{"*.example.com", "example.com", false},
+		{"*.exampl0.com", "foo.example.com", false},
+
+		// invalid hosts, not sure these are possible
+		{"*.*.example.com", "foo.bar.example.com", false},
+		{"foo.*.example.com", "foo.bar.example.com", false},
+	}
+
+	for _, test := range tests {
+		var msg = "should"
+		if !test.want {
+			msg = "should not"
+		}
+
+		t.Run(fmt.Sprintf("%s %s match %s", test.domain, msg, test.host), func(t *testing.T) {
+			have := domainMatchesHost(test.domain, test.host)
+			if test.want != have {
+				t.Fail()
+			}
+		})
+	}
+}
+
+func Test_inferCertARNs(t *testing.T) {
+	var tests = []struct {
+		name      string
+		ingress   *extensions.Ingress
+		acmResult []acm.CertificateSummary
+		acmErr    error
+		expected  int
+	}{
+		{
+			name: "when ACM has exact match as TLS host",
+			ingress: &extensions.Ingress{
+				Spec: extensions.IngressSpec{
+					TLS: []extensions.IngressTLS{
+						{
+							Hosts: []string{"foo.example.com"},
+						},
+					},
+				},
+			},
+			acmResult: []acm.CertificateSummary{
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:www"),
+					DomainName:     aws.String("foo.example.com"),
+				},
+			},
+			expected: 1,
+		}, {
+			name: "when ACM has wildcard match with TLS host",
+			ingress: &extensions.Ingress{
+				Spec: extensions.IngressSpec{
+					TLS: []extensions.IngressTLS{
+						{
+							Hosts: []string{"foo.example.com"},
+						},
+					},
+				},
+			},
+			acmResult: []acm.CertificateSummary{
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:www"),
+					DomainName:     aws.String("*.example.com"),
+				},
+			},
+			expected: 1,
+		}, {
+			name: "when ACM has multiple matches with TLS host",
+			ingress: &extensions.Ingress{
+				Spec: extensions.IngressSpec{
+					TLS: []extensions.IngressTLS{
+						{
+							Hosts: []string{"foo.example.com"},
+						},
+					},
+				},
+			},
+			acmResult: []acm.CertificateSummary{
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:www"),
+					DomainName:     aws.String("foo.example.com"),
+				},
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:mmm"),
+					DomainName:     aws.String("*.example.com"),
+				},
+			},
+			expected: 2,
+		}, {
+			name: "when ACM has exact match as Rules host",
+			ingress: &extensions.Ingress{
+				Spec: extensions.IngressSpec{
+					Rules: []extensions.IngressRule{
+						{
+							Host: "foo.example.com",
+						},
+					},
+				},
+			},
+			acmResult: []acm.CertificateSummary{
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:www"),
+					DomainName:     aws.String("foo.example.com"),
+				},
+			},
+			expected: 1,
+		}, {
+			name: "when ACM has wildcard match with Rules host",
+			ingress: &extensions.Ingress{
+				Spec: extensions.IngressSpec{
+					Rules: []extensions.IngressRule{
+						{
+							Host: "foo.example.com",
+						},
+					},
+				},
+			},
+			acmResult: []acm.CertificateSummary{
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:www"),
+					DomainName:     aws.String("*.example.com"),
+				},
+			},
+			expected: 1,
+		}, {
+			name: "when ACM has multiple matches with Rules host",
+			ingress: &extensions.Ingress{
+				Spec: extensions.IngressSpec{
+					Rules: []extensions.IngressRule{
+						{
+							Host: "foo.example.com",
+						},
+					},
+				},
+			},
+			acmResult: []acm.CertificateSummary{
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:www"),
+					DomainName:     aws.String("foo.example.com"),
+				},
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:mmm"),
+					DomainName:     aws.String("*.example.com"),
+				},
+			},
+			expected: 2,
+		}, {
+			name: "when ACM has multiple matches with Rules and TLS hosts",
+			ingress: &extensions.Ingress{
+				Spec: extensions.IngressSpec{
+					TLS: []extensions.IngressTLS{
+						{
+							Hosts: []string{"foo.example.com"},
+						},
+					},
+					Rules: []extensions.IngressRule{
+						{
+							Host: "foo.example.com",
+						},
+					},
+				},
+			},
+			acmResult: []acm.CertificateSummary{
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:www"),
+					DomainName:     aws.String("foo.example.com"),
+				},
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:mmm"),
+					DomainName:     aws.String("*.example.com"),
+				},
+			},
+			expected: 2,
+		}, {
+			name: "when ACM has multiple matches with multiple wildcard hosts",
+			ingress: &extensions.Ingress{
+				Spec: extensions.IngressSpec{
+					TLS: []extensions.IngressTLS{
+						{
+							Hosts: []string{"foo.bar.example.com", "bar.baz.example.com"},
+						},
+					},
+					Rules: []extensions.IngressRule{
+						{
+							Host: "foo.bar.example.com",
+						},
+						{
+							Host: "bar.baz.example.com",
+						},
+					},
+				},
+			},
+			acmResult: []acm.CertificateSummary{
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:www"),
+					DomainName:     aws.String("*.bar.example.com"),
+				},
+				{
+					CertificateArn: aws.String("arn:acm:xxx:yyy:zzz/kkk:mmm"),
+					DomainName:     aws.String("*.baz.example.com"),
+				},
+			},
+			expected: 2,
+		}, {
+			name:     "when ACM returns error",
+			ingress:  &extensions.Ingress{},
+			acmErr:   fmt.Errorf("expected error"),
+			expected: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var logger = log.New(test.name)
+
+			acmsvc := &mocks.CloudAPI{}
+			acmsvc.On("ListCertificates", []string{acm.CertificateStatusIssued}).Return(test.acmResult, test.acmErr)
+
+			certificates, err := inferCertARNs(acmsvc, test.ingress, logger)
+			if test.acmErr != err {
+				t.Error(err)
+			}
+
+			if len(certificates) != test.expected {
+				t.Errorf("Expected %d, got %d certificates in result", test.expected, len(certificates))
+			}
+
+			for i, cert := range certificates {
+				want := aws.StringValue(test.acmResult[i].CertificateArn)
+				have := cert
+				if want != have {
+					t.Errorf("Certificate ARNs don't match: expected %s, got %s", want, have)
+				}
+			}
+		})
+	}
+}
+
+func Test_uniqueHosts(t *testing.T) {
+	var tests = []struct {
+		expected int
+		input    *extensions.Ingress
+	}{
+		{0, &extensions.Ingress{}},
+		{2, &extensions.Ingress{
+			Spec: extensions.IngressSpec{
+				TLS: []extensions.IngressTLS{
+					{
+						Hosts: []string{"a", "b"},
+					},
+				},
+			},
+		}},
+		{3, &extensions.Ingress{
+			Spec: extensions.IngressSpec{
+				TLS: []extensions.IngressTLS{
+					{
+						Hosts: []string{
+							"a",
+							"b",
+						},
+					},
+				},
+				Rules: []extensions.IngressRule{
+					{
+						Host: "a",
+					}, {
+						Host: "c",
+					},
+				},
+			},
+		}},
+		{1, &extensions.Ingress{
+			Spec: extensions.IngressSpec{
+				Rules: []extensions.IngressRule{
+					{
+						Host: "a",
+					}, {
+						Host: "a",
+					},
+				},
+			},
+		}},
+	}
+
+	for _, test := range tests {
+		if len(uniqueHosts(test.input)) != test.expected {
+			t.Fail()
+		}
 	}
 }

--- a/internal/aws/acm.go
+++ b/internal/aws/acm.go
@@ -17,6 +17,9 @@ type ACMAPI interface {
 
 	// ACMAvailable whether ACM service is available
 	ACMAvailable() bool
+
+	// ListCertificates returns a list of certificate objects from ACM
+	ListCertificates(status []string) ([]acm.CertificateSummary, error)
 }
 
 // Status validates ACM connectivity
@@ -37,4 +40,23 @@ func (c *Cloud) ACMAvailable() bool {
 	resolver := endpoints.DefaultResolver()
 	_, err := resolver.EndpointFor(acm.EndpointsID, c.region)
 	return err == nil
+}
+
+// ListCertificates returns a list of certificates from ACM
+// Apply a filter to the query using the status parameter
+func (c *Cloud) ListCertificates(status []string) ([]acm.CertificateSummary, error) {
+	lcout, err := c.acm.ListCertificates(&acm.ListCertificatesInput{
+		CertificateStatuses: aws.StringSlice(status),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var certs []acm.CertificateSummary
+	for _, c := range lcout.CertificateSummaryList {
+		certs = append(certs, *c)
+	}
+
+	return certs, nil
 }

--- a/mocks/CloudAPI.go
+++ b/mocks/CloudAPI.go
@@ -2,6 +2,8 @@
 
 package mocks
 
+import acm "github.com/aws/aws-sdk-go/service/acm"
+
 import context "context"
 import ec2 "github.com/aws/aws-sdk-go/service/ec2"
 import elbv2 "github.com/aws/aws-sdk-go/service/elbv2"
@@ -843,6 +845,29 @@ func (_m *CloudAPI) IsNodeHealthy(_a0 string) (bool, error) {
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListCertificates provides a mock function with given fields: status
+func (_m *CloudAPI) ListCertificates(status []string) ([]acm.CertificateSummary, error) {
+	ret := _m.Called(status)
+
+	var r0 []acm.CertificateSummary
+	if rf, ok := ret.Get(0).(func([]string) []acm.CertificateSummary); ok {
+		r0 = rf(status)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]acm.CertificateSummary)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = rf(status)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
(I'm picking up a PR from @cv that was lost when the master branch of this project was re-based: https://github.com/kubernetes-sigs/aws-alb-ingress-controller/pull/600)

This change adds a fallback behaviour to the controller's handling of TLS certificates. If the ingress spec has a HTTPS listener but no `alb.ingress.kubernetes.io/certificate-arn` annotation is found, then the controller will attempt to attach certificates from ACM that best match what is required by the listener. Matching is done via the listeners' `spec.rules[].host` entries, as well as any hostnames in `spec.tls.hosts[]`. Wildcard certificates are correctly matched.

e.g.
If I have successfully issued a cert for `*.cv.dev.example.com` and for `website.qifan.example.com`, then the following ingress spec will attach both certs to all listeners of the ALB:
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/target-type: ip
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
    kubernetes.io/ingress.class: alb
  name: echoserver
  namespace: echoserver
spec:
  tls:
  - hosts:
    - echoserver.cv.dev.example.com
  rules:
  - host: website.qifan.dev.example.com
    http:
      paths:
      - backend:
          serviceName: echoserver
          servicePort: 80
        path: /
  ...
```

Potential TODOs:
* When multiple certs are attached to a listener, the correct certificate will be used via SNI. Clients that do not support SNI will use the default cert, which is chosen arbitrarily. The controller should instead try to attach the "best" cert as the default for a particular listener.

* ALBs only support 25 certificate attachments per load balancer (https://aws.amazon.com/blogs/aws/new-application-load-balancer-sni/). There is no specific messaging for users whose ingress specs exceed this limitation.