### PR TITLE
Add template for Cognito integrated ALB ingress

### DIFF
--- a/docs/examples/cognito-ingress-template.yaml
+++ b/docs/examples/cognito-ingress-template.yaml
@@ -1,0 +1,68 @@
+# Requirements:
+#
+#    - For this template, Cognito should have the following basic settings:
+#        - User Pool ARN ( Cognito -> General Settings )
+#            `arn:aws:cognito-idp:<region>:<account-id>:userpool/<region><cognito-id>`
+#        - User Pool Client ID ( Cognito -> App Integration -> Application Client Settings )
+#            `<user-pool-client-id>`
+#        - Domain Name ( Cognito -> App Integration -> Domain Name)
+#            `<user-pool-authentication-domain>`
+#        - OAuth Scopes ( Cognito -> App Integration -> Application Client Settings )
+#            `[x] openid`
+#        - OAuth Flows ( Cognito -> App Integration -> Application Client Settings )
+#            `[x] Authorization code grant`
+#        - Callback URL(s) ( Cognito -> App Integration -> Application Client Settings )
+#            `https://<app-name>.<your-domain>/oauth2/idpresponse`
+#
+#    - Related Kubernetes service/application
+#
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: <ingress-name>  # app.example.com
+  namespace: <placement-namespace>  # default
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/tags: Environment=<environment-name>,Owner=<your-name
+    # For each `listen-ports` object defined an ALB lister is created
+    # For each listener created the rules defined in `spec` apply with some basic caveats
+    # SSL redirect rule is applied only to the HTTP listener.  Cognito authentication rule
+    # is applied to the HTTPS listener
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    # Detailed redirect settings
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    # Authentication type this example is cognito centric.  OIDC also exists and cannot be
+    # used with this example as is
+    alb.ingress.kubernetes.io/auth-type: cognito
+    # Required parameter for ALB/Cognito integration
+    alb.ingress.kubernetes.io/auth-scope: openid
+    # Session timeout on authentication credentials
+    alb.ingress.kubernetes.io/auth-session-timeout: '3600'
+    # Session cookie name
+    alb.ingress.kubernetes.io/auth-session-cookie: AWSELBAuthSessionCookie
+    # Action to take when a request is not authenticated
+    alb.ingress.kubernetes.io/auth-on-unauthenticated-request: authenticate
+    # Cognito parameters required for creation of authentication rules
+    # The subdomain name only is sufficient for `UserPoolDomain`
+    # e.g. if `FQDN=app.auth.ap-northeast-1.amazoncognito.com` then `UserPoolDomain=app`
+    alb.ingress.kubernetes.io/auth-idp-cognito: '{"UserPoolArn": "arn:aws:cognito-idp:<region>:<account-id>:userpool/<region><cognito-id>","UserPoolClientId":"<user-pool-client-id>","UserPoolDomain":"<user-pool-authentication-domain>"}'
+    # ACM certificate ARN for your SSL domain
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:<region>:<account-id>:certificate/<certificate-id>
+spec:
+  rules:
+    # If you are using ExternalDNS, this will become your applications FQDN
+    - host: <FQDN>
+      http:
+        paths:
+          # This first path should perform an ssl-redirect as below
+          - path: /*
+            backend:
+              serviceName: ssl-redirect
+              # Configured via the redirect settings in the annotations
+              servicePort: use-annotation
+          - path: <html_path>
+            backend:
+              serviceName: <サービス名>
+              servicePort: <ポート番号>

--- a/docs/examples/cognito-ingress-template.yaml
+++ b/docs/examples/cognito-ingress-template.yaml
@@ -33,8 +33,7 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     # Detailed redirect settings
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
-    # Authentication type this example is cognito centric.  OIDC also exists and cannot be
-    # used with this example as is
+    # Authentication type must be cognito
     alb.ingress.kubernetes.io/auth-type: cognito
     # Required parameter for ALB/Cognito integration
     alb.ingress.kubernetes.io/auth-scope: openid

--- a/docs/examples/cognito-ingress-template.yaml
+++ b/docs/examples/cognito-ingress-template.yaml
@@ -61,7 +61,7 @@ spec:
               serviceName: ssl-redirect
               # Configured via the redirect settings in the annotations
               servicePort: use-annotation
-          - path: <html_path>
+          - path: <html-path>
             backend:
-              serviceName: <サービス名>
-              servicePort: <ポート番号>
+              serviceName: <service-name>
+              servicePort: <service-port>


### PR DESCRIPTION
## Simplify configuration of Cognito integrated ALB ingress:

### Requirement:
Cognito integration is not well documented in official capacity, and a template would at very least help users configure aws-alb-ingress-controller for a Cognito ALB ingress with considerably less effort.

**This PR:**
- [x] Cognito integrated ALB ingress template
