### PR TITLE
Load balancing algorithm for target groups support

### DIFF
--- a/docs/guide/ingress/annotation.md
+++ b/docs/guide/ingress/annotation.md
@@ -455,6 +455,10 @@ Custom attributes to LoadBalancers and TargetGroups can be controlled with follo
             ```
             alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=60
             ```
+        - set load balancing algorithm to least outstanding requests
+                    ```
+                    alb.ingress.kubernetes.io/target-group-attributes: load_balancing.algorithm.type=least_outstanding_requests
+                    ```
 
 ## Resource Tags
 ALB Ingress controller will automatically apply following tags to AWS resources(ALB/TargetGroups/SecurityGroups) created.

--- a/internal/alb/tg/attributes_test.go
+++ b/internal/alb/tg/attributes_test.go
@@ -139,6 +139,18 @@ func Test_NewAttributes(t *testing.T) {
 		},
 
 		{
+			name:       "LoadBalancingAlgorithmTypeKey is default",
+			ok:         true,
+			attributes: []*elbv2.TargetGroupAttribute{tgAttribute(LoadBalancingAlgorithmTypeKey, "round_robin")},
+			output:     MustNewAttributes([]*elbv2.TargetGroupAttribute{tgAttribute(LoadBalancingAlgorithmTypeKey, "round_robin")}),
+		},
+		{
+			name:       "LoadBalancingAlgorithmTypeKey is not round_robin or least_outstanding_requests",
+			ok:         false,
+			attributes: []*elbv2.TargetGroupAttribute{tgAttribute(LoadBalancingAlgorithmTypeKey, "error")},
+		},
+
+		{
 			name:       "Invalid attribute",
 			ok:         false,
 			attributes: []*elbv2.TargetGroupAttribute{tgAttribute("not a real attribute", "error")},
@@ -289,6 +301,18 @@ func Test_attributesChangeSet(t *testing.T) {
 			a:         MustNewAttributes([]*elbv2.TargetGroupAttribute{tgAttribute(StickinessLbCookieDurationSecondsKey, "500")}),
 			b:         MustNewAttributes([]*elbv2.TargetGroupAttribute{tgAttribute(StickinessLbCookieDurationSecondsKey, "501")}),
 			changeSet: []*elbv2.TargetGroupAttribute{tgAttribute(StickinessLbCookieDurationSecondsKey, "501")},
+		},
+
+		{
+			name: "LoadBalancingAlgorithmType: a=default b=default",
+			a:    MustNewAttributes([]*elbv2.TargetGroupAttribute{tgAttribute(LoadBalancingAlgorithmTypeKey, "round_robin")}),
+			b:    MustNewAttributes([]*elbv2.TargetGroupAttribute{tgAttribute(LoadBalancingAlgorithmTypeKey, "round_robin")}),
+		},
+		{
+			name:      "LoadBalancingAlgorithmType: a=default b=nondefault a!=b",
+			a:         MustNewAttributes([]*elbv2.TargetGroupAttribute{tgAttribute(LoadBalancingAlgorithmTypeKey, "round_robin")}),
+			b:         MustNewAttributes([]*elbv2.TargetGroupAttribute{tgAttribute(LoadBalancingAlgorithmTypeKey, "least_outstanding_requests")}),
+			changeSet: []*elbv2.TargetGroupAttribute{tgAttribute(LoadBalancingAlgorithmTypeKey, "least_outstanding_requests")},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
ALB's now support an additional algorithm, set at the target group level. This PR adds support for this.

Fixes https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/1082

https://aws.amazon.com/about-aws/whats-new/2019/11/application-load-balancer-now-supports-least-outstanding-requests-algorithm-for-load-balancing-requests/