### PR TITLE
Added configuration page for ALB Ingress Controller with Cognito auth.

### DIFF
--- a/docs/guide/cognito/setup.md
+++ b/docs/guide/cognito/setup.md
@@ -1,0 +1,25 @@
+# Setup Cognito/ALB Ingress Controller
+
+This document describes how to install ALB Ingress Controller with AWS Cognito integration to minimal capacity, other options and or configurations may be required for production, and on an app to app basis.  
+
+## Assumptions
+
+The following assumptions are observed regarding this procedure.
+* ExternalDNS is installed to the cluster and will provide a custom URL for your ALB. To setup ExternalDNS refer to the [install instructions](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/external-dns/setup/).
+
+## Cognitio Configuration
+
+Configure Cognito for use with ALB Ingress Controller using the following links with specified caveats.
+* [Create Cognito user pool](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-as-user-directory.html)
+* [Configure application integration](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-configuring-app-integration.html)
+    * On step 11.c for the `Callback URL` enter `https://<your-domain>/oauth2/idpresponse`.
+    * On step 11.d for `Allowed OAuth Flows` select `authorization code grant` and for `Allowed OAuth Scopes` select `openid`.
+
+## ALB Ingress Controller Setup
+
+Install the ALB Ingress Controller using the [install instructions](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/controller/setup/) with the following caveats.
+* When setting up IAM Role Permissions, add the `cognito-idp:DescribeUserPoolClient` permission to the example policy.
+
+## Deploying an Ingress
+
+Using the [cognito-ingress-template](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/examples/cognito-ingress-template.yaml) you can fill in the `<required>` variables to create an ALB ingress connected to your Cognito user pool for authentication.

--- a/docs/guide/cognito/setup.md
+++ b/docs/guide/cognito/setup.md
@@ -5,11 +5,13 @@ This document describes how to install ALB Ingress Controller with AWS Cognito i
 ## Assumptions
 
 The following assumptions are observed regarding this procedure.
+
 * ExternalDNS is installed to the cluster and will provide a custom URL for your ALB. To setup ExternalDNS refer to the [install instructions](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/external-dns/setup/).
 
 ## Cognitio Configuration
 
 Configure Cognito for use with ALB Ingress Controller using the following links with specified caveats.
+
 * [Create Cognito user pool](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-as-user-directory.html)
 * [Configure application integration](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-configuring-app-integration.html)
     * On step 11.c for the `Callback URL` enter `https://<your-domain>/oauth2/idpresponse`.
@@ -18,6 +20,7 @@ Configure Cognito for use with ALB Ingress Controller using the following links 
 ## ALB Ingress Controller Setup
 
 Install the ALB Ingress Controller using the [install instructions](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/controller/setup/) with the following caveats.
+
 * When setting up IAM Role Permissions, add the `cognito-idp:DescribeUserPoolClient` permission to the example policy.
 
 ## Deploying an Ingress

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,8 @@ nav:
       Setup: 'guide/external-dns/setup.md'
   - Tasks:
       SSL Redirect: 'guide/tasks/ssl_redirect.md'
+  - Cognito:
+      Cognito Integration: 'guide/cognito/setup.md'
   - Walkthrough:
     - Echo server: 'guide/walkthrough/echoserver.md'
 - About:


### PR DESCRIPTION
## Documentation: ALB Ingress Controller/Cognito Authentication

### Requirement:  

Cognito + ALB Integration has been implemented in code #754, and an ingress template has been created #875 but there is no documentation on minimal setup of the infrastructure required.

**This PR:**

- [x] Created documentation describing a minimal setup of infrastructure for ALB Ingress Controller + Cognito integration.