### PR TITLE
add flag to enable concurrent reconciliation.

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -23,6 +23,7 @@ const (
 	defaultRestrictScheme          = false
 	defaultRestrictSchemeNamespace = corev1.NamespaceDefault
 	defaultSyncRateLimit           = 0.3
+	defaultMaxConcurrentReconciles = 1
 )
 
 var (
@@ -42,7 +43,8 @@ type Configuration struct {
 	DefaultTargetType      string
 	DefaultBackendProtocol string
 
-	SyncRateLimit float32
+	SyncRateLimit           float32
+	MaxConcurrentReconciles int
 
 	RestrictScheme          bool
 	RestrictSchemeNamespace string
@@ -80,6 +82,8 @@ func (cfg *Configuration) BindFlags(fs *pflag.FlagSet) {
 		`Default protocol to use for target groups, must be "HTTP" or "HTTPS"`)
 	fs.Float32Var(&cfg.SyncRateLimit, "sync-rate-limit", defaultSyncRateLimit,
 		`Define the sync frequency upper limit`)
+	fs.IntVar(&cfg.MaxConcurrentReconciles, "max-concurrent-reconciles", defaultMaxConcurrentReconciles,
+		`Define the maximum of number concurrently running reconcile loops`)
 	fs.BoolVar(&cfg.RestrictScheme, "restrict-scheme", defaultRestrictScheme,
 		`Restrict the scheme to internal except for whitelisted namespaces`)
 	fs.StringVar(&cfg.RestrictSchemeNamespace, "restrict-scheme-namespace", defaultRestrictSchemeNamespace,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -33,7 +33,7 @@ func Initialize(config *config.Configuration, mgr manager.Manager, mc metric.Col
 	if err != nil {
 		return err
 	}
-	c, err := controller.New("alb-ingress-controller", mgr, controller.Options{Reconciler: reconciler})
+	c, err := controller.New("alb-ingress-controller", mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: config.MaxConcurrentReconciles})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR enables control over how many concurrent reconciliations can be run. Since reconciliation duration ranges from 30s-2min this should give more headroom for larger use-cases.