### PR TITLE
Fix UT failure due to coverall

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/imdario/mergo v0.3.7
 	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/magiconair/properties v1.8.0
+	github.com/mattn/goveralls v0.0.3-0.20190325144123-900af2b6e486 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
+github.com/mattn/goveralls v0.0.3-0.20190325144123-900af2b6e486 h1:Wm8cZ6zwoV7jgpZl3YUSw+3Nx9BIaIQAVBCdvSZuweM=
+github.com/mattn/goveralls v0.0.3-0.20190325144123-900af2b6e486/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=

--- a/scripts/ci_unit_test.sh
+++ b/scripts/ci_unit_test.sh
@@ -4,8 +4,9 @@ set -e
 COVER_PROFILE=profile.cov
 
 report_coverage() {
-    go get github.com/mattn/goveralls
-    CIRCLE_BUILD_NUM=${BUILD_ID}  CIRCLE_PR_NUMBER=${PULL_NUMBER} $(go env GOBIN)/goveralls \
+    go install -v github.com/mattn/goveralls
+    # need to override prow's BUILD_NUMBER to "" so it won't be reported as jobID to avoid 5xx error :D
+    BUILD_NUMBER="" PULL_REQUEST_NUMBER=${PULL_NUMBER} $GOBIN/goveralls \
            -coverprofile=$COVER_PROFILE \
            -service=prow \
            -repotoken $(cat /etc/coveralls-token/k8s-aws-alb-ingress-coveralls-token) \


### PR DESCRIPTION
Fix UT failure due to coverall by 
1. upgrade coveralls to the newest version to report serviceName without serviceJobID.
1. avoid an hidden prow environment variable BUILD_NUMBER be reported as serviceJobID(will cause 500x)