### PR TITLE
fix issue 838

### DIFF
--- a/internal/alb/sg/association.go
+++ b/internal/alb/sg/association.go
@@ -237,7 +237,7 @@ func (c *associationController) ensureSGInstance(ctx context.Context, groupName 
 
 func (c *associationController) deleteSGInstance(ctx context.Context, instance *ec2.SecurityGroup) error {
 	albctx.GetLogger(ctx).Infof("deleting securityGroup %v:%v", aws.StringValue(instance.GroupName), aws.StringValue(instance.Description))
-	return c.cloud.DeleteSecurityGroupByID(aws.StringValue(instance.GroupId))
+	return c.cloud.DeleteSecurityGroupByID(ctx, aws.StringValue(instance.GroupId))
 }
 
 func (c *associationController) buildAssociationConfig(ctx context.Context, ingress *extensions.Ingress) (associationConfig, error) {

--- a/mocks/CloudAPI.go
+++ b/mocks/CloudAPI.go
@@ -334,13 +334,13 @@ func (_m *CloudAPI) DeleteRuleWithContext(_a0 context.Context, _a1 *elbv2.Delete
 	return r0, r1
 }
 
-// DeleteSecurityGroupByID provides a mock function with given fields: _a0
-func (_m *CloudAPI) DeleteSecurityGroupByID(_a0 string) error {
-	ret := _m.Called(_a0)
+// DeleteSecurityGroupByID provides a mock function with given fields: _a0, _a1
+func (_m *CloudAPI) DeleteSecurityGroupByID(_a0 context.Context, _a1 string) error {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -446,6 +446,29 @@ func (_m *CloudAPI) DescribeLoadBalancerAttributesWithContext(_a0 context.Contex
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *elbv2.DescribeLoadBalancerAttributesInput) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeNetworkInterfaces provides a mock function with given fields: _a0, _a1
+func (_m *CloudAPI) DescribeNetworkInterfaces(_a0 context.Context, _a1 *ec2.DescribeNetworkInterfacesInput) ([]*ec2.NetworkInterface, error) {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 []*ec2.NetworkInterface
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeNetworkInterfacesInput) []*ec2.NetworkInterface); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*ec2.NetworkInterface)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeNetworkInterfacesInput) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)


### PR DESCRIPTION
Fix #838 
Changes done:
1. cap delete securityGroup API call to 2 minutes with 2 sec interval (eventually consistency beyonds 2 minutes will be handled by controller-level backoff). (tests in my env reveals that the instance SG successfully deleted after detached from ENI imediately and the LB sg requires about 2 sec latency).
1. handle cases when ENI is not attached to cluster but have managed SG attached.(caused by CNI bug https://github.com/aws/amazon-vpc-cni-k8s/issues/69)
