### PR TITLE
Scopes must be space-separated list

### DIFF
--- a/docs/guide/ingress/annotation.md
+++ b/docs/guide/ingress/annotation.md
@@ -219,7 +219,7 @@ ALB supports authentication with Cognito or OIDC. See [Authenticate Users Using 
         alb.ingress.kubernetes.io/auth-on-unauthenticated-request: authenticate
         ```
 
-- <a name="auth-scope">`alb.ingress.kubernetes.io/auth-scope`</a> specifies the set of user claims to be requested from the IDP(cognito or oidc).
+- <a name="auth-scope">`alb.ingress.kubernetes.io/auth-scope`</a> specifies the set of user claims to be requested from the IDP(cognito or oidc), in a space-separated list.
 
 	!!!info "options:"
 	* **phone**
@@ -230,7 +230,7 @@ ALB supports authentication with Cognito or OIDC. See [Authenticate Users Using 
 	
     !!!example
         ```
-        alb.ingress.kubernetes.io/auth-scope: email,openid
+        alb.ingress.kubernetes.io/auth-scope: 'email openid'
         ```
 
 - <a name="auth-session-cookie">`alb.ingress.kubernetes.io/auth-session-cookie`</a> specifies the name of the cookie used to maintain session information


### PR DESCRIPTION
If you try to use commas as indicated in the documentation, you get an error similar to the following:

```
kubebuilder/controller "msg"="Reconciler error" "error"="failed to reconcile listeners due to failed to reconcile listener due to InvalidLoadBalancerAction: A scope cannot contain a comma. Separate multiple scopes using spaces\n\tstatus code: 400, request id: faaec23d-4bed-11e9-a3d9-25197b2b13db"
```