### PR TITLE
added authorization bypass annotation

### DIFF
--- a/docs/guide/ingress/annotation.md
+++ b/docs/guide/ingress/annotation.md
@@ -19,6 +19,7 @@ You can add kubernetes annotations to ingress and service objects to customize t
 |[alb.ingress.kubernetes.io/auth-idp-oidc](#auth-idp-oidc)|json|N/A|ingress,service|
 |[alb.ingress.kubernetes.io/auth-on-unauthenticated-request](#auth-on-unauthenticated-request)|authenticate\|allow\|deny|authenticate|ingress,service|
 |[alb.ingress.kubernetes.io/auth-scope](#auth-scope)|string|openid|ingress,service|
+|[alb.ingress.kubernetes.io/auth-bypass](#auth-bypass)|string|none|ingress,service|
 |[alb.ingress.kubernetes.io/auth-session-cookie](#auth-session-cookie)|string|AWSELBAuthSessionCookie|ingress,service|
 |[alb.ingress.kubernetes.io/auth-session-timeout](#auth-session-timeout)|integer|'604800'|ingress,service|
 |[alb.ingress.kubernetes.io/auth-type](#auth-type)|none\|oidc\|cognito|none|ingress,service|
@@ -232,6 +233,16 @@ ALB supports authentication with Cognito or OIDC. See [Authenticate Users Using 
     !!!example
         ```
         alb.ingress.kubernetes.io/auth-scope: 'email openid'
+        ```
+
+- <a name="auth-bypass">`alb.ingress.kubernetes.io/auth-bypass`</a> specifies the set of paths which should be accessable without authentication (separated by comma).
+
+    !!!tip ""
+        Paths have to be exactly the same way as in rules
+
+    !!!example
+        ```
+        alb.ingress.kubernetes.io/auth-bypass: '/path1,/path2,/path/*'
         ```
 
 - <a name="auth-session-cookie">`alb.ingress.kubernetes.io/auth-session-cookie`</a> specifies the name of the cookie used to maintain session information

--- a/internal/alb/ls/listener.go
+++ b/internal/alb/ls/listener.go
@@ -262,7 +262,7 @@ func (controller *defaultController) buildDefaultActions(ctx context.Context, op
 	if err != nil {
 		return nil, err
 	}
-	return buildActions(ctx, authCfg, options.IngressAnnos, backend, options.TGGroup)
+	return buildActions(ctx, authCfg, options.IngressAnnos, "/", backend, options.TGGroup)
 }
 
 // inferCertARNs retrieves a set of certificates from ACM that matches the ingress' hosts list

--- a/internal/ingress/auth/auth.go
+++ b/internal/ingress/auth/auth.go
@@ -21,6 +21,7 @@ import (
 const (
 	AnnotationAuthType                     string = "auth-type"
 	AnnotationAuthScope                    string = "auth-scope"
+	AnnotationAuthBypass                   string = "auth-bypass"
 	AnnotationAuthSessionCookie            string = "auth-session-cookie"
 	AnnotationAuthSessionTimeout           string = "auth-session-timeout"
 	AnnotationAuthOnUnauthenticatedRequest string = "auth-on-unauthenticated-request"
@@ -115,6 +116,7 @@ func (m *defaultModule) NewConfig(ctx context.Context, ingress *extensions.Ingre
 	_ = annotations.LoadStringAnnotation(AnnotationAuthOnUnauthenticatedRequest, (*string)(&cfg.OnUnauthenticatedRequest), serviceAnnos, ingressAnnos)
 	_ = annotations.LoadStringAnnotation(AnnotationAuthScope, &cfg.Scope, serviceAnnos, ingressAnnos)
 	_ = annotations.LoadStringAnnotation(AnnotationAuthSessionCookie, &cfg.SessionCookie, serviceAnnos, ingressAnnos)
+	_ = annotations.LoadStringSliceAnnotation(AnnotationAuthBypass, &cfg.Bypass, serviceAnnos, ingressAnnos)
 	if _, err := annotations.LoadInt64Annotation(AnnotationAuthSessionTimeout, &cfg.SessionTimeout, serviceAnnos, ingressAnnos); err != nil {
 		return Config{}, err
 	}

--- a/internal/ingress/auth/auth_test.go
+++ b/internal/ingress/auth/auth_test.go
@@ -273,6 +273,7 @@ func TestDefaultModule_NewConfig(t *testing.T) {
 					Annotations: map[string]string{
 						parser.GetAnnotationWithPrefix(AnnotationAuthType):                     "cognito",
 						parser.GetAnnotationWithPrefix(AnnotationAuthIDPCognito):               "{\"UserPoolArn\": \"UserPoolArn\",\"UserPoolClientId\": \"UserPoolClientId\",\"UserPoolDomain\": \"UserPoolDomain\"}",
+						parser.GetAnnotationWithPrefix(AnnotationAuthBypass):                   "/path1,/path2,/path3/*",
 						parser.GetAnnotationWithPrefix(AnnotationAuthScope):                    "email openid",
 						parser.GetAnnotationWithPrefix(AnnotationAuthSessionCookie):            "customCookieName",
 						parser.GetAnnotationWithPrefix(AnnotationAuthSessionTimeout):           "600",
@@ -300,6 +301,7 @@ func TestDefaultModule_NewConfig(t *testing.T) {
 				},
 				Scope:                    "email openid",
 				SessionCookie:            "customCookieName",
+				Bypass:                   []string{"/path1", "/path2", "/path3/*"},
 				SessionTimeout:           600,
 				OnUnauthenticatedRequest: OnUnauthenticatedRequestAllow,
 			},

--- a/internal/ingress/auth/types.go
+++ b/internal/ingress/auth/types.go
@@ -45,6 +45,7 @@ type Config struct {
 	Type                     Type
 	Scope                    string
 	SessionCookie            string
+	Bypass                   []string
 	SessionTimeout           int64
 	OnUnauthenticatedRequest OnUnauthenticatedRequest
 


### PR DESCRIPTION
Added an authorization bypass annotation, which allows creating rules without authorization.

It will be probably possible to achieve the same behavior once 1.2.0 is released. 