### PR TITLE
fix sg rule handling bug when scale down to 0 under ip mode

### DIFF
--- a/internal/alb/sg/instance_attachment_v2.go
+++ b/internal/alb/sg/instance_attachment_v2.go
@@ -106,6 +106,9 @@ func (c *instanceAttachmentControllerV2) findInstanceSGsForTgGroup(ctx context.C
 			sgIDs.Insert(aws.StringValue(group.GroupId))
 		}
 	}
+	if len(sgIDs) == 0 {
+		return nil, nil
+	}
 	sgs, err := c.cloud.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
 		GroupIds: aws.StringSlice(sgIDs.List()),
 	})


### PR DESCRIPTION
Fix bug when deployment have 0 replicas under ip mode
Test done:
scale up/down deployment from 0 replica and observed correct behavior.