### PR TITLE
Fix panic when deleting an ALB with no default SG in the VPC

### DIFF
--- a/internal/alb/sg/lb_attachment.go
+++ b/internal/alb/sg/lb_attachment.go
@@ -2,6 +2,7 @@ package sg
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
@@ -61,6 +62,9 @@ func (controller *lbAttachmentController) getDefaultSecurityGroupID() (string, e
 	defaultSG, err := controller.cloud.GetSecurityGroupByName("default")
 	if err != nil {
 		return "", err
+	}
+	if defaultSG == nil {
+		return "", errors.New("default security group not found")
 	}
 	return aws.StringValue(defaultSG.GroupId), nil
 }

--- a/internal/alb/sg/lb_attachment_test.go
+++ b/internal/alb/sg/lb_attachment_test.go
@@ -143,6 +143,18 @@ func Test_LBAttachmentDelete(t *testing.T) {
 			ExpectedError: errors.New("failed to get default securityGroup for current vpc due to GetSecurityGroupByNameCall"),
 		},
 		{
+			Name: "delete failed when no default securityGroup",
+			Instance: elbv2.LoadBalancer{
+				LoadBalancerArn: aws.String("arn"),
+				SecurityGroups:  []*string{aws.String("sg-abcd")},
+			},
+			GetSecurityGroupByNameCall: &GetSecurityGroupByNameCall{
+				GroupName: "default",
+				Instance:  nil,
+			},
+			ExpectedError: errors.New("failed to get default securityGroup for current vpc due to default security group not found"),
+		},
+		{
 			Name: "delete failed when modify SG to default one",
 			Instance: elbv2.LoadBalancer{
 				LoadBalancerArn: aws.String("arn"),


### PR DESCRIPTION
Subnets that are shared across accounts using AWS Resource Access Manager do not have a `default` security group, causing `GetSecurityGroupByName` to return `nil`:

https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/866f0e2cbb348a83a73d6be998c92c1c2b411a99/internal/aws/ec2.go#L216-L218

which causes this panic:

```
E0416 17:17:07.880683       1 runtime.go:69] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
/path/to/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:76
/path/to/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:65
/path/to/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:51
/usr/local/Cellar/go/1.12.1/libexec/src/runtime/panic.go:522
/usr/local/Cellar/go/1.12.1/libexec/src/runtime/panic.go:82
/usr/local/Cellar/go/1.12.1/libexec/src/runtime/signal_unix.go:390
/path/to/aws-alb-ingress-controller/internal/alb/sg/lb_attachment.go:65
/path/to/aws-alb-ingress-controller/internal/alb/sg/lb_attachment.go:42
/path/to/aws-alb-ingress-controller/internal/alb/sg/association.go:87
/path/to/aws-alb-ingress-controller/internal/alb/lb/loadbalancer.go:141
...
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x15feac4]

goroutine 216 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/path/to/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:58 +0x105
panic(0x1879580, 0x2e1aca0)
	/usr/local/Cellar/go/1.12.1/libexec/src/runtime/panic.go:522 +0x1b5
github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/alb/sg.(*lbAttachmentController).getDefaultSecurityGroupID(0xc000447f20, 0x0, 0xc000c1de40, 0x0, 0x0)
	/path/to/aws-alb-ingress-controller/internal/alb/sg/lb_attachment.go:65 +0x64
github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/alb/sg.(*lbAttachmentController).Delete(0xc000447f20, 0x1def8c0, 0xc00091dc20, 0xc00080a780, 0xb, 0xc000b127e0)
	/path/to/aws-alb-ingress-controller/internal/alb/sg/lb_attachment.go:42 +0x43
github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/alb/sg.(*associationController).Delete(0xc00007f140, 0x1def8c0, 0xc00091dc20, 0xc00109b1c0, 0xb, 0xc000b127e0, 0x1b, 0xc00080a780, 0x161a043, 0x1def840)
	/path/to/aws-alb-ingress-controller/internal/alb/sg/association.go:87 +0x1b2
...
```

https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/866f0e2cbb348a83a73d6be998c92c1c2b411a99/internal/alb/sg/lb_attachment.go#L60-L66

The new test also causes a panic when the fix is not in place. The ALB deletion will still fail but at least we avoid a panic. Since ALBs require at least one security group, i'm not sure if theres a good fix in place that would allow the ALB to get deleted without significant refactoring. Ideally it could delete the ALB and then any managed security groups once they are unused.

In fact, you can't even create a `default` security group in the shared VPC which would allow the aws-alb-ingress-controller to delete ALBs:
```
aws ec2 --region us-east-1 create-security-group --vpc-id vpc-12345 --group-name default --description "default group"

An error occurred (InvalidParameterValue) when calling the CreateSecurityGroup operation: Cannot use reserved security group name: default
``` 