### PR TITLE
Update ingress docs for authentication

### DIFF
--- a/docs/guide/ingress/annotation.md
+++ b/docs/guide/ingress/annotation.md
@@ -216,14 +216,21 @@ ALB supports authentication with Cognito or OIDC. See [Authenticate Users Using 
     
     !!!example
         ```
-        alb.ingress.kubernetes.io/auth-type: openid
+        alb.ingress.kubernetes.io/auth-on-unauthenticated-request: authenticate
         ```
 
 - <a name="auth-scope">`alb.ingress.kubernetes.io/auth-scope`</a> specifies the set of user claims to be requested from the IDP(cognito or oidc).
 
+	!!!info "options:"
+	* **phone**
+	* **email**
+	* **profile**
+	* **openid**
+	* **aws.cognito.signin.user.admin**
+	
     !!!example
         ```
-        alb.ingress.kubernetes.io/auth-type: openid
+        alb.ingress.kubernetes.io/auth-scope: email,openid
         ```
 
 - <a name="auth-session-cookie">`alb.ingress.kubernetes.io/auth-session-cookie`</a> specifies the name of the cookie used to maintain session information


### PR DESCRIPTION
In the authentication section of the ingress annotations there were two entries that did not reflect the annotation they document.
For `auth-on-unauthenticated-request` the example was showing values for `auth-type`, and `for auth-scope` options were missing and example was also for auth-type.

