### PR TITLE
Add automountServiceAccountToken to example

### DIFF
--- a/docs/examples/alb-ingress-controller.yaml
+++ b/docs/examples/alb-ingress-controller.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app.kubernetes.io/name: alb-ingress-controller
     spec:
+      automountServiceAccountToken: true
       containers:
         - name: alb-ingress-controller
           args:


### PR DESCRIPTION
I ran into this issue: https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/965

Adding `automountServiceAccountToken: true` to the example deployment yaml fixed it.