### PR TITLE
Add healthcheck-enabled annotation and make the default `false`

### DIFF
--- a/docs/guide/ingress/annotation.md
+++ b/docs/guide/ingress/annotation.md
@@ -24,6 +24,7 @@ You can add kubernetes annotations to ingress and service objects to customize t
 |[alb.ingress.kubernetes.io/auth-type](#auth-type)|none\|oidc\|cognito|none|ingress,service|
 |[alb.ingress.kubernetes.io/backend-protocol](#backend-protocol)|HTTP \| HTTPS|HTTP|ingress,service|
 |[alb.ingress.kubernetes.io/certificate-arn](#certificate-arn)|stringList|N/A|ingress|
+|[alb.ingress.kubernetes.io/healthcheck-enabled](#healthcheck-enabled)|bool|false|ingress,service|
 |[alb.ingress.kubernetes.io/healthcheck-interval-seconds](#healthcheck-interval-seconds)|integer|'15'|ingress,service|
 |[alb.ingress.kubernetes.io/healthcheck-path](#healthcheck-path)|string|/|ingress,service|
 |[alb.ingress.kubernetes.io/healthcheck-port](#healthcheck-port)|integer \| traffic-port|traffic-port|ingress,service|
@@ -249,6 +250,13 @@ ALB supports authentication with Cognito or OIDC. See [Authenticate Users Using 
 
 ## Health Check
 Health check on target groups can be controlled with following annotations:
+
+- <a name="healthcheck-enabled">`alb.ingress.kubernetes.io/healthcheck-enabled`</a> specifies whether health check should be performed on targets.
+
+    !!!example
+        ```
+        alb.ingress.kubernetes.io/healthcheck-enabled: 'false'
+        ```
 
 - <a name="healthcheck-protocol">`alb.ingress.kubernetes.io/healthcheck-protocol`</a> specifies the protocol used when performing health check on targets.
 

--- a/internal/alb/tg/targetgroup_test.go
+++ b/internal/alb/tg/targetgroup_test.go
@@ -141,6 +141,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				IngressAnnos: &annotations.Ingress{Tags: &annoTags.Config{}},
 				ServiceAnnos: &annotations.Service{
 					HealthCheck: &healthcheck.Config{
+						Enabled:         aws.Bool(true),
 						Path:            aws.String("/ping"),
 						Port:            aws.String("8080"),
 						Protocol:        aws.String("HTTP"),
@@ -188,6 +189,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 			CreateTargetGroupCall: &CreateTargetGroupCall{
 				Input: &elbv2.CreateTargetGroupInput{
 					Name:                       aws.String("k8s-tgName"),
+					HealthCheckEnabled:         aws.Bool(true),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8080"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -202,6 +204,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				},
 				Instance: &elbv2.TargetGroup{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(true),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8080"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -278,6 +281,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				IngressAnnos: &annotations.Ingress{Tags: &annoTags.Config{}},
 				ServiceAnnos: &annotations.Service{
 					HealthCheck: &healthcheck.Config{
+						Enabled:         aws.Bool(false),
 						Path:            aws.String("/ping"),
 						Port:            aws.String("foo"),
 						Protocol:        aws.String("HTTP"),
@@ -325,6 +329,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 			CreateTargetGroupCall: &CreateTargetGroupCall{
 				Input: &elbv2.CreateTargetGroupInput{
 					Name:                       aws.String("k8s-tgName"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("9090"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -339,6 +344,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				},
 				Instance: &elbv2.TargetGroup{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8080"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -416,6 +422,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				IngressAnnos: &annotations.Ingress{Tags: &annoTags.Config{}},
 				ServiceAnnos: &annotations.Service{
 					HealthCheck: &healthcheck.Config{
+						Enabled:         aws.Bool(false),
 						Path:            aws.String("/ping"),
 						Port:            aws.String("foo"),
 						Protocol:        aws.String("HTTP"),
@@ -463,6 +470,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 			CreateTargetGroupCall: &CreateTargetGroupCall{
 				Input: &elbv2.CreateTargetGroupInput{
 					Name:                       aws.String("k8s-tgName"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("9091"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -477,6 +485,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				},
 				Instance: &elbv2.TargetGroup{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8080"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -540,6 +549,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				IngressAnnos: &annotations.Ingress{Tags: &annoTags.Config{}},
 				ServiceAnnos: &annotations.Service{
 					HealthCheck: &healthcheck.Config{
+						Enabled:         aws.Bool(false),
 						Path:            aws.String("/ping"),
 						Port:            aws.String("8080"),
 						Protocol:        aws.String("HTTP"),
@@ -584,6 +594,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				TGName: "k8s-tgName",
 				Instance: &elbv2.TargetGroup{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8080"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -647,6 +658,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				IngressAnnos: &annotations.Ingress{Tags: &annoTags.Config{}},
 				ServiceAnnos: &annotations.Service{
 					HealthCheck: &healthcheck.Config{
+						Enabled:         aws.Bool(false),
 						Path:            aws.String("/ping"),
 						Port:            aws.String("8080"),
 						Protocol:        aws.String("HTTP"),
@@ -691,6 +703,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				TGName: "k8s-tgName",
 				Instance: &elbv2.TargetGroup{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/pong"),
 					HealthCheckPort:            aws.String("8088"),
 					HealthCheckProtocol:        aws.String("HTTPS"),
@@ -706,6 +719,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 			ModifyTargetGroupCall: &ModifyTargetGroupCall{
 				Input: &elbv2.ModifyTargetGroupInput{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8080"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -717,6 +731,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				},
 				Instance: &elbv2.TargetGroup{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8088"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -780,6 +795,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				IngressAnnos: &annotations.Ingress{Tags: &annoTags.Config{}},
 				ServiceAnnos: &annotations.Service{
 					HealthCheck: &healthcheck.Config{
+						Enabled:         aws.Bool(false),
 						Path:            aws.String("/ping"),
 						Port:            aws.String("8080"),
 						Protocol:        aws.String("HTTP"),
@@ -829,6 +845,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				IngressAnnos: &annotations.Ingress{Tags: &annoTags.Config{}},
 				ServiceAnnos: &annotations.Service{
 					HealthCheck: &healthcheck.Config{
+						Enabled:         aws.Bool(false),
 						Path:            aws.String("/ping"),
 						Port:            aws.String("8080"),
 						Protocol:        aws.String("HTTP"),
@@ -866,6 +883,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 			CreateTargetGroupCall: &CreateTargetGroupCall{
 				Input: &elbv2.CreateTargetGroupInput{
 					Name:                       aws.String("k8s-tgName"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8080"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -895,6 +913,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				IngressAnnos: &annotations.Ingress{Tags: &annoTags.Config{}},
 				ServiceAnnos: &annotations.Service{
 					HealthCheck: &healthcheck.Config{
+						Enabled:         aws.Bool(false),
 						Path:            aws.String("/ping"),
 						Port:            aws.String("8080"),
 						Protocol:        aws.String("HTTP"),
@@ -929,6 +948,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				TGName: "k8s-tgName",
 				Instance: &elbv2.TargetGroup{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/pong"),
 					HealthCheckPort:            aws.String("8088"),
 					HealthCheckProtocol:        aws.String("HTTPS"),
@@ -944,6 +964,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 			ModifyTargetGroupCall: &ModifyTargetGroupCall{
 				Input: &elbv2.ModifyTargetGroupInput{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8080"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -970,6 +991,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				IngressAnnos: &annotations.Ingress{Tags: &annoTags.Config{}},
 				ServiceAnnos: &annotations.Service{
 					HealthCheck: &healthcheck.Config{
+						Enabled:         aws.Bool(false),
 						Path:            aws.String("/ping"),
 						Port:            aws.String("8080"),
 						Protocol:        aws.String("HTTP"),
@@ -1014,6 +1036,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				TGName: "k8s-tgName",
 				Instance: &elbv2.TargetGroup{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8080"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -1046,6 +1069,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				IngressAnnos: &annotations.Ingress{Tags: &annoTags.Config{}},
 				ServiceAnnos: &annotations.Service{
 					HealthCheck: &healthcheck.Config{
+						Enabled:         aws.Bool(false),
 						Path:            aws.String("/ping"),
 						Port:            aws.String("8080"),
 						Protocol:        aws.String("HTTP"),
@@ -1090,6 +1114,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				TGName: "k8s-tgName",
 				Instance: &elbv2.TargetGroup{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8080"),
 					HealthCheckProtocol:        aws.String("HTTP"),
@@ -1131,6 +1156,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				IngressAnnos: &annotations.Ingress{Tags: &annoTags.Config{}},
 				ServiceAnnos: &annotations.Service{
 					HealthCheck: &healthcheck.Config{
+						Enabled:         aws.Bool(false),
 						Path:            aws.String("/ping"),
 						Port:            aws.String("8080"),
 						Protocol:        aws.String("HTTP"),
@@ -1175,6 +1201,7 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				TGName: "k8s-tgName",
 				Instance: &elbv2.TargetGroup{
 					TargetGroupArn:             aws.String("MyTargetGroupArn"),
+					HealthCheckEnabled:         aws.Bool(false),
 					HealthCheckPath:            aws.String("/ping"),
 					HealthCheckPort:            aws.String("8080"),
 					HealthCheckProtocol:        aws.String("HTTP"),

--- a/internal/ingress/annotations/healthcheck/main_test.go
+++ b/internal/ingress/annotations/healthcheck/main_test.go
@@ -75,6 +75,7 @@ func TestIngressHealthCheck(t *testing.T) {
 
 	data := map[string]string{}
 	data[parser.GetAnnotationWithPrefix("healthcheck-interval-seconds")] = "15"
+	data[parser.GetAnnotationWithPrefix("healthcheck-enabled")] = "true"
 	ing.SetAnnotations(data)
 
 	hzi, _ := NewParser(mockBackend{}).Parse(ing)
@@ -83,12 +84,16 @@ func TestIngressHealthCheck(t *testing.T) {
 		t.Errorf("expected a Upstream type")
 	}
 
+	if *hz.Enabled != true {
+		t.Errorf("expected healthcheck-enabled to be true but returned %v", hz.Enabled)
+	}
+
 	if *hz.IntervalSeconds != 15 {
-		t.Errorf("expected 2 as healthcheck-interval-seconds but returned %v", *hz.IntervalSeconds)
+		t.Errorf("expected 15 as healthcheck-interval-seconds but returned %v", *hz.IntervalSeconds)
 	}
 
 	if *hz.Path != "/" {
-		t.Errorf("expected 0 as healthcheck-path but returned %v", hz.Path)
+		t.Errorf("expected / as healthcheck-path but returned %v", hz.Path)
 	}
 }
 


### PR DESCRIPTION
This adds support for the [`HealthCheckEnabled` setting of a target group](https://docs.aws.amazon.com/sdk-for-go/api/service/elbv2/#CreateTargetGroupInput).

I would suggest to set this flag to `false` by default as I would assume that usually you would configure a `readinessProbe` in the pod, then the ALB health check would be redundant. I'm aware that this would be a breaking change for some users and should be clearly noted in the release notes.

If the maintainers have a different opinion on this, I'll change the default it in the pull request of course.