### PR TITLE
Added docs for creating DNS pointing from ingress object

### DIFF
--- a/docs/guide/external-dns/setup.md
+++ b/docs/guide/external-dns/setup.md
@@ -46,9 +46,9 @@ Adequate roles and policies must be configured in AWS and available to the node(
 ## Usage:
 To create a record set in the subdomain, from your ingress which has been created by the ingress-controller, simply add the following annotation in the ingress object specification,
 
-  annotations:
-    kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/scheme: internet-facing
+    annotations:
+      kubernetes.io/ingress.class: alb
+      alb.ingress.kubernetes.io/scheme: internet-facing
 
-    # for creating record-set
-    external-dns.alpha.kubernetes.io/hostname: my-app.test-dns.com # give your domain name here
+      # for creating record-set
+      external-dns.alpha.kubernetes.io/hostname: my-app.test-dns.com # give your domain name here

--- a/docs/guide/external-dns/setup.md
+++ b/docs/guide/external-dns/setup.md
@@ -52,4 +52,3 @@ To create a record set in the subdomain, from your ingress which has been create
 
     # for creating record-set
     external-dns.alpha.kubernetes.io/hostname: my-app.test-dns.com # give your domain name here
->>>>>>> 479301ced134ba0aa5e03e6fed21cddf35396e1e

--- a/docs/guide/external-dns/setup.md
+++ b/docs/guide/external-dns/setup.md
@@ -41,4 +41,18 @@ Adequate roles and policies must be configured in AWS and available to the node(
     ```
     time="2017-09-19T02:51:54Z" level=info msg="config: &{Master: KubeConfig: Sources:[service ingress] Namespace: FQDNTemplate: Compatibility: Provider:aws GoogleProject: DomainFilter:[] AzureConfigFile:/etc/kuberne tes/azure.json AzureResourceGroup: Policy:upsert-only Registry:txt TXTOwnerID:my-identifier TXTPrefix: Interval:1m0s Once:false DryRun:false LogFormat:text MetricsAddress::7979 Debug:false}"
     time="2017-09-19T02:51:54Z" level=info msg="Connected to cluster at https://10.3.0.1:443"
+<<<<<<< Updated upstream
     ```
+=======
+    ```
+
+## Usage:
+To create a record set in the subdomain, from your ingress which has been created by the ingress-controller, simply add the following annotation in the ingress object specification,
+
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+
+    # for creating record-set
+    external-dns.alpha.kubernetes.io/hostname: my-app.test-dns.com # give your domain name here
+>>>>>>> Stashed changes


### PR DESCRIPTION
### Description:
Added docs for creating DNS pointing from ingress object

### Motivation:
I had set up the external-dns but I was having trouble finding the docs on how to add the dns entry using ingress/service/external-dns for a particular service in kubernetes. I then had to go through a lot of blogs/articles and at one place I finally found that it can be done using annotations. I think that it should be described in the docs that after setting up the external-dns how one can use it to create dns record-sets for their apps. Maybe I didn't look thoroughly enough, if so, please point in the right direction :) Also, please excuse any English grammar mistakes, if any, it's not my first language.

### Testing:
I did not do any testing as it was only documentation changes.