### PR TITLE
fix broken link for cognito-ingress-template

### DIFF
--- a/docs/guide/cognito/setup.md
+++ b/docs/guide/cognito/setup.md
@@ -25,4 +25,4 @@ Install the ALB Ingress Controller using the [install instructions](https://kube
 
 ## Deploying an Ingress
 
-Using the [cognito-ingress-template](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/examples/cognito-ingress-template.yaml) you can fill in the `<required>` variables to create an ALB ingress connected to your Cognito user pool for authentication.
+Using the [cognito-ingress-template](https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/examples/cognito-ingress-template.yaml) you can fill in the `<required>` variables to create an ALB ingress connected to your Cognito user pool for authentication.

--- a/docs/guide/cognito/setup.md
+++ b/docs/guide/cognito/setup.md
@@ -6,7 +6,7 @@ This document describes how to install ALB Ingress Controller with AWS Cognito i
 
 The following assumptions are observed regarding this procedure.
 
-* ExternalDNS is installed to the cluster and will provide a custom URL for your ALB. To setup ExternalDNS refer to the [install instructions](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/external-dns/setup/).
+* ExternalDNS is installed to the cluster and will provide a custom URL for your ALB. To setup ExternalDNS refer to the [install instructions](../external-dns/setup.md).
 
 ## Cognitio Configuration
 
@@ -19,10 +19,10 @@ Configure Cognito for use with ALB Ingress Controller using the following links 
 
 ## ALB Ingress Controller Setup
 
-Install the ALB Ingress Controller using the [install instructions](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/controller/setup/) with the following caveats.
+Install the ALB Ingress Controller using the [install instructions](../controller/setup.md) with the following caveats.
 
 * When setting up IAM Role Permissions, add the `cognito-idp:DescribeUserPoolClient` permission to the example policy.
 
 ## Deploying an Ingress
 
-Using the [cognito-ingress-template](https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/examples/cognito-ingress-template.yaml) you can fill in the `<required>` variables to create an ALB ingress connected to your Cognito user pool for authentication.
+Using the [cognito-ingress-template](../../examples/cognito-ingress-template.yaml) you can fill in the `<required>` variables to create an ALB ingress connected to your Cognito user pool for authentication.


### PR DESCRIPTION
aws-alb-ingress-controller/docs/guide/cognito/setup.md

https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/guide/cognito/setup.md#deploying-an-ingress

the cognito-ingress-template its not there!