### PR TITLE
AuthenticationRequestExtraParams for authentication action

### DIFF
--- a/internal/alb/ls/rules.go
+++ b/internal/alb/ls/rules.go
@@ -223,7 +223,7 @@ func buildConditions(ctx context.Context, rule extensions.IngressRule, path exte
 }
 
 // buildAuthAction builds ELB action for specific authCfg.
-// null will be returned if no auth if required.
+// null will be returned if no auth is required.
 func buildAuthAction(ctx context.Context, authCfg auth.Config) *elbv2.Action {
 	switch authCfg.Type {
 	case auth.TypeCognito:
@@ -231,9 +231,10 @@ func buildAuthAction(ctx context.Context, authCfg auth.Config) *elbv2.Action {
 			return &elbv2.Action{
 				Type: aws.String(elbv2.ActionTypeEnumAuthenticateCognito),
 				AuthenticateCognitoConfig: &elbv2.AuthenticateCognitoActionConfig{
-					UserPoolArn:      aws.String(authCfg.IDPCognito.UserPoolArn),
-					UserPoolClientId: aws.String(authCfg.IDPCognito.UserPoolClientId),
-					UserPoolDomain:   aws.String(authCfg.IDPCognito.UserPoolDomain),
+					AuthenticationRequestExtraParams: aws.StringMap(authCfg.IDPCognito.AuthenticationRequestExtraParams),
+					UserPoolArn:                      aws.String(authCfg.IDPCognito.UserPoolArn),
+					UserPoolClientId:                 aws.String(authCfg.IDPCognito.UserPoolClientId),
+					UserPoolDomain:                   aws.String(authCfg.IDPCognito.UserPoolDomain),
 
 					OnUnauthenticatedRequest: aws.String(string(authCfg.OnUnauthenticatedRequest)),
 					Scope:                    aws.String(authCfg.Scope),
@@ -247,12 +248,13 @@ func buildAuthAction(ctx context.Context, authCfg auth.Config) *elbv2.Action {
 			return &elbv2.Action{
 				Type: aws.String(elbv2.ActionTypeEnumAuthenticateOidc),
 				AuthenticateOidcConfig: &elbv2.AuthenticateOidcActionConfig{
-					Issuer:                aws.String(authCfg.IDPOIDC.Issuer),
-					AuthorizationEndpoint: aws.String(authCfg.IDPOIDC.AuthorizationEndpoint),
-					TokenEndpoint:         aws.String(authCfg.IDPOIDC.TokenEndpoint),
-					UserInfoEndpoint:      aws.String(authCfg.IDPOIDC.UserInfoEndpoint),
-					ClientId:              aws.String(authCfg.IDPOIDC.ClientId),
-					ClientSecret:          aws.String(authCfg.IDPOIDC.ClientSecret),
+					AuthenticationRequestExtraParams: aws.StringMap(authCfg.IDPOIDC.AuthenticationRequestExtraParams),
+					AuthorizationEndpoint:            aws.String(authCfg.IDPOIDC.AuthorizationEndpoint),
+					ClientId:                         aws.String(authCfg.IDPOIDC.ClientId),
+					ClientSecret:                     aws.String(authCfg.IDPOIDC.ClientSecret),
+					Issuer:                           aws.String(authCfg.IDPOIDC.Issuer),
+					TokenEndpoint:                    aws.String(authCfg.IDPOIDC.TokenEndpoint),
+					UserInfoEndpoint:                 aws.String(authCfg.IDPOIDC.UserInfoEndpoint),
 
 					OnUnauthenticatedRequest: aws.String(string(authCfg.OnUnauthenticatedRequest)),
 					Scope:                    aws.String(authCfg.Scope),

--- a/internal/alb/ls/rules_test.go
+++ b/internal/alb/ls/rules_test.go
@@ -363,6 +363,10 @@ func Test_getDesiredRules(t *testing.T) {
 					authCfg: auth.Config{
 						Type: auth.TypeOIDC,
 						IDPOIDC: auth.IDPOIDC{
+							AuthenticationRequestExtraParams: auth.AuthenticationRequestExtraParams{
+								"param1": "value1",
+								"param2": "value2",
+							},
 							Issuer:                "Issuer",
 							AuthorizationEndpoint: "AuthorizationEndpoint",
 							TokenEndpoint:         "TokenEndpoint",
@@ -384,6 +388,10 @@ func Test_getDesiredRules(t *testing.T) {
 					authCfg: auth.Config{
 						Type: auth.TypeCognito,
 						IDPCognito: auth.IDPCognito{
+							AuthenticationRequestExtraParams: auth.AuthenticationRequestExtraParams{
+								"param1": "value1",
+								"param2": "value2",
+							},
 							UserPoolArn:      "UserPoolArn",
 							UserPoolClientId: "UserPoolClientId",
 							UserPoolDomain:   "UserPoolDomain",
@@ -405,6 +413,10 @@ func Test_getDesiredRules(t *testing.T) {
 							Order: aws.Int64(1),
 							Type:  aws.String("authenticate-oidc"),
 							AuthenticateOidcConfig: &elbv2.AuthenticateOidcActionConfig{
+								AuthenticationRequestExtraParams: aws.StringMap(auth.AuthenticationRequestExtraParams{
+									"param1": "value1",
+									"param2": "value2",
+								}),
 								Issuer:                   aws.String("Issuer"),
 								AuthorizationEndpoint:    aws.String("AuthorizationEndpoint"),
 								TokenEndpoint:            aws.String("TokenEndpoint"),
@@ -433,6 +445,10 @@ func Test_getDesiredRules(t *testing.T) {
 							Order: aws.Int64(1),
 							Type:  aws.String("authenticate-cognito"),
 							AuthenticateCognitoConfig: &elbv2.AuthenticateCognitoActionConfig{
+								AuthenticationRequestExtraParams: aws.StringMap(auth.AuthenticationRequestExtraParams{
+									"param1": "value1",
+									"param2": "value2",
+								}),
 								UserPoolArn:              aws.String("UserPoolArn"),
 								UserPoolClientId:         aws.String("UserPoolClientId"),
 								UserPoolDomain:           aws.String("UserPoolDomain"),

--- a/internal/ingress/auth/auth.go
+++ b/internal/ingress/auth/auth.go
@@ -166,12 +166,13 @@ func (m *defaultModule) loadIDPOIDC(ctx context.Context, idpOIDC *IDPOIDC, names
 	clientId := string(k8sSecret.Data["clientId"])
 	clientSecret := string(k8sSecret.Data["clientSecret"])
 	*idpOIDC = IDPOIDC{
-		Issuer:                annoIDPOIDC.Issuer,
-		AuthorizationEndpoint: annoIDPOIDC.AuthorizationEndpoint,
-		TokenEndpoint:         annoIDPOIDC.TokenEndpoint,
-		UserInfoEndpoint:      annoIDPOIDC.UserInfoEndpoint,
-		ClientId:              clientId,
-		ClientSecret:          clientSecret,
+		AuthenticationRequestExtraParams: annoIDPOIDC.AuthenticationRequestExtraParams,
+		AuthorizationEndpoint:            annoIDPOIDC.AuthorizationEndpoint,
+		Issuer:                           annoIDPOIDC.Issuer,
+		TokenEndpoint:                    annoIDPOIDC.TokenEndpoint,
+		UserInfoEndpoint:                 annoIDPOIDC.UserInfoEndpoint,
+		ClientId:                         clientId,
+		ClientSecret:                     clientSecret,
 	}
 	return true, nil
 }

--- a/internal/ingress/auth/auth_test.go
+++ b/internal/ingress/auth/auth_test.go
@@ -86,7 +86,7 @@ func TestDefaultModule_NewConfig(t *testing.T) {
 					Name:      "ingress",
 					Annotations: map[string]string{
 						parser.GetAnnotationWithPrefix(AnnotationAuthType):       "cognito",
-						parser.GetAnnotationWithPrefix(AnnotationAuthIDPCognito): "{\"UserPoolArn\": \"UserPoolArn\",\"UserPoolClientId\": \"UserPoolClientId\",\"UserPoolDomain\": \"UserPoolDomain\"}",
+						parser.GetAnnotationWithPrefix(AnnotationAuthIDPCognito): "{\"UserPoolArn\": \"UserPoolArn\",\"UserPoolClientId\": \"UserPoolClientId\",\"UserPoolDomain\": \"UserPoolDomain\",\"AuthenticationRequestExtraParams\": { \"param1\": \"value1\",\"param2\": \"value2\"}}",
 					},
 				},
 			},
@@ -104,6 +104,10 @@ func TestDefaultModule_NewConfig(t *testing.T) {
 			expectedAuthCfg: Config{
 				Type: TypeCognito,
 				IDPCognito: IDPCognito{
+					AuthenticationRequestExtraParams: AuthenticationRequestExtraParams{
+						"param1": "value1",
+						"param2": "value2",
+					},
 					UserPoolArn:      "UserPoolArn",
 					UserPoolClientId: "UserPoolClientId",
 					UserPoolDomain:   "UserPoolDomain",
@@ -132,7 +136,7 @@ func TestDefaultModule_NewConfig(t *testing.T) {
 					Name:      "service",
 					Annotations: map[string]string{
 						parser.GetAnnotationWithPrefix(AnnotationAuthType):       "cognito",
-						parser.GetAnnotationWithPrefix(AnnotationAuthIDPCognito): "{\"UserPoolArn\": \"UserPoolArn\",\"UserPoolClientId\": \"UserPoolClientId\",\"UserPoolDomain\": \"UserPoolDomain\"}",
+						parser.GetAnnotationWithPrefix(AnnotationAuthIDPCognito): "{\"UserPoolArn\": \"UserPoolArn\",\"UserPoolClientId\": \"UserPoolClientId\",\"UserPoolDomain\": \"UserPoolDomain\",\"AuthenticationRequestExtraParams\": { \"param1\": \"value1\",\"param2\": \"value2\"}}",
 					},
 				},
 			},
@@ -140,6 +144,10 @@ func TestDefaultModule_NewConfig(t *testing.T) {
 			expectedAuthCfg: Config{
 				Type: TypeCognito,
 				IDPCognito: IDPCognito{
+					AuthenticationRequestExtraParams: AuthenticationRequestExtraParams{
+						"param1": "value1",
+						"param2": "value2",
+					},
 					UserPoolArn:      "UserPoolArn",
 					UserPoolClientId: "UserPoolClientId",
 					UserPoolDomain:   "UserPoolDomain",
@@ -158,7 +166,7 @@ func TestDefaultModule_NewConfig(t *testing.T) {
 					Name:      "ingress",
 					Annotations: map[string]string{
 						parser.GetAnnotationWithPrefix(AnnotationAuthType):    "oidc",
-						parser.GetAnnotationWithPrefix(AnnotationAuthIDPOIDC): "{\"Issuer\": \"Issuer\",\"AuthorizationEndpoint\": \"AuthorizationEndpoint\",\"TokenEndpoint\": \"TokenEndpoint\",\"UserInfoEndpoint\": \"UserInfoEndpoint\",\"SecretName\": \"oidc-secret\"}",
+						parser.GetAnnotationWithPrefix(AnnotationAuthIDPOIDC): "{\"Issuer\": \"Issuer\",\"AuthorizationEndpoint\": \"AuthorizationEndpoint\",\"TokenEndpoint\": \"TokenEndpoint\",\"UserInfoEndpoint\": \"UserInfoEndpoint\",\"SecretName\": \"oidc-secret\",\"AuthenticationRequestExtraParams\": { \"param1\": \"value1\",\"param2\": \"value2\"}}",
 					},
 				},
 			},
@@ -188,10 +196,14 @@ func TestDefaultModule_NewConfig(t *testing.T) {
 				IDPOIDC: IDPOIDC{
 					Issuer:                "Issuer",
 					AuthorizationEndpoint: "AuthorizationEndpoint",
-					TokenEndpoint:         "TokenEndpoint",
-					UserInfoEndpoint:      "UserInfoEndpoint",
-					ClientId:              "clientId",
-					ClientSecret:          "clientSecret",
+					AuthenticationRequestExtraParams: AuthenticationRequestExtraParams{
+						"param1": "value1",
+						"param2": "value2",
+					},
+					TokenEndpoint:    "TokenEndpoint",
+					UserInfoEndpoint: "UserInfoEndpoint",
+					ClientId:         "clientId",
+					ClientSecret:     "clientSecret",
 				},
 				Scope:                    DefaultAuthScope,
 				SessionCookie:            DefaultAuthSessionCookie,
@@ -217,7 +229,7 @@ func TestDefaultModule_NewConfig(t *testing.T) {
 					Name:      "service",
 					Annotations: map[string]string{
 						parser.GetAnnotationWithPrefix(AnnotationAuthType):    "oidc",
-						parser.GetAnnotationWithPrefix(AnnotationAuthIDPOIDC): "{\"Issuer\": \"Issuer\",\"AuthorizationEndpoint\": \"AuthorizationEndpoint\",\"TokenEndpoint\": \"TokenEndpoint\",\"UserInfoEndpoint\": \"UserInfoEndpoint\",\"SecretName\": \"oidc-secret\"}",
+						parser.GetAnnotationWithPrefix(AnnotationAuthIDPOIDC): "{\"Issuer\": \"Issuer\",\"AuthorizationEndpoint\": \"AuthorizationEndpoint\",\"TokenEndpoint\": \"TokenEndpoint\",\"UserInfoEndpoint\": \"UserInfoEndpoint\",\"SecretName\": \"oidc-secret\",\"AuthenticationRequestExtraParams\": { \"param1\": \"value1\",\"param2\": \"value2\"}}",
 					},
 				},
 			},
@@ -237,10 +249,14 @@ func TestDefaultModule_NewConfig(t *testing.T) {
 				IDPOIDC: IDPOIDC{
 					Issuer:                "Issuer",
 					AuthorizationEndpoint: "AuthorizationEndpoint",
-					TokenEndpoint:         "TokenEndpoint",
-					UserInfoEndpoint:      "UserInfoEndpoint",
-					ClientId:              "clientId",
-					ClientSecret:          "clientSecret",
+					AuthenticationRequestExtraParams: AuthenticationRequestExtraParams{
+						"param1": "value1",
+						"param2": "value2",
+					},
+					TokenEndpoint:    "TokenEndpoint",
+					UserInfoEndpoint: "UserInfoEndpoint",
+					ClientId:         "clientId",
+					ClientSecret:     "clientSecret",
 				},
 				Scope:                    DefaultAuthScope,
 				SessionCookie:            DefaultAuthSessionCookie,

--- a/internal/ingress/auth/types.go
+++ b/internal/ingress/auth/types.go
@@ -9,6 +9,10 @@ const (
 	TypeOIDC    Type = "oidc"
 )
 
+// parameters are specified as strings
+// multiple values for a parameter are not supported
+type AuthenticationRequestExtraParams map[string]string
+
 type OnUnauthenticatedRequest string
 
 const (
@@ -19,19 +23,21 @@ const (
 
 // configuration for IDP of Cognito
 type IDPCognito struct {
-	UserPoolArn      string
-	UserPoolClientId string
-	UserPoolDomain   string
+	AuthenticationRequestExtraParams AuthenticationRequestExtraParams
+	UserPoolArn                      string
+	UserPoolClientId                 string
+	UserPoolDomain                   string
 }
 
 // configuration for IDP of OIDC
 type IDPOIDC struct {
-	Issuer                string
-	AuthorizationEndpoint string
-	TokenEndpoint         string
-	UserInfoEndpoint      string
-	ClientId              string
-	ClientSecret          string
+	AuthenticationRequestExtraParams AuthenticationRequestExtraParams
+	AuthorizationEndpoint            string
+	ClientId                         string
+	ClientSecret                     string
+	Issuer                           string
+	TokenEndpoint                    string
+	UserInfoEndpoint                 string
 }
 
 // authentication configuration
@@ -50,10 +56,11 @@ type Config struct {
 // You can specify clientId & ClientSecret directly, or configure it as k8s secret
 // The secret should be in same namespace as ingress/service and configured as "clientId: base64(ClientId) clientSecret: base64(ClientSecret)"
 type AnnotationSchemaIDPOIDC struct {
-	Issuer                string
-	AuthorizationEndpoint string
-	TokenEndpoint         string
-	UserInfoEndpoint      string
+	AuthenticationRequestExtraParams AuthenticationRequestExtraParams
+	AuthorizationEndpoint            string
+	Issuer                           string
+	TokenEndpoint                    string
+	UserInfoEndpoint                 string
 
 	SecretName string
 }


### PR DESCRIPTION
Allow additional parameters to be configured and added to the 
authentication request for OIDC and Cognito
Closes #949 

Tested in our clusters