### PR TITLE
Create loadbalancer.newLBinstance doesn't honour security group annotations

### DIFF
--- a/internal/alb/lb/loadbalancer.go
+++ b/internal/alb/lb/loadbalancer.go
@@ -62,10 +62,11 @@ type loadBalancerConfig struct {
 	Name string
 	Tags map[string]string
 
-	Type          *string
-	Scheme        *string
-	IpAddressType *string
-	Subnets       []string
+	Type           *string
+	Scheme         *string
+	IpAddressType  *string
+	Subnets        []string
+	SecurityGroups []string
 }
 
 type defaultController struct {
@@ -184,12 +185,13 @@ func (controller *defaultController) ensureLBInstance(ctx context.Context, lbCon
 func (controller *defaultController) newLBInstance(ctx context.Context, lbConfig *loadBalancerConfig) (*elbv2.LoadBalancer, error) {
 	albctx.GetLogger(ctx).Infof("creating LoadBalancer %v", lbConfig.Name)
 	resp, err := controller.cloud.CreateLoadBalancerWithContext(ctx, &elbv2.CreateLoadBalancerInput{
-		Name:          aws.String(lbConfig.Name),
-		Type:          lbConfig.Type,
-		Scheme:        lbConfig.Scheme,
-		IpAddressType: lbConfig.IpAddressType,
-		Subnets:       aws.StringSlice(lbConfig.Subnets),
-		Tags:          tags.ConvertToELBV2(lbConfig.Tags),
+		Name:           aws.String(lbConfig.Name),
+		Type:           lbConfig.Type,
+		Scheme:         lbConfig.Scheme,
+		IpAddressType:  lbConfig.IpAddressType,
+		Subnets:        aws.StringSlice(lbConfig.Subnets),
+		Tags:           tags.ConvertToELBV2(lbConfig.Tags),
+		SecurityGroups: aws.StringSlice(lbConfig.SecurityGroups),
 	})
 	if err != nil {
 		albctx.GetLogger(ctx).Errorf("failed to create LoadBalancer %v due to %v", lbConfig.Name, err)

--- a/internal/alb/sg/lb_attachment.go
+++ b/internal/alb/sg/lb_attachment.go
@@ -3,6 +3,7 @@ package sg
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/albctx"
@@ -58,6 +59,9 @@ func (controller *lbAttachmentController) Delete(ctx context.Context, lbInstance
 }
 
 func (controller *lbAttachmentController) getDefaultSecurityGroupID() (string, error) {
+	if len(os.Getenv("VPC_DEFAULT_SG_ID")) > 0 {
+		return os.Getenv("VPC_DEFAULT_SG_ID"), nil
+	}
 	defaultSG, err := controller.cloud.GetSecurityGroupByName("default")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Create loadbalancer.newLBinstance doesn't honour security group annotations, leading to #865 