### PR TITLE
remove aws api cache

### DIFF
--- a/internal/aws/cloud.go
+++ b/internal/aws/cloud.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/wafregional"
 	"github.com/aws/aws-sdk-go/service/wafregional/wafregionaliface"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/metric"
-	"github.com/ticketmaster/aws-sdk-go-cache/cache"
 )
 
 type CloudAPI interface {
@@ -47,8 +46,8 @@ type Cloud struct {
 // But due to huge number of aws clients, it's best to have one container AWS client that embed these aws clients.
 // TODO: remove clusterName dependency
 // TODO: remove mc dependency like https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/aws_metrics.go
-func New(cfg CloudConfig, clusterName string, mc metric.Collector, cc *cache.Config) (CloudAPI, error) {
-	awsSession := NewSession(&aws.Config{MaxRetries: aws.Int(cfg.APIMaxRetries)}, cfg.APIDebug, mc, cc)
+func New(cfg CloudConfig, clusterName string, mc metric.Collector) (CloudAPI, error) {
+	awsSession := NewSession(&aws.Config{MaxRetries: aws.Int(cfg.APIMaxRetries)}, cfg.APIDebug, mc)
 	metadata := ec2metadata.New(awsSession)
 
 	if len(cfg.VpcID) == 0 {

--- a/internal/aws/session.go
+++ b/internal/aws/session.go
@@ -10,20 +10,16 @@ import (
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/metric"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/util/log"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/ticketmaster/aws-sdk-go-cache/cache"
 )
 
 // NewSession returns an AWS session based off of the provided AWS config
-func NewSession(awsconfig *aws.Config, AWSDebug bool, mc metric.Collector, cc *cache.Config) *session.Session {
+func NewSession(awsconfig *aws.Config, AWSDebug bool, mc metric.Collector) *session.Session {
 	session, err := session.NewSession(awsconfig)
 	if err != nil {
 		mc.IncAPIErrorCount(prometheus.Labels{"service": "AWS", "request": "NewSession"})
 		glog.ErrorDepth(4, fmt.Sprintf("Failed to create AWS session: %s", err.Error()))
 		return nil
 	}
-
-	// Adds caching to session
-	cache.AddCaching(session, cc)
 
 	session.Handlers.Retry.PushFront(func(r *request.Request) {
 		mc.IncAPIRetryCount(prometheus.Labels{"service": r.ClientInfo.ServiceName, "operation": r.Operation.Name})

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"context"
-	"time"
 
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/aws"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/metric"
@@ -11,7 +10,6 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/ticketmaster/aws-sdk-go-cache/cache"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -56,11 +54,10 @@ func (f *Framework) BeforeEach() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 	if f.Cloud == nil {
-		cc := cache.NewConfig(0 * time.Millisecond)
 		reg := prometheus.NewRegistry()
 		mc, _ := metric.NewCollector(reg, "alb")
 		var err error
-		f.Cloud, err = aws.New(aws.CloudConfig{Region: f.Options.AWSRegion, VpcID: f.Options.AWSVPCID}, f.Options.ClusterName, mc, cc)
+		f.Cloud, err = aws.New(aws.CloudConfig{Region: f.Options.AWSRegion, VpcID: f.Options.AWSVPCID}, f.Options.ClusterName, mc)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 


### PR DESCRIPTION
The purpose of this PR
1.  Remove the cache on aws API calls(the cache hit rate is about 20%). Also the AWS API calls will be even lesser in upcoming releases.
1. The cache have caused memory leaks.
