### PR TITLE
Optional host rule

### DIFF
--- a/docs/guide/ingress/annotation.md
+++ b/docs/guide/ingress/annotation.md
@@ -24,6 +24,7 @@ You can add kubernetes annotations to ingress and service objects to customize t
 |[alb.ingress.kubernetes.io/auth-type](#auth-type)|none\|oidc\|cognito|none|ingress,service|
 |[alb.ingress.kubernetes.io/backend-protocol](#backend-protocol)|HTTP \| HTTPS|HTTP|ingress,service|
 |[alb.ingress.kubernetes.io/certificate-arn](#certificate-arn)|stringList|N/A|ingress|
+|[alb.ingress.kubernetes.io/host-checking](#host-checking)|string|true|
 |[alb.ingress.kubernetes.io/healthcheck-interval-seconds](#healthcheck-interval-seconds)|integer|'15'|ingress,service|
 |[alb.ingress.kubernetes.io/healthcheck-path](#healthcheck-path)|string|/|ingress,service|
 |[alb.ingress.kubernetes.io/healthcheck-port](#healthcheck-port)|integer \| traffic-port|traffic-port|ingress,service|

--- a/internal/alb/ls/rules.go
+++ b/internal/alb/ls/rules.go
@@ -135,7 +135,7 @@ func (c *rulesController) getDesiredRules(ctx context.Context, listener *elbv2.L
 			if err != nil {
 				return nil, err
 			}
-			elbConditions := buildConditions(ctx, ingressRule, path)
+			elbConditions := buildConditions(ctx, ingressRule, path, ingressAnnos)
 			elbRule := elbv2.Rule{
 				IsDefault:  aws.Bool(false),
 				Priority:   aws.String(strconv.Itoa(nextPriority)),
@@ -209,9 +209,10 @@ func buildActions(ctx context.Context, authCfg auth.Config, ingressAnnos *annota
 }
 
 // buildConditions will build listener rule conditions for specific ingressRule
-func buildConditions(ctx context.Context, rule extensions.IngressRule, path extensions.HTTPIngressPath) []*elbv2.RuleCondition {
+func buildConditions(ctx context.Context, rule extensions.IngressRule, path extensions.HTTPIngressPath, ingressAnnos *annotations.Ingress) []*elbv2.RuleCondition {
 	var conditions []*elbv2.RuleCondition
-	if rule.Host != "" {
+
+	if rule.Host != "" && *ingressAnnos.TargetGroup.HostChecking == true {
 		conditions = append(conditions, condition("host-header", rule.Host))
 	}
 	if path.Path != "" {

--- a/internal/ingress/annotations/targetgroup/main.go
+++ b/internal/ingress/annotations/targetgroup/main.go
@@ -36,6 +36,7 @@ type Config struct {
 	SuccessCodes            *string
 	TargetType              *string
 	UnhealthyThresholdCount *int64
+	HostChecking            *bool
 }
 
 type targetGroup struct {
@@ -47,6 +48,7 @@ const (
 	DefaultHealthyThresholdCount   = 2
 	DefaultUnhealthyThresholdCount = 2
 	DefaultSuccessCodes            = "200"
+	DefaultHostChecking            = true
 )
 
 // NewParser creates a new target group annotation parser
@@ -93,6 +95,11 @@ func (tg targetGroup) Parse(ing parser.AnnotationInterface) (interface{}, error)
 		successCodes = s
 	}
 
+	hostchecking, err := parser.GetBoolAnnotation("host-checking", ing)
+	if err != nil {
+		hostchecking = aws.Bool(DefaultHostChecking)
+	}
+
 	attributes, err := parseAttributes(ing)
 	if err != nil {
 		return nil, err
@@ -105,6 +112,7 @@ func (tg targetGroup) Parse(ing parser.AnnotationInterface) (interface{}, error)
 		UnhealthyThresholdCount: unhealthyThresholdCount,
 		SuccessCodes:            successCodes,
 		Attributes:              attributes,
+		HostChecking:            hostchecking,
 	}, nil
 }
 
@@ -122,6 +130,7 @@ func (a *Config) Merge(b *Config, cfg *config.Configuration) *Config {
 		SuccessCodes:            parser.MergeString(a.SuccessCodes, b.SuccessCodes, DefaultSuccessCodes),
 		HealthyThresholdCount:   parser.MergeInt64(a.HealthyThresholdCount, b.HealthyThresholdCount, DefaultHealthyThresholdCount),
 		UnhealthyThresholdCount: parser.MergeInt64(a.UnhealthyThresholdCount, b.UnhealthyThresholdCount, DefaultUnhealthyThresholdCount),
+		HostChecking:            parser.MergeBool(a.HostChecking, b.HostChecking, DefaultHostChecking),
 	}
 }
 
@@ -158,5 +167,6 @@ func Dummy() *Config {
 		SuccessCodes:            aws.String("200"),
 		TargetType:              aws.String(elbv2.TargetTypeEnumInstance),
 		UnhealthyThresholdCount: aws.Int64(2),
+		HostChecking:            aws.Bool(true),
 	}
 }


### PR DESCRIPTION
We have a scenario where we do not want to use the host checking rule, but this is on by default when using a hostname in ingress.  This PR allows for disabling of the host validation rule.