### PR TITLE
Allow node-labels annotation.

### DIFF
--- a/internal/ingress/controller/store/dummy.go
+++ b/internal/ingress/controller/store/dummy.go
@@ -18,6 +18,7 @@ type Dummy struct {
 	GetNodeInstanceIDFunc func(*corev1.Node) (string, error)
 
 	GetServiceEndpointsFunc func(string) (*corev1.Endpoints, error)
+	IsNodeSelectedFunc      func(string, *corev1.Node) (bool, error)
 }
 
 // GetConfigMap ...
@@ -87,6 +88,11 @@ func (d *Dummy) GetInstanceIDFromPodIP(s string) (string, error) {
 	return "", nil
 }
 
+// IsNodeSelected ...
+func (d Dummy) IsNodeSelected(nodeLabelAnnotation string, node *corev1.Node) (bool, error) {
+	return d.IsNodeSelectedFunc(nodeLabelAnnotation, node)
+}
+
 func NewDummy() *Dummy {
 	return &Dummy{
 		GetServiceFunc:                func(_ string) (*corev1.Service, error) { return dummy.NewService(), nil },
@@ -95,5 +101,6 @@ func NewDummy() *Dummy {
 		GetServiceEndpointsFunc:       func(string) (*corev1.Endpoints, error) { return nil, nil },
 		GetIngressAnnotationsResponse: annotations.NewIngressDummy(),
 		GetServiceAnnotationsResponse: annotations.NewServiceDummy(),
+		IsNodeSelectedFunc:            func(string, *corev1.Node) (bool, error) { return true, nil },
 	}
 }

--- a/internal/ingress/controller/store/mock_Storer.go
+++ b/internal/ingress/controller/store/mock_Storer.go
@@ -181,3 +181,8 @@ func (_m *MockStorer) ListNodes() []*v1.Node {
 
 	return r0
 }
+
+// IsNodeSelected provides a mock function with given fields:
+func (_m *MockStorer) IsNodeSelected(nodeLabelAnnotation string, node *v1.Node) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
This commit allows the ingress object to specify an annotation about which nodes should
be in the target group. The annotation is of the format:

`alb.ingress.kubernetes.io/node-labels: kops.k8s.io/instancegroup=web,foo=bar`

The implementation checks the labels on the node against the key-value pairs specified in the
above annotation. If they match, the node is part of the target group. Otherwise not.

If the `alb.ingress.kubernetes.io/node-labels` annotation does not exist, the original
behavior stays; i.e. all nodes are selected.

Testing Done:

1. Verified that adding no annotation retains existing behavior.
2. Verified that adding a single key-value pair works. The correct set of nodes are selected.
3. Verified that adding multiple key-value pairs works as expected. The correct set of nodes are selected.
4. Verified that removing a key-value pair from the annotation works as expected. The appropriate nodes are removed from the target-group.
5. Verified that removing the entire annotation works as expected. All nodes get added to the target-group.
