### PR TITLE
docs: clarify security group name comes from tag

### DIFF
--- a/docs/guide/ingress/annotation.md
+++ b/docs/guide/ingress/annotation.md
@@ -158,7 +158,7 @@ Access control for LoadBalancer can be controlled with following annotations:
         When this annotation is not present, the controller will automatically create 2 security groups: the first security group will be attached to the LoadBalancer and allow access from [`inbound-cidrs`](#inbound-cidrs) to the [`listen-ports`](#listen-ports). The second security group will be attached to the EC2 instance(s) and allow all TCP traffic from the first security group created for the LoadBalancer.
 
     !!!tip ""
-        both name or ID of securityGroups are supported.
+        Both name or ID of securityGroups are supported. Name matches a `Name` tag, not the `groupName` attribute.
 
     !!!warning ""
         The [default limit](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_vpc) of security groups per network interface in AWS is 5. This limit is quickly reached when multiple load balancers are provisioned by the controller without this annotation, therefore it is recommended to set this annotation to a self-managed security group (or request AWS support to increase the number of security groups per network interface for your AWS account). If this annotation is specified, you should also manage the security group used by the EC2 instances to allow inbound traffic from the security group attached to the LoadBalancer.


### PR DESCRIPTION
This clarifies the `alb.ingress.kubernetes.io/security-groups` documentation. We found ourselves momentarily confused when our security groups were not attached to the load balancer. I read the code and realized it's looking for a `Name` tag, but we'd only specified the `groupName` property (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SecurityGroup.html).

https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/4bba2f2b0ba2fb171c38c9382a85627c196f48e9/internal/aws/ec2.go#L167-L189

The code later assumes that multiple values could be returned which is possible with `tag:Name` but not possible when setting the actual group name (must be unique). I found this behavior surprising (since the user can specify multiple SG names if they want to match multiple SGs).

If you're interested in supporting `groupName`, I'd be happy to work on a PR that makes two API calls in `GetSecurityGroupsByName`, one filtering by name tag and the other by group name, and then merges the results. In the mean time, wanted to make sure the docs clarified the current behavior appropriately.