### PR TITLE
Update the Travis go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - GO111MODULE=on
 
 go:
-  - "1.11.2"
+  - "1.12.9"
 
 cache:
   directories:


### PR DESCRIPTION
This matches what the other prow jobs use ([example](https://github.com/kubernetes/test-infra/blob/74fb928e018d8469853761006e9a6662d35de05f/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml#L10))