### PR TITLE
Add support for pod IP targets outside of the VPC

### DIFF
--- a/internal/alb/tg/targets.go
+++ b/internal/alb/tg/targets.go
@@ -64,6 +64,12 @@ func (c *targetsController) Reconcile(ctx context.Context, t *Targets) error {
 	if err != nil {
 		return err
 	}
+	if t.TargetType != elbv2.TargetTypeEnumInstance {
+		err = aws.PopulateTargetAZ(ctx, c.cloud, desired)
+		if err != nil {
+			return err
+		}
+	}
 	current, err := c.getCurrentTargets(ctx, t.TgArn)
 	if err != nil {
 		return err

--- a/internal/alb/tg/targets_test.go
+++ b/internal/alb/tg/targets_test.go
@@ -256,7 +256,7 @@ func Test_TargetsReconcile(t *testing.T) {
 				InputIngress:    dummy.NewIngress(),
 				InputBackend:    backend,
 				InputTargetType: elbv2.TargetTypeEnumIp,
-				Output:          []*elbv2.TargetDescription{newTd("192.168.0.1", 123), newTdWithAZ("192.168.1.1", 1234, "all")},
+				Output:          []*elbv2.TargetDescription{newTd("192.168.0.1", 123), newTd("192.168.1.1", 1234)},
 			},
 		},
 	} {

--- a/internal/alb/tg/targets_test.go
+++ b/internal/alb/tg/targets_test.go
@@ -245,7 +245,11 @@ func Test_TargetsReconcile(t *testing.T) {
 			},
 			GetVpcCall: &GetVpcCall{
 				Output: &ec2.Vpc{
-					CidrBlock: aws.String("192.168.0.0/24"),
+					CidrBlockAssociationSet: []*ec2.VpcCidrBlockAssociation{
+						&ec2.VpcCidrBlockAssociation{
+							CidrBlock: aws.String("192.168.0.0/24"),
+						},
+					},
 				},
 			},
 			ResolveCall: &ResolveCall{

--- a/internal/aws/ec2.go
+++ b/internal/aws/ec2.go
@@ -57,7 +57,7 @@ type EC2API interface {
 	CreateEC2TagsWithContext(context.Context, *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
 	DeleteEC2TagsWithContext(context.Context, *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error)
 
-	// GetVpc returns the VPC for the configured VPC ID
+	// GetVpcWithContext returns the VPC for the configured VPC ID
 	GetVpcWithContext(context.Context) (*ec2.Vpc, error)
 }
 

--- a/internal/aws/ec2.go
+++ b/internal/aws/ec2.go
@@ -56,6 +56,9 @@ type EC2API interface {
 	RevokeSecurityGroupIngressWithContext(context.Context, *ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error)
 	CreateEC2TagsWithContext(context.Context, *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
 	DeleteEC2TagsWithContext(context.Context, *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error)
+
+	// GetVpc returns the VPC for the configured VPC ID
+	GetVpcWithContext(context.Context) (*ec2.Vpc, error)
 }
 
 func (c *Cloud) ModifyNetworkInterfaceAttributeWithContext(ctx context.Context, i *ec2.ModifyNetworkInterfaceAttributeInput) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
@@ -293,4 +296,19 @@ func (c *Cloud) IsNodeHealthy(instanceid string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// GetVpcWithContext returns the VPC for the configured VPC ID
+func (c *Cloud) GetVpcWithContext(ctx context.Context) (*ec2.Vpc, error) {
+	o, err := c.ec2.DescribeVpcsWithContext(ctx, &ec2.DescribeVpcsInput{
+		VpcIds: []*string{aws.String(c.vpcID)},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(o.Vpcs) != 1 {
+		return nil, fmt.Errorf("Invalid amount of VPCs %d returned for %s", len(o.Vpcs), c.vpcID)
+	}
+
+	return o.Vpcs[0], nil
 }

--- a/internal/aws/elbv2.go
+++ b/internal/aws/elbv2.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -321,4 +322,24 @@ func (c *Cloud) describeTargetGroupsHelper(input *elbv2.DescribeTargetGroupsInpu
 		return true
 	})
 	return result, err
+}
+
+// PopulateTargetAZ populates the AvailabilityZone field of the provided TargetDescriptions
+func PopulateTargetAZ(ctx context.Context, c CloudAPI, a []*elbv2.TargetDescription) error {
+	vpc, err := c.GetVpcWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, ipv4Net, err := net.ParseCIDR(*vpc.CidrBlock)
+	if err != nil {
+		return err
+	}
+
+	for i := range a {
+		if !ipv4Net.Contains(net.ParseIP(*a[i].Id)) {
+			a[i].AvailabilityZone = aws.String("all")
+		}
+	}
+	return nil
 }

--- a/internal/aws/elbv2.go
+++ b/internal/aws/elbv2.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"net"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -322,24 +321,4 @@ func (c *Cloud) describeTargetGroupsHelper(input *elbv2.DescribeTargetGroupsInpu
 		return true
 	})
 	return result, err
-}
-
-// PopulateTargetAZ populates the AvailabilityZone field of the provided TargetDescriptions
-func PopulateTargetAZ(ctx context.Context, c CloudAPI, a []*elbv2.TargetDescription) error {
-	vpc, err := c.GetVpcWithContext(ctx)
-	if err != nil {
-		return err
-	}
-
-	_, ipv4Net, err := net.ParseCIDR(*vpc.CidrBlock)
-	if err != nil {
-		return err
-	}
-
-	for i := range a {
-		if !ipv4Net.Contains(net.ParseIP(*a[i].Id)) {
-			a[i].AvailabilityZone = aws.String("all")
-		}
-	}
-	return nil
 }

--- a/mocks/CloudAPI.go
+++ b/mocks/CloudAPI.go
@@ -831,6 +831,29 @@ func (_m *CloudAPI) GetTargetGroupByName(_a0 context.Context, _a1 string) (*elbv
 	return r0, r1
 }
 
+// GetVpcWithContext provides a mock function with given fields: _a0
+func (_m *CloudAPI) GetVpcWithContext(_a0 context.Context) (*ec2.Vpc, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.Vpc
+	if rf, ok := ret.Get(0).(func(context.Context) *ec2.Vpc); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.Vpc)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetWebACLSummary provides a mock function with given fields: ctx, resourceArn
 func (_m *CloudAPI) GetWebACLSummary(ctx context.Context, resourceArn *string) (*waf.WebACLSummary, error) {
 	ret := _m.Called(ctx, resourceArn)


### PR DESCRIPTION
As discussed in #858 this adds support for pod IP targets outside of the ALB's VPC by specifying the target's `AvailabilityZone` of `all`. Originally implemented in #468

closes #783
closes #858

I've tested this on my cluster using `--aws-vpc-id` and it appears to work correctly:
```
I0226 23:05:46.256829       1 api.go:2231] Request: elasticloadbalancing/DescribeTargetHealth, Payload: {  TargetGroupArn: "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/7d116f13-62358f9ba102d9c729f/158773697cb693ed"}
I0226 23:05:46.280342       1 api.go:2231] Response: elasticloadbalancing/DescribeTargetHealth, Body: {}
I0226 23:05:46.280386       1 targets.go:79] test/my-ingress: Adding targets to arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/7d116f13-62358f9ba102d9c729f/158773697cb693ed: 1.2.3.4:80, 1.2.3.5:80
I0226 23:05:46.280719       1 api.go:2830] Request: elasticloadbalancing/RegisterTargets, Payload: {  TargetGroupArn: "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/7d116f13-62358f9ba102d9c729f/158773697cb693ed",  Targets: [{      AvailabilityZone: "all",      Id: "1.2.3.4",      Port: 80    },{      AvailabilityZone: "all",      Id: "1.2.3.5",      Port: 80    }]}
I0226 23:05:46.632281       1 api.go:2830] Response: elasticloadbalancing/RegisterTargets, Body: {}
```