### PR TITLE
Add DescribeNetworkInterfaces to sample iam policy

### DIFF
--- a/docs/examples/iam-policy.json
+++ b/docs/examples/iam-policy.json
@@ -23,6 +23,7 @@
         "ec2:DescribeInstances",
         "ec2:DescribeInstanceStatus",
         "ec2:DescribeInternetGateways",
+        "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",


### PR DESCRIPTION
The following commit: https://github.com/kubernetes-sigs/aws-alb-ingress-controller/commit/299a7d3c6db6c960ddb2a44a32be6e9d024df54f#diff-30fbe7ba5c348ca676c72fe41c40953bR203 added a call to `DescribeNetworkInterfaces` as part of the sg/ENI reconciliation process.

Without updating the iam policy, the controller will start throwing up the following error for all ALBs:
```
E0220 22:23:56.140505       1 :0] kubebuilder/controller "msg"="Reconciler error" "error"="failed to reconcile securityGroup associations due to failed to get ENIs attached to sg-00d990d829ca89f49 due to UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: d271d98f-d11a-4b17-92c9-e62d9321d66d"  "controller"="alb-ingress-controller" "request"={"Namespace":"qa","Name":"website"}
```

This change adds the required permission to the sample policy in the documentation.