### PR TITLE
Advanced routing/weighted loadbalancing support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,3 +18,5 @@ issues:
   exclude:
   - IpAddressType # AWS SDK GO are using IpAddressType, while go-lint requires IPAddressType :(
   - ClientId      # AWS SDK GO are using ClientId, while go-lint requires ClientID :(
+  - SourceIp
+  - Http

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kubernetes-sigs/aws-alb-ingress-controller
 require (
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 // indirect
 	github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20190907061006-260b0e114d90
-	github.com/aws/aws-sdk-go v1.23.21
+	github.com/aws/aws-sdk-go v1.27.3
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/glogr v0.1.0
 	github.com/go-logr/logr v0.1.0 // indirect
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/common v0.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/ticketmaster/aws-sdk-go-cache v0.0.0-20180926195306-58922816129c
+	github.com/ticketmaster/aws-sdk-go-cache v0.0.0-20180926195306-58922816129c // indirect
 	golang.org/x/oauth2 v0.0.0-20190212230446-3e8b2be13635 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20181213150558-05914d821849

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,10 @@ github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20190907061006-260b0e114d90/go.m
 github.com/aws/aws-sdk-go v1.15.39/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.23.21 h1:eVJT2C99cAjZlBY8+CJovf6AwrSANzAcYNuxdCB+SPk=
 github.com/aws/aws-sdk-go v1.23.21/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.25.43 h1:R5YqHQFIulYVfgRySz9hvBRTWBjudISa+r0C8XQ1ufg=
+github.com/aws/aws-sdk-go v1.25.43/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.27.3 h1:CBWC7Yot0U6OU/uosUmq7tKJVBTq6HrhgW1Vjpt9SMw=
+github.com/aws/aws-sdk-go v1.27.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -380,6 +384,7 @@ golang.org/x/tools v0.0.0-20191010075000-0337d82405ff h1:XdBG6es/oFDr1HwaxkxgVve
 golang.org/x/tools v0.0.0-20191010075000-0337d82405ff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/internal/alb/ls/listener_test.go
+++ b/internal/alb/ls/listener_test.go
@@ -117,9 +117,18 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					Port:            aws.Int64(80),
 					DefaultActions: []*elbv2.Action{
 						{
-							Order:          aws.Int64(1),
-							TargetGroupArn: aws.String("tgArn"),
-							Type:           aws.String(elbv2.ActionTypeEnumForward),
+							Order: aws.Int64(1),
+							Type:  aws.String(elbv2.ActionTypeEnumForward),
+							ForwardConfig: &elbv2.ForwardActionConfig{
+								TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+									Enabled: aws.Bool(false),
+								},
+								TargetGroups: []*elbv2.TargetGroupTuple{
+									{TargetGroupArn: aws.String("tgArn"),
+										Weight: aws.Int64(1),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -234,9 +243,18 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					Port:      aws.Int64(443),
 					DefaultActions: []*elbv2.Action{
 						{
-							Order:          aws.Int64(1),
-							Type:           aws.String(elbv2.ActionTypeEnumForward),
-							TargetGroupArn: aws.String("tgArn"),
+							Order: aws.Int64(1),
+							Type:  aws.String(elbv2.ActionTypeEnumForward),
+							ForwardConfig: &elbv2.ForwardActionConfig{
+								TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+									Enabled: aws.Bool(false),
+								},
+								TargetGroups: []*elbv2.TargetGroupTuple{
+									{TargetGroupArn: aws.String("tgArn"),
+										Weight: aws.Int64(1),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -308,9 +326,18 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				SslPolicy: aws.String("sslPolicy"),
 				DefaultActions: []*elbv2.Action{
 					{
-						Order:          aws.Int64(1),
-						Type:           aws.String(elbv2.ActionTypeEnumForward),
-						TargetGroupArn: aws.String("tgArn"),
+						Order: aws.Int64(1),
+						Type:  aws.String(elbv2.ActionTypeEnumForward),
+						ForwardConfig: &elbv2.ForwardActionConfig{
+							TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+								Enabled: aws.Bool(false),
+							},
+							TargetGroups: []*elbv2.TargetGroupTuple{
+								{TargetGroupArn: aws.String("tgArn"),
+									Weight: aws.Int64(1),
+								},
+							},
+						},
 					},
 				},
 			},
@@ -336,9 +363,18 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					SslPolicy: aws.String("sslPolicy"),
 					DefaultActions: []*elbv2.Action{
 						{
-							Order:          aws.Int64(1),
-							Type:           aws.String(elbv2.ActionTypeEnumForward),
-							TargetGroupArn: aws.String("tgArn"),
+							Order: aws.Int64(1),
+							Type:  aws.String(elbv2.ActionTypeEnumForward),
+							ForwardConfig: &elbv2.ForwardActionConfig{
+								TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+									Enabled: aws.Bool(false),
+								},
+								TargetGroups: []*elbv2.TargetGroupTuple{
+									{TargetGroupArn: aws.String("tgArn"),
+										Weight: aws.Int64(1),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -389,9 +425,19 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				SslPolicy:    nil,
 				DefaultActions: []*elbv2.Action{
 					{
-						Order:          aws.Int64(1),
-						Type:           aws.String(elbv2.ActionTypeEnumForward),
-						TargetGroupArn: aws.String("tgArn2"),
+						Order: aws.Int64(1),
+						Type:  aws.String(elbv2.ActionTypeEnumForward),
+						ForwardConfig: &elbv2.ForwardActionConfig{
+							TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+								Enabled: aws.Bool(false),
+							},
+							TargetGroups: []*elbv2.TargetGroupTuple{
+								{
+									TargetGroupArn: aws.String("tgArn2"),
+									Weight:         aws.Int64(1),
+								},
+							},
+						},
 					},
 				},
 			},
@@ -409,9 +455,19 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					SslPolicy: aws.String("sslPolicy"),
 					DefaultActions: []*elbv2.Action{
 						{
-							Order:          aws.Int64(1),
-							Type:           aws.String(elbv2.ActionTypeEnumForward),
-							TargetGroupArn: aws.String("tgArn"),
+							Order: aws.Int64(1),
+							Type:  aws.String(elbv2.ActionTypeEnumForward),
+							ForwardConfig: &elbv2.ForwardActionConfig{
+								TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+									Enabled: aws.Bool(false),
+								},
+								TargetGroups: []*elbv2.TargetGroupTuple{
+									{
+										TargetGroupArn: aws.String("tgArn"),
+										Weight:         aws.Int64(1),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -427,9 +483,19 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					SslPolicy: aws.String("sslPolicy"),
 					DefaultActions: []*elbv2.Action{
 						{
-							Order:          aws.Int64(1),
-							Type:           aws.String(elbv2.ActionTypeEnumForward),
-							TargetGroupArn: aws.String("tgArn"),
+							Order: aws.Int64(1),
+							Type:  aws.String(elbv2.ActionTypeEnumForward),
+							ForwardConfig: &elbv2.ForwardActionConfig{
+								TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+									Enabled: aws.Bool(false),
+								},
+								TargetGroups: []*elbv2.TargetGroupTuple{
+									{
+										TargetGroupArn: aws.String("tgArn"),
+										Weight:         aws.Int64(1),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -456,9 +522,19 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					SslPolicy: aws.String("sslPolicy"),
 					DefaultActions: []*elbv2.Action{
 						{
-							Order:          aws.Int64(1),
-							Type:           aws.String(elbv2.ActionTypeEnumForward),
-							TargetGroupArn: aws.String("tgArn"),
+							Order: aws.Int64(1),
+							Type:  aws.String(elbv2.ActionTypeEnumForward),
+							ForwardConfig: &elbv2.ForwardActionConfig{
+								TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+									Enabled: aws.Bool(false),
+								},
+								TargetGroups: []*elbv2.TargetGroupTuple{
+									{
+										TargetGroupArn: aws.String("tgArn"),
+										Weight:         aws.Int64(1),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -513,9 +589,19 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				SslPolicy: aws.String("sslPolicy"),
 				DefaultActions: []*elbv2.Action{
 					{
-						Order:          aws.Int64(1),
-						Type:           aws.String(elbv2.ActionTypeEnumForward),
-						TargetGroupArn: aws.String("tgArn"),
+						Order: aws.Int64(1),
+						Type:  aws.String(elbv2.ActionTypeEnumForward),
+						ForwardConfig: &elbv2.ForwardActionConfig{
+							TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+								Enabled: aws.Bool(false),
+							},
+							TargetGroups: []*elbv2.TargetGroupTuple{
+								{
+									TargetGroupArn: aws.String("tgArn"),
+									Weight:         aws.Int64(1),
+								},
+							},
+						},
 					},
 				},
 			},
@@ -593,9 +679,19 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					SslPolicy: aws.String("sslPolicy"),
 					DefaultActions: []*elbv2.Action{
 						{
-							Order:          aws.Int64(1),
-							Type:           aws.String(elbv2.ActionTypeEnumForward),
-							TargetGroupArn: aws.String("tgArn"),
+							Order: aws.Int64(1),
+							Type:  aws.String(elbv2.ActionTypeEnumForward),
+							ForwardConfig: &elbv2.ForwardActionConfig{
+								TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+									Enabled: aws.Bool(false),
+								},
+								TargetGroups: []*elbv2.TargetGroupTuple{
+									{
+										TargetGroupArn: aws.String("tgArn"),
+										Weight:         aws.Int64(1),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -646,9 +742,19 @@ func TestDefaultController_Reconcile(t *testing.T) {
 				SslPolicy:    nil,
 				DefaultActions: []*elbv2.Action{
 					{
-						Order:          aws.Int64(1),
-						Type:           aws.String(elbv2.ActionTypeEnumForward),
-						TargetGroupArn: aws.String("tgArn2"),
+						Order: aws.Int64(1),
+						Type:  aws.String(elbv2.ActionTypeEnumForward),
+						ForwardConfig: &elbv2.ForwardActionConfig{
+							TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+								Enabled: aws.Bool(false),
+							},
+							TargetGroups: []*elbv2.TargetGroupTuple{
+								{
+									TargetGroupArn: aws.String("tgArn2"),
+									Weight:         aws.Int64(1),
+								},
+							},
+						},
 					},
 				},
 			},
@@ -666,9 +772,19 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					SslPolicy: aws.String("sslPolicy"),
 					DefaultActions: []*elbv2.Action{
 						{
-							Order:          aws.Int64(1),
-							Type:           aws.String(elbv2.ActionTypeEnumForward),
-							TargetGroupArn: aws.String("tgArn"),
+							Order: aws.Int64(1),
+							Type:  aws.String(elbv2.ActionTypeEnumForward),
+							ForwardConfig: &elbv2.ForwardActionConfig{
+								TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+									Enabled: aws.Bool(false),
+								},
+								TargetGroups: []*elbv2.TargetGroupTuple{
+									{
+										TargetGroupArn: aws.String("tgArn"),
+										Weight:         aws.Int64(1),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -774,9 +890,19 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					Port:            aws.Int64(80),
 					DefaultActions: []*elbv2.Action{
 						{
-							Order:          aws.Int64(1),
-							TargetGroupArn: aws.String("tgArn"),
-							Type:           aws.String(elbv2.ActionTypeEnumForward),
+							Order: aws.Int64(1),
+							Type:  aws.String(elbv2.ActionTypeEnumForward),
+							ForwardConfig: &elbv2.ForwardActionConfig{
+								TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+									Enabled: aws.Bool(false),
+								},
+								TargetGroups: []*elbv2.TargetGroupTuple{
+									{
+										TargetGroupArn: aws.String("tgArn"),
+										Weight:         aws.Int64(1),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -827,9 +953,19 @@ func TestDefaultController_Reconcile(t *testing.T) {
 					Port:            aws.Int64(80),
 					DefaultActions: []*elbv2.Action{
 						{
-							Order:          aws.Int64(1),
-							TargetGroupArn: aws.String("tgArn"),
-							Type:           aws.String(elbv2.ActionTypeEnumForward),
+							Order: aws.Int64(1),
+							Type:  aws.String(elbv2.ActionTypeEnumForward),
+							ForwardConfig: &elbv2.ForwardActionConfig{
+								TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+									Enabled: aws.Bool(false),
+								},
+								TargetGroups: []*elbv2.TargetGroupTuple{
+									{
+										TargetGroupArn: aws.String("tgArn"),
+										Weight:         aws.Int64(1),
+									},
+								},
+							},
 						},
 					},
 				},

--- a/internal/alb/ls/rules.go
+++ b/internal/alb/ls/rules.go
@@ -3,9 +3,11 @@ package ls
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"sort"
 	"strconv"
+
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/conditions"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/alb/tg"
@@ -135,7 +137,7 @@ func (c *rulesController) getDesiredRules(ctx context.Context, listener *elbv2.L
 			if err != nil {
 				return nil, err
 			}
-			elbConditions := buildConditions(ctx, ingressRule, path)
+			elbConditions := buildConditions(ctx, ingressAnnos, ingressRule, path)
 			elbRule := elbv2.Rule{
 				IsDefault:  aws.Bool(false),
 				Priority:   aws.String(strconv.Itoa(nextPriority)),
@@ -172,22 +174,26 @@ func (c *rulesController) getCurrentRules(ctx context.Context, listenerArn strin
 
 // buildActions will build listener rule actions for specific authCfg and backend
 func buildActions(ctx context.Context, authCfg auth.Config, ingressAnnos *annotations.Ingress, backend extensions.IngressBackend, tgGroup tg.TargetGroupGroup) ([]*elbv2.Action, error) {
-	var actions []*elbv2.Action
+	var elbActions []*elbv2.Action
 
 	// Handle auth actions
 	authAction := buildAuthAction(ctx, authCfg)
 	if authAction != nil {
-		actions = append(actions, authAction)
+		elbActions = append(elbActions, authAction)
 	}
 
 	// Handle backend actions
 	if action.Use(backend.ServicePort.String()) {
 		// backend is based on annotation
-		backendAction, err := ingressAnnos.Action.GetAction(backend.ServiceName)
+		annotationAction, err := ingressAnnos.Action.GetAction(backend.ServiceName)
 		if err != nil {
 			return nil, err
 		}
-		actions = append(actions, &backendAction)
+		annotationELBAction, err := buildAnnotationAction(ctx, annotationAction, tgGroup)
+		if err != nil {
+			return nil, err
+		}
+		elbActions = append(elbActions, annotationELBAction)
 	} else {
 		// backend is based on service
 		targetGroup, ok := tgGroup.TGByBackend[backend]
@@ -196,30 +202,111 @@ func buildActions(ctx context.Context, authCfg auth.Config, ingressAnnos *annota
 				backend.ServiceName, backend.ServicePort.String())
 		}
 		backendAction := elbv2.Action{
-			Type:           aws.String(elbv2.ActionTypeEnumForward),
-			TargetGroupArn: aws.String(targetGroup.Arn),
+			Type: aws.String(elbv2.ActionTypeEnumForward),
+			ForwardConfig: &elbv2.ForwardActionConfig{
+				TargetGroups: []*elbv2.TargetGroupTuple{
+					{
+						TargetGroupArn: aws.String(targetGroup.Arn),
+						Weight:         aws.Int64(1),
+					},
+				},
+				TargetGroupStickinessConfig: &elbv2.TargetGroupStickinessConfig{
+					Enabled: aws.Bool(false),
+				},
+			},
 		}
-		actions = append(actions, &backendAction)
+		elbActions = append(elbActions, &backendAction)
 	}
 
-	for index, action := range actions {
-		action.Order = aws.Int64(int64(index) + 1)
+	for index, elbAction := range elbActions {
+		elbAction.Order = aws.Int64(int64(index) + 1)
 	}
-	return actions, nil
+	return elbActions, nil
 }
 
 // buildConditions will build listener rule conditions for specific ingressRule
-func buildConditions(ctx context.Context, rule extensions.IngressRule, path extensions.HTTPIngressPath) []*elbv2.RuleCondition {
-	var conditions []*elbv2.RuleCondition
+func buildConditions(ctx context.Context, ingressAnnos *annotations.Ingress, rule extensions.IngressRule, path extensions.HTTPIngressPath) []*elbv2.RuleCondition {
+	var elbConditions []*elbv2.RuleCondition
+
+	hostHeaderConfig := &elbv2.HostHeaderConditionConfig{
+		Values: nil,
+	}
+	pathPatternConfig := &elbv2.PathPatternConditionConfig{
+		Values: nil,
+	}
 	if rule.Host != "" {
-		conditions = append(conditions, condition("host-header", rule.Host))
+		hostHeaderConfig.Values = append(hostHeaderConfig.Values, aws.String(rule.Host))
 	}
 	if path.Path != "" {
-		conditions = append(conditions, condition("path-pattern", path.Path))
-	} else if len(conditions) == 0 {
-		conditions = append(conditions, condition("path-pattern", "/*"))
+		pathPatternConfig.Values = append(pathPatternConfig.Values, aws.String(path.Path))
 	}
-	return conditions
+	annotationConditions := ingressAnnos.Conditions.GetConditions(path.Backend.ServiceName)
+	for _, condition := range annotationConditions {
+		switch aws.StringValue(condition.Field) {
+		case conditions.FieldHostHeader:
+			hostHeaderConfig.Values = append(hostHeaderConfig.Values, condition.HostHeaderConfig.Values...)
+		case conditions.FieldPathPattern:
+			pathPatternConfig.Values = append(pathPatternConfig.Values, condition.PathPatternConfig.Values...)
+		case conditions.FieldHTTPRequestMethod:
+			elbConditions = append(elbConditions, &elbv2.RuleCondition{
+				Field: aws.String(conditions.FieldHTTPRequestMethod),
+				HttpRequestMethodConfig: &elbv2.HttpRequestMethodConditionConfig{
+					Values: condition.HttpRequestMethodConfig.Values,
+				},
+			})
+		case conditions.FieldSourceIP:
+			elbConditions = append(elbConditions, &elbv2.RuleCondition{
+				Field: aws.String(conditions.FieldSourceIP),
+				SourceIpConfig: &elbv2.SourceIpConditionConfig{
+					Values: condition.SourceIpConfig.Values,
+				},
+			})
+		case conditions.FieldHTTPHeader:
+			elbConditions = append(elbConditions, &elbv2.RuleCondition{
+				Field: aws.String(conditions.FieldHTTPHeader),
+				HttpHeaderConfig: &elbv2.HttpHeaderConditionConfig{
+					HttpHeaderName: condition.HttpHeaderConfig.HttpHeaderName,
+					Values:         condition.HttpHeaderConfig.Values,
+				},
+			})
+		case conditions.FieldQueryString:
+			var queryStringKVPairs []*elbv2.QueryStringKeyValuePair
+			for _, kv := range condition.QueryStringConfig.Values {
+				queryStringKVPairs = append(queryStringKVPairs, &elbv2.QueryStringKeyValuePair{
+					Key:   kv.Key,
+					Value: kv.Value,
+				})
+			}
+			elbConditions = append(elbConditions, &elbv2.RuleCondition{
+				Field: aws.String(conditions.FieldQueryString),
+				QueryStringConfig: &elbv2.QueryStringConditionConfig{
+					Values: queryStringKVPairs,
+				},
+			})
+		}
+	}
+
+	if len(hostHeaderConfig.Values) != 0 {
+		elbConditions = append(elbConditions, &elbv2.RuleCondition{
+			Field:            aws.String(conditions.FieldHostHeader),
+			HostHeaderConfig: hostHeaderConfig,
+		})
+	}
+	if len(pathPatternConfig.Values) != 0 {
+		elbConditions = append(elbConditions, &elbv2.RuleCondition{
+			Field:             aws.String(conditions.FieldPathPattern),
+			PathPatternConfig: pathPatternConfig,
+		})
+	}
+	if len(elbConditions) == 0 {
+		elbConditions = append(elbConditions, &elbv2.RuleCondition{
+			Field: aws.String(conditions.FieldPathPattern),
+			PathPatternConfig: &elbv2.PathPatternConditionConfig{
+				Values: []*string{aws.String("/*")},
+			},
+		})
+	}
+	return elbConditions
 }
 
 // buildAuthAction builds ELB action for specific authCfg.
@@ -267,6 +354,83 @@ func buildAuthAction(ctx context.Context, authCfg auth.Config) *elbv2.Action {
 	return nil
 }
 
+func buildAnnotationAction(ctx context.Context, action action.Action, tgGroup tg.TargetGroupGroup) (*elbv2.Action, error) {
+	switch aws.StringValue(action.Type) {
+	case elbv2.ActionTypeEnumFixedResponse:
+		return &elbv2.Action{
+			Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
+			FixedResponseConfig: &elbv2.FixedResponseActionConfig{
+				ContentType: action.FixedResponseConfig.ContentType,
+				MessageBody: action.FixedResponseConfig.MessageBody,
+				StatusCode:  action.FixedResponseConfig.StatusCode,
+			},
+		}, nil
+	case elbv2.ActionTypeEnumRedirect:
+		return &elbv2.Action{
+			Type: aws.String(elbv2.ActionTypeEnumRedirect),
+			RedirectConfig: &elbv2.RedirectActionConfig{
+				Host:       action.RedirectConfig.Host,
+				Path:       action.RedirectConfig.Path,
+				Port:       action.RedirectConfig.Port,
+				Protocol:   action.RedirectConfig.Protocol,
+				Query:      action.RedirectConfig.Query,
+				StatusCode: action.RedirectConfig.StatusCode,
+			},
+		}, nil
+	case elbv2.ActionTypeEnumForward:
+		return buildAnnotationForwardAction(ctx, action, tgGroup)
+	}
+	return nil, errors.Errorf("unknown action type: %v", aws.StringValue(action.Type))
+}
+
+func buildAnnotationForwardAction(ctx context.Context, action action.Action, tgGroup tg.TargetGroupGroup) (*elbv2.Action, error) {
+	var elbTGs []*elbv2.TargetGroupTuple
+	for _, tgt := range action.ForwardConfig.TargetGroups {
+		normalizedWeight := tgt.Weight
+		if normalizedWeight == nil {
+			normalizedWeight = aws.Int64(1)
+		}
+		if tgt.TargetGroupArn != nil {
+			elbTGs = append(elbTGs, &elbv2.TargetGroupTuple{
+				TargetGroupArn: tgt.TargetGroupArn,
+				Weight:         normalizedWeight,
+			})
+		} else {
+			backend := extensions.IngressBackend{
+				ServiceName: aws.StringValue(tgt.ServiceName),
+				ServicePort: intstr.Parse(aws.StringValue(tgt.ServicePort)),
+			}
+			targetGroup, ok := tgGroup.TGByBackend[backend]
+			if !ok {
+				return nil, errors.Errorf("unable to find targetGroup for backend %v:%v",
+					backend.ServiceName, backend.ServicePort.String())
+			}
+			elbTGs = append(elbTGs, &elbv2.TargetGroupTuple{
+				TargetGroupArn: aws.String(targetGroup.Arn),
+				Weight:         normalizedWeight,
+			})
+		}
+	}
+	elbAction := &elbv2.Action{
+		Type: aws.String(elbv2.ActionTypeEnumForward),
+		ForwardConfig: &elbv2.ForwardActionConfig{
+			TargetGroups: elbTGs,
+		},
+	}
+
+	if action.ForwardConfig.TargetGroupStickinessConfig != nil {
+		elbAction.ForwardConfig.TargetGroupStickinessConfig = &elbv2.TargetGroupStickinessConfig{
+			DurationSeconds: action.ForwardConfig.TargetGroupStickinessConfig.DurationSeconds,
+			Enabled:         action.ForwardConfig.TargetGroupStickinessConfig.Enabled,
+		}
+	} else {
+		elbAction.ForwardConfig.TargetGroupStickinessConfig = &elbv2.TargetGroupStickinessConfig{
+			Enabled: aws.Bool(false),
+		}
+	}
+	return elbAction, nil
+}
+
 // rulesChangeSets compares desired to current, returning a list of rules to add, modify and remove from current to match desired
 func rulesChangeSets(current, desired []elbv2.Rule) (add []elbv2.Rule, modify []elbv2.Rule, remove []elbv2.Rule) {
 	currentMap := make(map[string]elbv2.Rule, len(current))
@@ -291,70 +455,67 @@ func rulesChangeSets(current, desired []elbv2.Rule) (add []elbv2.Rule, modify []
 		desiredRule := desiredMap[key]
 		desiredRule.RuleArn = currentRule.RuleArn
 
-		sortConditions(currentRule.Conditions)
-		sortConditions(desiredRule.Conditions)
-		sortActions(currentRule.Actions)
-		sortActions(desiredRule.Actions)
-		if !reflect.DeepEqual(currentRule, desiredRule) {
+		if !ruleMatches(desiredRule, currentRule) {
 			modify = append(modify, desiredRule)
 		}
 	}
 	return add, modify, remove
 }
 
-func condition(field string, values ...string) *elbv2.RuleCondition {
-	return &elbv2.RuleCondition{
-		Field:  aws.String(field),
-		Values: aws.StringSlice(values),
-	}
-}
-
-func sortConditions(conditions []*elbv2.RuleCondition) {
-	for _, cond := range conditions {
-		sort.Slice(cond.Values, func(i, j int) bool { return aws.StringValue(cond.Values[i]) < aws.StringValue(cond.Values[j]) })
-	}
-
-	sort.Slice(conditions, func(i, j int) bool {
-		return aws.StringValue(conditions[i].Field) < aws.StringValue(conditions[j].Field)
-	})
-}
-
-func sortActions(actions []*elbv2.Action) {
-	sort.Slice(actions, func(i, j int) bool {
-		return aws.Int64Value(actions[i].Order) < aws.Int64Value(actions[j].Order)
-	})
-}
-
 // createsRedirectLoop checks whether specified rule creates redirectionLoop for listener of protocol & port
 func createsRedirectLoop(listener *elbv2.Listener, r elbv2.Rule) bool {
 	for _, action := range r.Actions {
-		var host, path *string
 		rc := action.RedirectConfig
 		if rc == nil {
 			continue
 		}
 
+		var hosts []string
+		var paths []string
 		for _, c := range r.Conditions {
-			if aws.StringValue(c.Field) == "host-header" {
-				host = c.Values[0]
-			}
-			if aws.StringValue(c.Field) == "path-pattern" {
-				path = c.Values[0]
+			switch aws.StringValue(c.Field) {
+			case conditions.FieldHostHeader:
+				hosts = append(hosts, aws.StringValueSlice(c.HostHeaderConfig.Values)...)
+			case conditions.FieldPathPattern:
+				paths = append(paths, aws.StringValueSlice(c.PathPatternConfig.Values)...)
 			}
 		}
 
-		if host == nil && aws.StringValue(rc.Host) != "#{host}" {
+		if len(hosts) == 0 && aws.StringValue(rc.Host) != "#{host}" {
 			return false
 		}
-		if host != nil && aws.StringValue(rc.Host) != aws.StringValue(host) && aws.StringValue(rc.Host) != "#{host}" {
+
+		if len(hosts) != 0 && aws.StringValue(rc.Host) != "#{host}" {
+			hostMatches := false
+			for _, host := range hosts {
+				if aws.StringValue(rc.Host) == host {
+					hostMatches = true
+					break
+				}
+			}
+			// it won't be redirect loop if none of the host condition matches
+			if !hostMatches {
+				return false
+			}
+		}
+
+		if len(paths) == 0 && aws.StringValue(rc.Path) != "/#{path}" {
 			return false
 		}
-		if path == nil && aws.StringValue(rc.Path) != "/#{path}" {
-			return false
+		if len(paths) != 0 && aws.StringValue(rc.Path) != "/#{path}" {
+			pathMatches := false
+			for _, path := range paths {
+				if aws.StringValue(rc.Path) == path {
+					pathMatches = true
+					break
+				}
+			}
+			// it won't be redirect loop if none of the path condition matches
+			if !pathMatches {
+				return false
+			}
 		}
-		if path != nil && aws.StringValue(rc.Path) != aws.StringValue(path) && aws.StringValue(rc.Path) != "/#{path}" {
-			return false
-		}
+
 		if aws.StringValue(rc.Port) != "#{port}" && aws.StringValue(rc.Port) != fmt.Sprintf("%v", aws.Int64Value(listener.Port)) {
 			return false
 		}

--- a/internal/alb/ls/rules_comp.go
+++ b/internal/alb/ls/rules_comp.go
@@ -1,0 +1,186 @@
+package ls
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/aws"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/conditions"
+)
+
+// ruleMatches checks whether current rule matches desired rule.
+func ruleMatches(desired elbv2.Rule, current elbv2.Rule) bool {
+	return actionsMatches(desired.Actions, current.Actions) &&
+		conditionsMatches(desired.Conditions, current.Conditions)
+}
+
+// actionsMatches checks whether current actions matches desired actions
+// the actions is compared based on their order.
+func actionsMatches(desired []*elbv2.Action, current []*elbv2.Action) bool {
+	sortedDesired := sortedActions(desired)
+	sortedCurrent := sortedActions(current)
+	if len(sortedDesired) != len(sortedCurrent) {
+		return false
+	}
+	for i := range sortedDesired {
+		if !actionMatches(sortedDesired[i], sortedCurrent[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// conditionsMatches checks whether current conditions matches desired conditions
+func conditionsMatches(desired []*elbv2.RuleCondition, current []*elbv2.RuleCondition) bool {
+	return sliceMatches(desired, current, func(i interface{}, j interface{}) bool {
+		return conditionMatches(i.(*elbv2.RuleCondition), j.(*elbv2.RuleCondition))
+	})
+}
+
+// sortedActions returns sorted actions based on action order.
+func sortedActions(actions []*elbv2.Action) []*elbv2.Action {
+	actionsClone := make([]*elbv2.Action, len(actions))
+	copy(actionsClone, actions)
+	sort.Slice(actionsClone, func(i, j int) bool {
+		return aws.Int64Value(actionsClone[i].Order) < aws.Int64Value(actionsClone[j].Order)
+	})
+	return actionsClone
+}
+
+// actionMatches checks whether current action matches desired action
+func actionMatches(desired *elbv2.Action, current *elbv2.Action) bool {
+	if aws.StringValue(desired.Type) != aws.StringValue(current.Type) {
+		return false
+	}
+	switch aws.StringValue(desired.Type) {
+	case elbv2.ActionTypeEnumAuthenticateOidc:
+		return reflect.DeepEqual(desired.AuthenticateOidcConfig, current.AuthenticateOidcConfig)
+	case elbv2.ActionTypeEnumAuthenticateCognito:
+		return reflect.DeepEqual(desired.AuthenticateCognitoConfig, current.AuthenticateCognitoConfig)
+	case elbv2.ActionTypeEnumRedirect:
+		return reflect.DeepEqual(desired.RedirectConfig, current.RedirectConfig)
+	case elbv2.ActionTypeEnumFixedResponse:
+		return reflect.DeepEqual(desired.FixedResponseConfig, current.FixedResponseConfig)
+	case elbv2.ActionTypeEnumForward:
+		return reflect.DeepEqual(desired.ForwardConfig, current.ForwardConfig)
+	}
+	return false
+}
+
+func conditionMatches(desired *elbv2.RuleCondition, current *elbv2.RuleCondition) bool {
+	if aws.StringValue(desired.Field) != aws.StringValue(current.Field) {
+		return false
+	}
+	switch aws.StringValue(desired.Field) {
+	case conditions.FieldHostHeader:
+		return hostHeaderConditionConfigMatches(desired.HostHeaderConfig, current.HostHeaderConfig)
+	case conditions.FieldPathPattern:
+		return pathPatternConditionConfigMatches(desired.PathPatternConfig, current.PathPatternConfig)
+	case conditions.FieldHTTPHeader:
+		return httpHeaderConditionConfigMatches(desired.HttpHeaderConfig, current.HttpHeaderConfig)
+	case conditions.FieldHTTPRequestMethod:
+		return httpRequestMethodConditionConfigMatches(desired.HttpRequestMethodConfig, current.HttpRequestMethodConfig)
+	case conditions.FieldQueryString:
+		return queryStringConditionConfigMatches(desired.QueryStringConfig, current.QueryStringConfig)
+	case conditions.FieldSourceIP:
+		return sourceIpConditionConfigMatches(desired.SourceIpConfig, current.SourceIpConfig)
+	}
+	return false
+}
+
+func hostHeaderConditionConfigMatches(desired *elbv2.HostHeaderConditionConfig, current *elbv2.HostHeaderConditionConfig) bool {
+	if desired == nil || current == nil {
+		return desired == current
+	}
+	return sliceMatches(desired.Values, current.Values, reflect.DeepEqual)
+}
+
+func pathPatternConditionConfigMatches(desired *elbv2.PathPatternConditionConfig, current *elbv2.PathPatternConditionConfig) bool {
+	if desired == nil || current == nil {
+		return desired == current
+	}
+	return sliceMatches(desired.Values, current.Values, reflect.DeepEqual)
+}
+
+func httpHeaderConditionConfigMatches(desired *elbv2.HttpHeaderConditionConfig, current *elbv2.HttpHeaderConditionConfig) bool {
+	if desired == nil || current == nil {
+		return desired == current
+	}
+	return (aws.StringValue(desired.HttpHeaderName) == aws.StringValue(current.HttpHeaderName)) &&
+		sliceMatches(desired.Values, current.Values, reflect.DeepEqual)
+}
+
+func httpRequestMethodConditionConfigMatches(desired *elbv2.HttpRequestMethodConditionConfig, current *elbv2.HttpRequestMethodConditionConfig) bool {
+	if desired == nil || current == nil {
+		return desired == current
+	}
+	return sliceMatches(desired.Values, current.Values, reflect.DeepEqual)
+}
+
+func queryStringConditionConfigMatches(desired *elbv2.QueryStringConditionConfig, current *elbv2.QueryStringConditionConfig) bool {
+	if desired == nil || current == nil {
+		return desired == current
+	}
+	return sliceMatches(desired.Values, current.Values, reflect.DeepEqual)
+}
+
+func sourceIpConditionConfigMatches(desired *elbv2.SourceIpConditionConfig, current *elbv2.SourceIpConditionConfig) bool {
+	if desired == nil || current == nil {
+		return desired == current
+	}
+	return sliceMatches(desired.Values, current.Values, reflect.DeepEqual)
+}
+
+// stringSliceMatches checks whether current slice matches desired slice, without comparing order.
+func stringSliceMatches(desired []*string, current []*string) bool {
+	if len(desired) != len(current) {
+		return false
+	}
+	visited := make([]bool, len(current))
+	for _, elemI := range desired {
+		found := false
+		for j, elemJ := range current {
+			if visited[j] {
+				continue
+			}
+			if aws.StringValue(elemI) == aws.StringValue(elemJ) {
+				visited[j] = true
+				found = true
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func sliceMatches(listA interface{}, listB interface{}, comparator func(interface{}, interface{}) bool) bool {
+	valueA := reflect.ValueOf(listA)
+	valueB := reflect.ValueOf(listB)
+	lenA := valueA.Len()
+	lenB := valueB.Len()
+	if lenA != lenB {
+		return false
+	}
+	visited := make([]bool, lenB)
+	for i := 0; i < lenA; i++ {
+		elem := valueA.Index(i).Interface()
+		found := false
+		for j := 0; j < lenB; j++ {
+			if visited[j] {
+				continue
+			}
+			if comparator(elem, valueB.Index(j).Interface()) {
+				visited[j] = true
+				found = true
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/alb/ls/rules_comp_test.go
+++ b/internal/alb/ls/rules_comp_test.go
@@ -1,0 +1,770 @@
+package ls
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/aws"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/conditions"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_actionsMatches(t *testing.T) {
+	type args struct {
+		desired []*elbv2.Action
+		current []*elbv2.Action
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "nil and empty conditions matches",
+			args: args{
+				desired: nil,
+				current: []*elbv2.Action{},
+			},
+			want: true,
+		},
+		{
+			name: "actions matches with order",
+			args: args{
+				desired: []*elbv2.Action{
+					{
+						Type: aws.String(elbv2.ActionTypeEnumAuthenticateOidc),
+						AuthenticateOidcConfig: &elbv2.AuthenticateOidcActionConfig{
+							ClientId: aws.String("oidc-client"),
+						},
+						Order: aws.Int64(1),
+					},
+					{
+						Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
+						FixedResponseConfig: &elbv2.FixedResponseActionConfig{
+							MessageBody: aws.String("hello world!"),
+							StatusCode:  aws.String("200"),
+						},
+						Order: aws.Int64(2),
+					},
+				},
+				current: []*elbv2.Action{
+					{
+						Type: aws.String(elbv2.ActionTypeEnumAuthenticateOidc),
+						AuthenticateOidcConfig: &elbv2.AuthenticateOidcActionConfig{
+							ClientId: aws.String("oidc-client"),
+						},
+						Order: aws.Int64(1),
+					},
+					{
+						Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
+						FixedResponseConfig: &elbv2.FixedResponseActionConfig{
+							MessageBody: aws.String("hello world!"),
+							StatusCode:  aws.String("200"),
+						},
+						Order: aws.Int64(2),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "actions matches without order",
+			args: args{
+				desired: []*elbv2.Action{
+					{
+						Type: aws.String(elbv2.ActionTypeEnumAuthenticateOidc),
+						AuthenticateOidcConfig: &elbv2.AuthenticateOidcActionConfig{
+							ClientId: aws.String("oidc-client"),
+						},
+						Order: aws.Int64(1),
+					},
+					{
+						Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
+						FixedResponseConfig: &elbv2.FixedResponseActionConfig{
+							MessageBody: aws.String("hello world!"),
+							StatusCode:  aws.String("200"),
+						},
+						Order: aws.Int64(2),
+					},
+				},
+				current: []*elbv2.Action{
+					{
+						Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
+						FixedResponseConfig: &elbv2.FixedResponseActionConfig{
+							MessageBody: aws.String("hello world!"),
+							StatusCode:  aws.String("200"),
+						},
+						Order: aws.Int64(2),
+					},
+					{
+						Type: aws.String(elbv2.ActionTypeEnumAuthenticateOidc),
+						AuthenticateOidcConfig: &elbv2.AuthenticateOidcActionConfig{
+							ClientId: aws.String("oidc-client"),
+						},
+						Order: aws.Int64(1),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "actions mismatches - mismatched order",
+			args: args{
+				desired: []*elbv2.Action{
+					{
+						Type: aws.String(elbv2.ActionTypeEnumAuthenticateOidc),
+						AuthenticateOidcConfig: &elbv2.AuthenticateOidcActionConfig{
+							ClientId: aws.String("oidc-client"),
+						},
+						Order: aws.Int64(1),
+					},
+					{
+						Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
+						FixedResponseConfig: &elbv2.FixedResponseActionConfig{
+							MessageBody: aws.String("hello world!"),
+							StatusCode:  aws.String("200"),
+						},
+						Order: aws.Int64(2),
+					},
+				},
+				current: []*elbv2.Action{
+					{
+						Type: aws.String(elbv2.ActionTypeEnumAuthenticateOidc),
+						AuthenticateOidcConfig: &elbv2.AuthenticateOidcActionConfig{
+							ClientId: aws.String("oidc-client"),
+						},
+						Order: aws.Int64(2),
+					},
+					{
+						Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
+						FixedResponseConfig: &elbv2.FixedResponseActionConfig{
+							MessageBody: aws.String("hello world!"),
+							StatusCode:  aws.String("200"),
+						},
+						Order: aws.Int64(1),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "actions mismatches - mismatched action",
+			args: args{
+				desired: []*elbv2.Action{
+					{
+						Type: aws.String(elbv2.ActionTypeEnumAuthenticateOidc),
+						AuthenticateOidcConfig: &elbv2.AuthenticateOidcActionConfig{
+							ClientId: aws.String("oidc-client"),
+						},
+						Order: aws.Int64(1),
+					},
+					{
+						Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
+						FixedResponseConfig: &elbv2.FixedResponseActionConfig{
+							MessageBody: aws.String("hello world!"),
+							StatusCode:  aws.String("200"),
+						},
+						Order: aws.Int64(2),
+					},
+				},
+				current: []*elbv2.Action{
+					{
+						Type: aws.String(elbv2.ActionTypeEnumAuthenticateOidc),
+						AuthenticateOidcConfig: &elbv2.AuthenticateOidcActionConfig{
+							ClientId: aws.String("oidc-client"),
+						},
+						Order: aws.Int64(1),
+					},
+					{
+						Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
+						FixedResponseConfig: &elbv2.FixedResponseActionConfig{
+							MessageBody: aws.String("hello world!"),
+							StatusCode:  aws.String("201"),
+						},
+						Order: aws.Int64(2),
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := actionsMatches(tt.args.desired, tt.args.current); got != tt.want {
+				t.Errorf("actionsMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_conditionsMatches(t *testing.T) {
+	type args struct {
+		desired []*elbv2.RuleCondition
+		current []*elbv2.RuleCondition
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "nil and empty conditions matches",
+			args: args{
+				desired: nil,
+				current: []*elbv2.RuleCondition{},
+			},
+			want: true,
+		},
+		{
+			name: "conditions matches with order",
+			args: args{
+				desired: []*elbv2.RuleCondition{
+					{
+						Field: aws.String(conditions.FieldHostHeader),
+						HostHeaderConfig: &elbv2.HostHeaderConditionConfig{
+							Values: aws.StringSlice([]string{"a.example.com", "b.example.com"}),
+						},
+					},
+					{
+						Field: aws.String(conditions.FieldQueryString),
+						QueryStringConfig: &elbv2.QueryStringConditionConfig{
+							Values: []*elbv2.QueryStringKeyValuePair{
+								{
+									Key:   aws.String("version"),
+									Value: aws.String("v1"),
+								},
+								{
+									Value: aws.String("example"),
+								},
+							},
+						},
+					},
+					{
+						Field: aws.String(conditions.FieldQueryString),
+						QueryStringConfig: &elbv2.QueryStringConditionConfig{
+							Values: []*elbv2.QueryStringKeyValuePair{
+								{
+									Key:   aws.String("username"),
+									Value: aws.String("m00nf1sh"),
+								},
+							},
+						},
+					},
+				},
+				current: []*elbv2.RuleCondition{
+					{
+						Field: aws.String(conditions.FieldHostHeader),
+						HostHeaderConfig: &elbv2.HostHeaderConditionConfig{
+							Values: aws.StringSlice([]string{"a.example.com", "b.example.com"}),
+						},
+					},
+					{
+						Field: aws.String(conditions.FieldQueryString),
+						QueryStringConfig: &elbv2.QueryStringConditionConfig{
+							Values: []*elbv2.QueryStringKeyValuePair{
+								{
+									Key:   aws.String("version"),
+									Value: aws.String("v1"),
+								},
+								{
+									Value: aws.String("example"),
+								},
+							},
+						},
+					},
+					{
+						Field: aws.String(conditions.FieldQueryString),
+						QueryStringConfig: &elbv2.QueryStringConditionConfig{
+							Values: []*elbv2.QueryStringKeyValuePair{
+								{
+									Key:   aws.String("username"),
+									Value: aws.String("m00nf1sh"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "conditions matches without order",
+			args: args{
+				desired: []*elbv2.RuleCondition{
+					{
+						Field: aws.String(conditions.FieldHostHeader),
+						HostHeaderConfig: &elbv2.HostHeaderConditionConfig{
+							Values: aws.StringSlice([]string{"a.example.com", "b.example.com"}),
+						},
+					},
+					{
+						Field: aws.String(conditions.FieldQueryString),
+						QueryStringConfig: &elbv2.QueryStringConditionConfig{
+							Values: []*elbv2.QueryStringKeyValuePair{
+								{
+									Key:   aws.String("version"),
+									Value: aws.String("v1"),
+								},
+								{
+									Value: aws.String("example"),
+								},
+							},
+						},
+					},
+					{
+						Field: aws.String(conditions.FieldQueryString),
+						QueryStringConfig: &elbv2.QueryStringConditionConfig{
+							Values: []*elbv2.QueryStringKeyValuePair{
+								{
+									Key:   aws.String("username"),
+									Value: aws.String("m00nf1sh"),
+								},
+							},
+						},
+					},
+				},
+				current: []*elbv2.RuleCondition{
+					{
+						Field: aws.String(conditions.FieldHostHeader),
+						HostHeaderConfig: &elbv2.HostHeaderConditionConfig{
+							Values: aws.StringSlice([]string{"b.example.com", "a.example.com"}),
+						},
+					},
+					{
+						Field: aws.String(conditions.FieldQueryString),
+						QueryStringConfig: &elbv2.QueryStringConditionConfig{
+							Values: []*elbv2.QueryStringKeyValuePair{
+								{
+									Key:   aws.String("username"),
+									Value: aws.String("m00nf1sh"),
+								},
+							},
+						},
+					},
+					{
+						Field: aws.String(conditions.FieldQueryString),
+						QueryStringConfig: &elbv2.QueryStringConditionConfig{
+							Values: []*elbv2.QueryStringKeyValuePair{
+								{
+									Value: aws.String("example"),
+								},
+								{
+									Key:   aws.String("version"),
+									Value: aws.String("v1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "conditions mismatch",
+			args: args{
+				desired: []*elbv2.RuleCondition{
+					{
+						Field: aws.String(conditions.FieldHostHeader),
+						HostHeaderConfig: &elbv2.HostHeaderConditionConfig{
+							Values: aws.StringSlice([]string{"a.example.com", "b.example.com"}),
+						},
+					},
+				},
+				current: []*elbv2.RuleCondition{
+					{
+						Field: aws.String(conditions.FieldHostHeader),
+						HostHeaderConfig: &elbv2.HostHeaderConditionConfig{
+							Values: aws.StringSlice([]string{"a.example.com", "c.example.com"}),
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "conditions mismatch - missing condition",
+			args: args{
+				desired: []*elbv2.RuleCondition{
+					{
+						Field: aws.String(conditions.FieldHostHeader),
+						HostHeaderConfig: &elbv2.HostHeaderConditionConfig{
+							Values: aws.StringSlice([]string{"a.example.com", "b.example.com"}),
+						},
+					},
+					{
+						Field: aws.String(conditions.FieldQueryString),
+						QueryStringConfig: &elbv2.QueryStringConditionConfig{
+							Values: []*elbv2.QueryStringKeyValuePair{
+								{
+									Key:   aws.String("username"),
+									Value: aws.String("m00nf1sh"),
+								},
+							},
+						},
+					},
+				},
+				current: []*elbv2.RuleCondition{
+					{
+						Field: aws.String(conditions.FieldHostHeader),
+						HostHeaderConfig: &elbv2.HostHeaderConditionConfig{
+							Values: aws.StringSlice([]string{"a.example.com", "b.example.com"}),
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "conditions mismatch - extra condition",
+			args: args{
+				desired: []*elbv2.RuleCondition{
+					{
+						Field: aws.String(conditions.FieldHostHeader),
+						HostHeaderConfig: &elbv2.HostHeaderConditionConfig{
+							Values: aws.StringSlice([]string{"a.example.com", "b.example.com"}),
+						},
+					},
+				},
+				current: []*elbv2.RuleCondition{
+					{
+						Field: aws.String(conditions.FieldHostHeader),
+						HostHeaderConfig: &elbv2.HostHeaderConditionConfig{
+							Values: aws.StringSlice([]string{"a.example.com", "b.example.com"}),
+						},
+					},
+					{
+						Field: aws.String(conditions.FieldQueryString),
+						QueryStringConfig: &elbv2.QueryStringConditionConfig{
+							Values: []*elbv2.QueryStringKeyValuePair{
+								{
+									Key:   aws.String("username"),
+									Value: aws.String("m00nf1sh"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := conditionsMatches(tt.args.desired, tt.args.current); got != tt.want {
+				t.Errorf("conditionsMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_sliceMatches(t *testing.T) {
+	type args struct {
+		desired []*string
+		current []*string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "nil and empty slice matches",
+			args: args{
+				desired: nil,
+				current: []*string{},
+			},
+			want: true,
+		},
+		{
+			name: "elements matches with order",
+			args: args{
+				desired: aws.StringSlice([]string{"a", "b", "c"}),
+				current: aws.StringSlice([]string{"a", "b", "c"}),
+			},
+			want: true,
+		},
+		{
+			name: "elements matches without order",
+			args: args{
+				desired: aws.StringSlice([]string{"a", "b", "c"}),
+				current: aws.StringSlice([]string{"b", "a", "c"}),
+			},
+			want: true,
+		},
+		{
+			name: "elements length mismatch",
+			args: args{
+				desired: aws.StringSlice([]string{"a", "b"}),
+				current: aws.StringSlice([]string{"a", "b", "c"}),
+			},
+			want: false,
+		},
+		{
+			name: "elements occurrence mismatch",
+			args: args{
+				desired: aws.StringSlice([]string{"a", "a", "b"}),
+				current: aws.StringSlice([]string{"a", "b", "c"}),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stringSliceMatches(tt.args.desired, tt.args.current); got != tt.want {
+				t.Errorf("sliceMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_httpHeaderConditionConfigMatches(t *testing.T) {
+	type args struct {
+		desired *elbv2.HttpHeaderConditionConfig
+		current *elbv2.HttpHeaderConditionConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "header condition mismatch if desired nil while current non-nil",
+			args: args{
+				desired: nil,
+				current: &elbv2.HttpHeaderConditionConfig{
+					HttpHeaderName: aws.String("header1"),
+					Values:         aws.StringSlice([]string{"value1"}),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "header condition mismatch if header name mismatch",
+			args: args{
+				desired: &elbv2.HttpHeaderConditionConfig{
+					HttpHeaderName: aws.String("header1"),
+					Values:         aws.StringSlice([]string{"value1"}),
+				},
+				current: &elbv2.HttpHeaderConditionConfig{
+					HttpHeaderName: aws.String("header2"),
+					Values:         aws.StringSlice([]string{"value1"}),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "header condition mismatch if header values mismatch",
+			args: args{
+				desired: &elbv2.HttpHeaderConditionConfig{
+					HttpHeaderName: aws.String("header1"),
+					Values:         aws.StringSlice([]string{"value1"}),
+				},
+				current: &elbv2.HttpHeaderConditionConfig{
+					HttpHeaderName: aws.String("header1"),
+					Values:         aws.StringSlice([]string{"value2"}),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "header condition matches without values order",
+			args: args{
+				desired: &elbv2.HttpHeaderConditionConfig{
+					HttpHeaderName: aws.String("header1"),
+					Values:         aws.StringSlice([]string{"value1", "value2"}),
+				},
+				current: &elbv2.HttpHeaderConditionConfig{
+					HttpHeaderName: aws.String("header1"),
+					Values:         aws.StringSlice([]string{"value2", "value1"}),
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := httpHeaderConditionConfigMatches(tt.args.desired, tt.args.current); got != tt.want {
+				t.Errorf("httpHeaderConditionConfigMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_queryStringConditionConfigMatches(t *testing.T) {
+	type args struct {
+		desired *elbv2.QueryStringConditionConfig
+		current *elbv2.QueryStringConditionConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "query string condition mismatch if desired nil while current non-nil",
+			args: args{
+				desired: nil,
+				current: &elbv2.QueryStringConditionConfig{Values: []*elbv2.QueryStringKeyValuePair{
+					{
+						Key:   aws.String("param1"),
+						Value: aws.String("value1"),
+					},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "query string condition mismatch if desired key-pair is less than current",
+			args: args{
+				desired: &elbv2.QueryStringConditionConfig{Values: []*elbv2.QueryStringKeyValuePair{
+					{
+						Key:   aws.String("param1"),
+						Value: aws.String("value1"),
+					},
+				}},
+				current: &elbv2.QueryStringConditionConfig{Values: []*elbv2.QueryStringKeyValuePair{
+					{
+						Key:   aws.String("param1"),
+						Value: aws.String("value1"),
+					},
+					{
+						Key:   aws.String("param2"),
+						Value: aws.String("value2"),
+					},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "query string condition mismatch if desired key-pair is more than current",
+			args: args{
+				desired: &elbv2.QueryStringConditionConfig{Values: []*elbv2.QueryStringKeyValuePair{
+					{
+						Key:   aws.String("param1"),
+						Value: aws.String("value1"),
+					},
+					{
+						Key:   aws.String("param2"),
+						Value: aws.String("value2"),
+					},
+				}},
+				current: &elbv2.QueryStringConditionConfig{Values: []*elbv2.QueryStringKeyValuePair{
+					{
+						Key:   aws.String("param1"),
+						Value: aws.String("value1"),
+					},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "query string condition mismatch if desired and current keyPair key mismatch",
+			args: args{
+				desired: &elbv2.QueryStringConditionConfig{Values: []*elbv2.QueryStringKeyValuePair{
+					{
+						Key:   aws.String("param1"),
+						Value: aws.String("value1"),
+					},
+				}},
+				current: &elbv2.QueryStringConditionConfig{Values: []*elbv2.QueryStringKeyValuePair{
+					{
+						Key:   aws.String("param2"),
+						Value: aws.String("value1"),
+					},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "query string condition mismatch if desired and current keyPair value mismatch",
+			args: args{
+				desired: &elbv2.QueryStringConditionConfig{Values: []*elbv2.QueryStringKeyValuePair{
+					{
+						Key:   aws.String("param1"),
+						Value: aws.String("value1"),
+					},
+				}},
+				current: &elbv2.QueryStringConditionConfig{Values: []*elbv2.QueryStringKeyValuePair{
+					{
+						Key:   aws.String("param1"),
+						Value: aws.String("value2"),
+					},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "query string condition matches if desired and current keyPair matches without order",
+			args: args{
+				desired: &elbv2.QueryStringConditionConfig{Values: []*elbv2.QueryStringKeyValuePair{
+					{
+						Key:   aws.String("param1"),
+						Value: aws.String("value1"),
+					},
+					{
+						Key:   aws.String("param2"),
+						Value: aws.String("value2"),
+					},
+				}},
+				current: &elbv2.QueryStringConditionConfig{Values: []*elbv2.QueryStringKeyValuePair{
+					{
+						Key:   aws.String("param2"),
+						Value: aws.String("value2"),
+					},
+					{
+						Key:   aws.String("param1"),
+						Value: aws.String("value1"),
+					},
+				}},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := queryStringConditionConfigMatches(tt.args.desired, tt.args.current); got != tt.want {
+				t.Errorf("queryStringConditionConfigMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_sortActions(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		actions         []*elbv2.Action
+		expectedActions []*elbv2.Action
+	}{
+		{
+			name: "sort based on action order",
+			actions: []*elbv2.Action{
+				{
+					Order: aws.Int64(3),
+				},
+				{
+					Order: aws.Int64(1),
+				},
+				{
+					Order: aws.Int64(2),
+				},
+			},
+			expectedActions: []*elbv2.Action{
+				{
+					Order: aws.Int64(1),
+				},
+				{
+					Order: aws.Int64(2),
+				},
+				{
+					Order: aws.Int64(3),
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actions := sortedActions(tc.actions)
+			assert.Equal(t, tc.expectedActions, actions)
+		})
+	}
+}

--- a/internal/alb/tg/targetgroup_group.go
+++ b/internal/alb/tg/targetgroup_group.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/albctx"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/alb/tags"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/albctx"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/aws"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/action"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/backend"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/controller/store"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/k8s"
 	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -38,6 +41,7 @@ func NewGroupController(
 	tgController := NewController(cloud, store, nameTagGen, tagsController, endpointResolver)
 	return &defaultGroupController{
 		cloud:        cloud,
+		store:        store,
 		nameTagGen:   nameTagGen,
 		tgController: tgController,
 	}
@@ -47,6 +51,7 @@ var _ GroupController = (*defaultGroupController)(nil)
 
 type defaultGroupController struct {
 	cloud      aws.CloudAPI
+	store      store.Storer
 	nameTagGen NameTagGenerator
 
 	tgController Controller
@@ -54,11 +59,12 @@ type defaultGroupController struct {
 
 func (controller *defaultGroupController) Reconcile(ctx context.Context, ingress *extensions.Ingress) (TargetGroupGroup, error) {
 	tgByBackend := make(map[extensions.IngressBackend]TargetGroup)
-	var err error
-	for _, backend := range controller.extractIngressBackends(ingress) {
-		if action.Use(backend.ServicePort.String()) {
-			continue
-		}
+
+	backends, err := controller.extractTargetGroupBackends(ingress)
+	if err != nil {
+		return TargetGroupGroup{}, err
+	}
+	for _, backend := range backends {
 		if _, ok := tgByBackend[backend]; ok {
 			continue
 		}
@@ -106,19 +112,47 @@ func (controller *defaultGroupController) Delete(ctx context.Context, ingressKey
 	return controller.GC(ctx, tgGroup)
 }
 
-// TODO, should be k8s utils :D
-func (controller *defaultGroupController) extractIngressBackends(ingress *extensions.Ingress) []extensions.IngressBackend {
-	var output []extensions.IngressBackend
+func (controller *defaultGroupController) extractTargetGroupBackends(ingress *extensions.Ingress) ([]extensions.IngressBackend, error) {
+	var rawIngBackends []extensions.IngressBackend
 	if ingress.Spec.Backend != nil {
-		output = append(output, *ingress.Spec.Backend)
+		rawIngBackends = append(rawIngBackends, *ingress.Spec.Backend)
 	}
 	for _, rule := range ingress.Spec.Rules {
 		if rule.HTTP == nil {
 			continue
 		}
 		for _, path := range rule.HTTP.Paths {
-			output = append(output, path.Backend)
+			rawIngBackends = append(rawIngBackends, path.Backend)
 		}
 	}
-	return output
+
+	var ingBackends []extensions.IngressBackend
+	for _, ingBackend := range rawIngBackends {
+		if action.Use(ingBackend.ServicePort.String()) {
+			continue
+		}
+		ingBackends = append(ingBackends, ingBackend)
+	}
+
+	ingAnnos, err := controller.store.GetIngressAnnotations(k8s.MetaNamespaceKey(ingress))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, action := range ingAnnos.Action.Actions {
+		if aws.StringValue(action.Type) != elbv2.ActionTypeEnumForward {
+			continue
+		}
+
+		for _, tgt := range action.ForwardConfig.TargetGroups {
+			if tgt.ServiceName != nil {
+				ingBackends = append(ingBackends, extensions.IngressBackend{
+					ServiceName: aws.StringValue(tgt.ServiceName),
+					ServicePort: intstr.Parse(aws.StringValue(tgt.ServicePort)),
+				})
+			}
+		}
+	}
+
+	return ingBackends, nil
 }

--- a/internal/ingress/annotations/action/main.go
+++ b/internal/ingress/annotations/action/main.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/errors"
 
@@ -19,21 +18,21 @@ const UseActionAnnotation = "use-annotation"
 const default404ServiceName = "Default 404"
 
 type Config struct {
-	Actions map[string]*elbv2.Action
+	Actions map[string]Action
 }
 
-type action struct {
+type actionParser struct {
 	r resolver.Resolver
 }
 
 // NewParser creates a new target group annotation parser
 func NewParser(r resolver.Resolver) parser.IngressAnnotation {
-	return action{r}
+	return &actionParser{r}
 }
 
 // Parse parses the annotations contained in the resource
-func (a action) Parse(ing parser.AnnotationInterface) (interface{}, error) {
-	actions := make(map[string]*elbv2.Action)
+func (a *actionParser) Parse(ing parser.AnnotationInterface) (interface{}, error) {
+	actions := make(map[string]Action)
 	annos, err := parser.GetStringAnnotations("actions", ing)
 	if err != nil {
 		if errors.IsMissingAnnotations(err) {
@@ -43,33 +42,16 @@ func (a action) Parse(ing parser.AnnotationInterface) (interface{}, error) {
 	}
 
 	for serviceName, raw := range annos {
-		var data *elbv2.Action
-		err := json.Unmarshal([]byte(raw), &data)
+		action := Action{}
+		err := json.Unmarshal([]byte(raw), &action)
 		if err != nil {
 			return nil, err
 		}
-		err = data.Validate()
-		if err != nil {
+		if err := action.validate(); err != nil {
 			return nil, err
 		}
-		switch *data.Type {
-		case "fixed-response":
-			if data.FixedResponseConfig == nil {
-				return nil, fmt.Errorf("%v is type fixed-response but did not include a valid FixedResponseConfig configuration", serviceName)
-			}
-		case "redirect":
-			if data.RedirectConfig == nil {
-				return nil, fmt.Errorf("%v is type redirect but did not include a valid RedirectConfig configuration", serviceName)
-			}
-		case "forward":
-			if data.TargetGroupArn == nil {
-				return nil, fmt.Errorf("%v is type forward but did not include a valid TargetGroupArn configuration", serviceName)
-			}
-		default:
-			return nil, fmt.Errorf("an invalid action type %v was configured in %v", *data.Type, serviceName)
-		}
-		setDefaults(data)
-		actions[serviceName] = data
+		action.setDefaults()
+		actions[serviceName] = action
 	}
 
 	return &Config{
@@ -78,18 +60,18 @@ func (a action) Parse(ing parser.AnnotationInterface) (interface{}, error) {
 }
 
 // GetAction returns the action named serviceName configured by an annotation
-func (c *Config) GetAction(serviceName string) (elbv2.Action, error) {
+func (c *Config) GetAction(serviceName string) (Action, error) {
 	if serviceName == default404ServiceName {
 		return default404Action(), nil
 	}
 
 	action, ok := c.Actions[serviceName]
 	if !ok {
-		return elbv2.Action{}, fmt.Errorf(
+		return Action{}, errors.Errorf(
 			"backend with `servicePort: %s` was configured with `serviceName: %v` but an action annotation for %v is not set",
 			UseActionAnnotation, serviceName, serviceName)
 	}
-	return *action, nil
+	return action, nil
 }
 
 // Use returns true if the parameter requested an annotation configured action
@@ -97,13 +79,12 @@ func Use(s string) bool {
 	return s == UseActionAnnotation
 }
 
-func default404Action() elbv2.Action {
-	return elbv2.Action{
-		Type: aws.String("fixed-response"),
-		FixedResponseConfig: &elbv2.FixedResponseActionConfig{
+func default404Action() Action {
+	return Action{
+		Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
+		FixedResponseConfig: &FixedResponseActionConfig{
 			ContentType: aws.String("text/plain"),
-			// MessageBody:
-			StatusCode: aws.String("404"),
+			StatusCode:  aws.String("404"),
 		},
 	}
 }
@@ -116,56 +97,47 @@ func Default404Backend() extensions.IngressBackend {
 	}
 }
 
-func setDefaults(d *elbv2.Action) *elbv2.Action {
-	if d.RedirectConfig != nil {
-		if d.RedirectConfig.Host == nil {
-			d.RedirectConfig.Host = aws.String("#{host}")
-		}
-		if d.RedirectConfig.Path == nil {
-			d.RedirectConfig.Path = aws.String("/#{path}")
-		}
-		if d.RedirectConfig.Port == nil {
-			d.RedirectConfig.Port = aws.String("#{port}")
-		}
-		if d.RedirectConfig.Protocol == nil {
-			d.RedirectConfig.Protocol = aws.String("#{protocol}")
-		}
-		if d.RedirectConfig.Query == nil {
-			d.RedirectConfig.Query = aws.String("#{query}")
-		}
-	}
-	return d
-}
-
 func Dummy() *Config {
+	redirectAction := Action{
+		Type: aws.String(elbv2.ActionTypeEnumRedirect),
+		RedirectConfig: &RedirectActionConfig{
+			Protocol:   aws.String(elbv2.ProtocolEnumHttps),
+			StatusCode: aws.String(elbv2.RedirectActionStatusCodeEnumHttp301),
+		},
+	}
+	redirectAction.setDefaults()
+
+	redirectPath2Action := Action{
+		Type: aws.String(elbv2.ActionTypeEnumRedirect),
+		RedirectConfig: &RedirectActionConfig{
+			Path:       aws.String("/#{path}2"),
+			StatusCode: aws.String(elbv2.RedirectActionStatusCodeEnumHttp301),
+		},
+	}
+	redirectPath2Action.setDefaults()
+
+	fixedResponseAction := Action{
+		Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
+		FixedResponseConfig: &FixedResponseActionConfig{
+			ContentType: aws.String("text/plain"),
+			StatusCode:  aws.String("503"),
+			MessageBody: aws.String("message body"),
+		},
+	}
+	fixedResponseAction.setDefaults()
+
+	forwardAction := Action{
+		Type:           aws.String(elbv2.ActionTypeEnumForward),
+		TargetGroupArn: aws.String("legacy-tg-arn"),
+	}
+	forwardAction.setDefaults()
+
 	return &Config{
-		Actions: map[string]*elbv2.Action{
-			"redirect": setDefaults(&elbv2.Action{
-				Type: aws.String(elbv2.ActionTypeEnumRedirect),
-				RedirectConfig: &elbv2.RedirectActionConfig{
-					Protocol:   aws.String(elbv2.ProtocolEnumHttps),
-					StatusCode: aws.String(elbv2.RedirectActionStatusCodeEnumHttp301),
-				},
-			}),
-			"redirect-path2": setDefaults(&elbv2.Action{
-				Type: aws.String(elbv2.ActionTypeEnumRedirect),
-				RedirectConfig: &elbv2.RedirectActionConfig{
-					Path:       aws.String("/#{path}2"),
-					StatusCode: aws.String(elbv2.RedirectActionStatusCodeEnumHttp301),
-				},
-			}),
-			"fixed-response-action": setDefaults(&elbv2.Action{
-				Type: aws.String(elbv2.ActionTypeEnumFixedResponse),
-				FixedResponseConfig: &elbv2.FixedResponseActionConfig{
-					ContentType: aws.String("text/plain"),
-					StatusCode:  aws.String("503"),
-					MessageBody: aws.String("message body"),
-				},
-			}),
-			"forward": setDefaults(&elbv2.Action{
-				Type:           aws.String(elbv2.ActionTypeEnumForward),
-				TargetGroupArn: aws.String("legacy-tg-arn"),
-			}),
+		Actions: map[string]Action{
+			"redirect":              redirectAction,
+			"redirect-path2":        redirectPath2Action,
+			"fixed-response-action": fixedResponseAction,
+			"forward":               forwardAction,
 		},
 	}
 }

--- a/internal/ingress/annotations/action/types.go
+++ b/internal/ingress/annotations/action/types.go
@@ -1,0 +1,214 @@
+package action
+
+import (
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/aws"
+	"github.com/pkg/errors"
+)
+
+// Information about an action that returns a custom HTTP response.
+type FixedResponseActionConfig struct {
+	// The content type.
+	//
+	// Valid Values: text/plain | text/css | text/html | application/javascript
+	// | application/json
+	ContentType *string
+
+	// The message.
+	MessageBody *string
+
+	// The HTTP response code (2XX, 4XX, or 5XX).
+	//
+	// StatusCode is a required field
+	StatusCode *string
+}
+
+// Information about an redirect action
+type RedirectActionConfig struct {
+	// The hostname. This component is not percent-encoded. The hostname can contain
+	// #{host}.
+	Host *string
+
+	// The absolute path, starting with the leading "/". This component is not percent-encoded.
+	// The path can contain #{host}, #{path}, and #{port}.
+	Path *string
+
+	// The port. You can specify a value from 1 to 65535 or #{port}.
+	Port *string
+
+	// The protocol. You can specify HTTP, HTTPS, or #{protocol}. You can redirect
+	// HTTP to HTTP, HTTP to HTTPS, and HTTPS to HTTPS. You cannot redirect HTTPS
+	// to HTTP.
+	Protocol *string
+
+	// The query parameters, URL-encoded when necessary, but not percent-encoded.
+	// Do not include the leading "?", as it is automatically added. You can specify
+	// any of the reserved keywords.
+	Query *string
+
+	// The HTTP redirect code. The redirect is either permanent (HTTP 301) or temporary
+	// (HTTP 302).
+	//
+	// StatusCode is a required field
+	StatusCode *string
+}
+
+func (c *RedirectActionConfig) validate() error {
+	if c.StatusCode == nil {
+		return errors.New("StatusCode is required")
+	}
+	return nil
+}
+
+func (c *RedirectActionConfig) setDefaults() {
+	if c.Host == nil {
+		c.Host = aws.String("#{host}")
+	}
+	if c.Path == nil {
+		c.Path = aws.String("/#{path}")
+	}
+	if c.Port == nil {
+		c.Port = aws.String("#{port}")
+	}
+	if c.Protocol == nil {
+		c.Protocol = aws.String("#{protocol}")
+	}
+	if c.Query == nil {
+		c.Query = aws.String("#{query}")
+	}
+}
+
+// Information about the target group stickiness for a rule.
+type TargetGroupStickinessConfig struct {
+	// The time period, in seconds, during which requests from a client should be
+	// routed to the same target group. The range is 1-604800 seconds (7 days).
+	DurationSeconds *int64
+
+	// Indicates whether target group stickiness is enabled.
+	Enabled *bool
+}
+
+// Information about how traffic will be distributed between multiple target
+// groups in a forward rule.
+type TargetGroupTuple struct {
+	// The Amazon Resource Name (ARN) of the target group.
+	TargetGroupArn *string
+
+	// the K8s service Name
+	ServiceName *string
+
+	// the K8s service port
+	ServicePort *string
+
+	// The weight. The range is 0 to 999.
+	Weight *int64
+}
+
+func (t *TargetGroupTuple) validate() error {
+	if (t.TargetGroupArn != nil) == (t.ServiceName != nil) {
+		return errors.New("precisely one of TargetGroupArn and ServiceName can be specified")
+	}
+
+	if t.ServiceName != nil && t.ServicePort == nil {
+		return errors.New("missing ServicePort")
+	}
+	return nil
+}
+
+// Information about a forward action.
+type ForwardActionConfig struct {
+	// The target group stickiness for the rule.
+	TargetGroupStickinessConfig *TargetGroupStickinessConfig
+
+	// One or more target groups. For Network Load Balancers, you can specify a
+	// single target group.
+	TargetGroups []*TargetGroupTuple
+}
+
+func (c *ForwardActionConfig) validate() error {
+	for _, t := range c.TargetGroups {
+		if err := t.validate(); err != nil {
+			return errors.Wrap(err, "invalid TargetGroupTuple")
+		}
+	}
+	if len(c.TargetGroups) > 1 {
+		for _, t := range c.TargetGroups {
+			if t.Weight == nil {
+				return errors.New("weight must be set when route to multiple target groups")
+			}
+		}
+	}
+	return nil
+}
+
+// Information about an action.
+type Action struct {
+	// The type of action.
+	//
+	// Type is a required field
+	Type *string
+
+	// The Amazon Resource Name (ARN) of the target group. Specify only when Type
+	// is forward and you want to route to a single target group. To route to one
+	// or more target groups, use ForwardConfig instead.
+	TargetGroupArn *string
+
+	// [Application Load Balancer] Information for creating an action that returns
+	// a custom HTTP response. Specify only when Type is fixed-response.
+	FixedResponseConfig *FixedResponseActionConfig
+
+	// Information for creating an action that distributes requests among one or
+	// more target groups. For Network Load Balancers, you can specify a single
+	// target group. Specify only when Type is forward. If you specify both ForwardConfig
+	// and TargetGroupArn, you can specify only one target group using ForwardConfig
+	// and it must be the same target group specified in TargetGroupArn.
+	ForwardConfig *ForwardActionConfig
+
+	// [Application Load Balancer] Information for creating a redirect action. Specify
+	// only when Type is redirect.
+	RedirectConfig *RedirectActionConfig
+}
+
+func (a *Action) validate() error {
+	switch aws.StringValue(a.Type) {
+	case elbv2.ActionTypeEnumFixedResponse:
+		if a.FixedResponseConfig == nil {
+			return errors.New("missing FixedResponseConfig")
+		}
+	case elbv2.ActionTypeEnumRedirect:
+		if a.RedirectConfig == nil {
+			return errors.New("missing RedirectConfig")
+		}
+		if err := a.RedirectConfig.validate(); err != nil {
+			return errors.Wrap(err, "invalid RedirectConfig")
+		}
+	case elbv2.ActionTypeEnumForward:
+		if (a.TargetGroupArn != nil) == (a.ForwardConfig != nil) {
+			return errors.New("precisely one of TargetGroupArn and ForwardConfig can be specified")
+		}
+		if a.ForwardConfig != nil {
+			if err := a.ForwardConfig.validate(); err != nil {
+				return errors.Wrap(err, "invalid ForwardConfig")
+			}
+		}
+	default:
+		return errors.Errorf("unknown action type: %v", *a.Type)
+	}
+	return nil
+}
+
+func (a *Action) setDefaults() {
+	if aws.StringValue(a.Type) == elbv2.ActionTypeEnumForward && a.TargetGroupArn != nil {
+		a.ForwardConfig = &ForwardActionConfig{
+			TargetGroups: []*TargetGroupTuple{
+				{
+					TargetGroupArn: a.TargetGroupArn,
+				},
+			},
+		}
+	}
+
+	if a.RedirectConfig != nil {
+		a.RedirectConfig.setDefaults()
+	}
+}

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/action"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/conditions"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/healthcheck"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/loadbalancer"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/parser"
@@ -46,6 +47,7 @@ type Ingress struct {
 	// TODO: found out why the ObjectMeta is needed?
 	metav1.ObjectMeta
 	Action       *action.Config
+	Conditions   *conditions.Config
 	HealthCheck  *healthcheck.Config
 	TargetGroup  *targetgroup.Config
 	LoadBalancer *loadbalancer.Config
@@ -71,6 +73,7 @@ func (s *Service) Merge(b *Ingress, cfg *config.Configuration) *Service {
 	return &Service{
 		ObjectMeta:   s.ObjectMeta,
 		Action:       s.Action,
+		Conditions:   s.Conditions,
 		LoadBalancer: s.LoadBalancer,
 		Tags:         s.Tags,
 		Error:        s.Error,
@@ -97,6 +100,7 @@ func NewIngressAnnotationExtractor(cfg resolver.Resolver) Extractor {
 	return Extractor{
 		map[string]parser.IngressAnnotation{
 			"Action":       action.NewParser(cfg),
+			"Conditions":   conditions.NewParser(),
 			"HealthCheck":  healthcheck.NewParser(cfg),
 			"TargetGroup":  targetgroup.NewParser(cfg),
 			"LoadBalancer": loadbalancer.NewParser(cfg),

--- a/internal/ingress/annotations/conditions/main.go
+++ b/internal/ingress/annotations/conditions/main.go
@@ -1,0 +1,67 @@
+package conditions
+
+import (
+	"encoding/json"
+
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/parser"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/errors"
+)
+
+const UseConditionAnnotation = "use-annotation"
+
+type Config struct {
+	Conditions map[string][]RuleCondition
+}
+
+// NewParser creates a new target group annotation parser
+func NewParser() parser.IngressAnnotation {
+	return &conditionsParser{}
+}
+
+type conditionsParser struct {
+}
+
+// Parse parses the annotations contained in the resource
+func (p *conditionsParser) Parse(ing parser.AnnotationInterface) (interface{}, error) {
+	conditionsByName := make(map[string][]RuleCondition)
+	annos, err := parser.GetStringAnnotations("conditions", ing)
+	if err != nil {
+		if errors.IsMissingAnnotations(err) {
+			return &Config{}, nil
+		}
+		return nil, err
+	}
+
+	for serviceName, raw := range annos {
+		var conditions []RuleCondition
+		err := json.Unmarshal([]byte(raw), &conditions)
+		if err != nil {
+			return nil, err
+		}
+		for _, condition := range conditions {
+			if err := condition.validate(); err != nil {
+				return nil, err
+			}
+		}
+
+		conditionsByName[serviceName] = conditions
+	}
+
+	return &Config{
+		Conditions: conditionsByName,
+	}, nil
+}
+
+// GetConditions returns the conditions named serviceName configured by an annotation
+func (c *Config) GetConditions(serviceName string) []RuleCondition {
+	conditions, ok := c.Conditions[serviceName]
+	if !ok {
+		return nil
+	}
+	return conditions
+}
+
+// Use returns true if the parameter requested an annotation configured action
+func Use(s string) bool {
+	return s == UseConditionAnnotation
+}

--- a/internal/ingress/annotations/conditions/main_test.go
+++ b/internal/ingress/annotations/conditions/main_test.go
@@ -1,0 +1,166 @@
+package conditions
+
+import (
+	"testing"
+
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/aws"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/parser"
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/controller/dummy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConditionsParse_Valid(t *testing.T) {
+	tcs := []struct {
+		name               string
+		conditionsJSON     string
+		expectedConditions []RuleCondition
+	}{
+		{
+			name:           "host-header",
+			conditionsJSON: `[{"field": "host-header","HostHeaderConfig": {"Values": ["www.example.com", "*.alb.example.com"]}}]`,
+			expectedConditions: []RuleCondition{
+				{
+					Field: aws.String(FieldHostHeader),
+					HostHeaderConfig: &HostHeaderConditionConfig{
+						Values: []*string{aws.String("www.example.com"), aws.String("*.alb.example.com")},
+					},
+				},
+			},
+		},
+		{
+			name:           "path-pattern",
+			conditionsJSON: `[{"field": "path-pattern","PathPatternConfig": {"Values": ["/*", "/m00nf1sh"]}}]`,
+			expectedConditions: []RuleCondition{
+				{
+					Field: aws.String(FieldPathPattern),
+					PathPatternConfig: &PathPatternConditionConfig{
+						Values: []*string{aws.String("/*"), aws.String("/m00nf1sh")},
+					},
+				},
+			},
+		},
+		{
+			name:           "http-header",
+			conditionsJSON: `[{"field": "http-header","HttpHeaderConfig": {"HttpHeaderName": "header-a", "Values": ["a"]}}, {"field": "http-header","HttpHeaderConfig": {"HttpHeaderName": "header-b", "Values": ["b-1", "b-2"]}}]`,
+			expectedConditions: []RuleCondition{
+				{
+					Field: aws.String(FieldHTTPHeader),
+					HttpHeaderConfig: &HttpHeaderConditionConfig{
+						HttpHeaderName: aws.String("header-a"),
+						Values:         []*string{aws.String("a")},
+					},
+				},
+				{
+					Field: aws.String(FieldHTTPHeader),
+					HttpHeaderConfig: &HttpHeaderConditionConfig{
+						HttpHeaderName: aws.String("header-b"),
+						Values:         []*string{aws.String("b-1"), aws.String("b-2")},
+					},
+				},
+			},
+		},
+		{
+			name:           "http-request-method",
+			conditionsJSON: `[{"field": "http-request-method", "HttpRequestMethodConfig": {"Values": ["GET", "HEAD"]}}]`,
+			expectedConditions: []RuleCondition{
+				{
+					Field: aws.String(FieldHTTPRequestMethod),
+					HttpRequestMethodConfig: &HttpRequestMethodConditionConfig{
+						Values: []*string{aws.String("GET"), aws.String("HEAD")},
+					},
+				},
+			},
+		},
+		{
+			name:           "query-string",
+			conditionsJSON: `[{"field": "query-string", "QueryStringConfig": {"Values": [{"Key": "user", "Value": "m00n"},{"Key": "eats", "Value": "f1sh"}]}}]`,
+			expectedConditions: []RuleCondition{
+				{
+					Field: aws.String(FieldQueryString),
+					QueryStringConfig: &QueryStringConditionConfig{
+						Values: []*QueryStringKeyValuePair{
+							{
+								Key:   aws.String("user"),
+								Value: aws.String("m00n"),
+							},
+							{
+								Key:   aws.String("eats"),
+								Value: aws.String("f1sh"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data := map[string]string{}
+	for _, tc := range tcs {
+		data[parser.GetAnnotationWithPrefix("conditions."+tc.name)] = tc.conditionsJSON
+	}
+	ing := dummy.NewIngress()
+	ing.SetAnnotations(data)
+
+	conditionsConfigRaw, err := NewParser().Parse(ing)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	conditionsConfig, ok := conditionsConfigRaw.(*Config)
+	if !ok {
+		t.Errorf("expected a Config type")
+		return
+	}
+
+	for _, tc := range tcs {
+		assert.Equal(t, tc.expectedConditions, conditionsConfig.Conditions[tc.name])
+	}
+}
+
+func TestConditionsParse_Invalid(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		conditionsJSON string
+		expectedErr    string
+	}{
+		{
+			name:           "should error if HostHeaderConfig absent for host-header condition",
+			conditionsJSON: `[{"Field": "host-header"}]`,
+			expectedErr:    "missing HostHeaderConfig",
+		},
+		{
+			name:           "should error if PathPatternConfig absent for path-pattern condition",
+			conditionsJSON: `[{"Field": "path-pattern"}]`,
+			expectedErr:    "missing PathPatternConfig",
+		},
+		{
+			name:           "should error if HttpHeaderConfig absent for http-header condition",
+			conditionsJSON: `[{"Field": "http-header"}]`,
+			expectedErr:    "missing HttpHeaderConfig",
+		},
+		{
+			name:           "should error if HttpRequestMethodConfig absent for http-request-method condition",
+			conditionsJSON: `[{"Field": "http-request-method"}]`,
+			expectedErr:    "missing HttpRequestMethodConfig",
+		},
+		{
+			name:           "should error if FieldQueryString absent for query-string condition",
+			conditionsJSON: `[{"Field": "query-string"}]`,
+			expectedErr:    "missing QueryStringConfig",
+		},
+		{
+			name:           "should error if FieldSourceIP absent for source-ip condition",
+			conditionsJSON: `[{"Field": "source-ip"}]`,
+			expectedErr:    "missing SourceIpConfig",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ing := dummy.NewIngress()
+			data := map[string]string{}
+			data[parser.GetAnnotationWithPrefix("conditions.test-condition")] = tc.conditionsJSON
+			ing.SetAnnotations(data)
+			_, err := NewParser().Parse(ing)
+			assert.EqualError(t, err, tc.expectedErr)
+		})
+	}
+}

--- a/internal/ingress/annotations/conditions/types.go
+++ b/internal/ingress/annotations/conditions/types.go
@@ -1,0 +1,255 @@
+package conditions
+
+import (
+	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/aws"
+	"github.com/pkg/errors"
+)
+
+const (
+	FieldHostHeader        = "host-header"
+	FieldPathPattern       = "path-pattern"
+	FieldHTTPHeader        = "http-header"
+	FieldHTTPRequestMethod = "http-request-method"
+	FieldQueryString       = "query-string"
+	FieldSourceIP          = "source-ip"
+)
+
+// Information about a host header condition.
+type HostHeaderConditionConfig struct {
+	// One or more host names. The maximum size of each name is 128 characters.
+	// The comparison is case insensitive. The following wildcard characters are
+	// supported: * (matches 0 or more characters) and ? (matches exactly 1 character).
+	//
+	// If you specify multiple strings, the condition is satisfied if one of the
+	// strings matches the host name.
+	Values []*string
+}
+
+func (c *HostHeaderConditionConfig) validate() error {
+	if len(c.Values) == 0 {
+		return errors.New("Values cannot be empty")
+	}
+	return nil
+}
+
+// Information about an HTTP header condition.
+//
+// There is a set of standard HTTP header fields. You can also define custom
+// HTTP header fields.
+type HttpHeaderConditionConfig struct {
+	// The name of the HTTP header field. The maximum size is 40 characters. The
+	// header name is case insensitive. The allowed characters are specified by
+	// RFC 7230. Wildcards are not supported.
+	//
+	// You can't use an HTTP header condition to specify the host header. Use HostHeaderConditionConfig
+	// to specify a host header condition.
+	HttpHeaderName *string
+
+	// One or more strings to compare against the value of the HTTP header. The
+	// maximum size of each string is 128 characters. The comparison strings are
+	// case insensitive. The following wildcard characters are supported: * (matches
+	// 0 or more characters) and ? (matches exactly 1 character).
+	//
+	// If the same header appears multiple times in the request, we search them
+	// in order until a match is found.
+	//
+	// If you specify multiple strings, the condition is satisfied if one of the
+	// strings matches the value of the HTTP header. To require that all of the
+	// strings are a match, create one condition per string.
+	Values []*string
+}
+
+func (c *HttpHeaderConditionConfig) validate() error {
+	if len(c.Values) == 0 {
+		return errors.New("Values cannot be empty")
+	}
+	return nil
+}
+
+// Information about an HTTP method condition.
+//
+// HTTP defines a set of request methods, also referred to as HTTP verbs. For
+// more information, see the HTTP Method Registry (https://www.iana.org/assignments/http-methods/http-methods.xhtml).
+// You can also define custom HTTP methods.
+type HttpRequestMethodConditionConfig struct {
+	// The name of the request method. The maximum size is 40 characters. The allowed
+	// characters are A-Z, hyphen (-), and underscore (_). The comparison is case
+	// sensitive. Wildcards are not supported; therefore, the method name must be
+	// an exact match.
+	//
+	// If you specify multiple strings, the condition is satisfied if one of the
+	// strings matches the HTTP request method. We recommend that you route GET
+	// and HEAD requests in the same way, because the response to a HEAD request
+	// may be cached.
+	Values []*string
+}
+
+func (c *HttpRequestMethodConditionConfig) validate() error {
+	if len(c.Values) == 0 {
+		return errors.New("Values cannot be empty")
+	}
+	return nil
+}
+
+// Information about a path pattern condition.
+type PathPatternConditionConfig struct {
+	// One or more path patterns to compare against the request URL. The maximum
+	// size of each string is 128 characters. The comparison is case sensitive.
+	// The following wildcard characters are supported: * (matches 0 or more characters)
+	// and ? (matches exactly 1 character).
+	//
+	// If you specify multiple strings, the condition is satisfied if one of them
+	// matches the request URL. The path pattern is compared only to the path of
+	// the URL, not to its query string. To compare against the query string, use
+	// QueryStringConditionConfig.
+	Values []*string
+}
+
+func (c *PathPatternConditionConfig) validate() error {
+	if len(c.Values) == 0 {
+		return errors.New("Values cannot be empty")
+	}
+	return nil
+}
+
+// Information about a key/value pair.
+type QueryStringKeyValuePair struct {
+	// The key. You can omit the key.
+	Key *string
+
+	// The value.
+	Value *string
+}
+
+// Information about a query string condition.
+//
+// The query string component of a URI starts after the first '?' character
+// and is terminated by either a '#' character or the end of the URI. A typical
+// query string contains key/value pairs separated by '&' characters. The allowed
+// characters are specified by RFC 3986. Any character can be percentage encoded.
+type QueryStringConditionConfig struct {
+	// One or more key/value pairs or values to find in the query string. The maximum
+	// size of each string is 128 characters. The comparison is case insensitive.
+	// The following wildcard characters are supported: * (matches 0 or more characters)
+	// and ? (matches exactly 1 character). To search for a literal '*' or '?' character
+	// in a query string, you must escape these characters in Values using a '\'
+	// character.
+	//
+	// If you specify multiple key/value pairs or values, the condition is satisfied
+	// if one of them is found in the query string.
+	Values []*QueryStringKeyValuePair
+}
+
+func (c *QueryStringConditionConfig) validate() error {
+	if len(c.Values) == 0 {
+		return errors.New("Values cannot be empty")
+	}
+	return nil
+}
+
+// Information about a source IP condition.
+//
+// You can use this condition to route based on the IP address of the source
+// that connects to the load balancer. If a client is behind a proxy, this is
+// the IP address of the proxy not the IP address of the client.
+type SourceIpConditionConfig struct {
+	// One or more source IP addresses, in CIDR format. You can use both IPv4 and
+	// IPv6 addresses. Wildcards are not supported.
+	//
+	// If you specify multiple addresses, the condition is satisfied if the source
+	// IP address of the request matches one of the CIDR blocks. This condition
+	// is not satisfied by the addresses in the X-Forwarded-For header. To search
+	// for addresses in the X-Forwarded-For header, use HttpHeaderConditionConfig.
+	Values []*string
+}
+
+func (c *SourceIpConditionConfig) validate() error {
+	if len(c.Values) == 0 {
+		return errors.New("Values cannot be empty")
+	}
+	return nil
+}
+
+// Information about a condition for a rule.
+type RuleCondition struct {
+	// The field in the HTTP request. The following are the possible values:
+	//
+	//    * http-header
+	//
+	//    * http-request-method
+	//
+	//    * host-header
+	//
+	//    * path-pattern
+	//
+	//    * query-string
+	//
+	//    * source-ip
+	Field *string
+
+	// Information for a host header condition. Specify only when Field is host-header.
+	HostHeaderConfig *HostHeaderConditionConfig
+
+	// Information for an HTTP header condition. Specify only when Field is http-header.
+	HttpHeaderConfig *HttpHeaderConditionConfig
+
+	// Information for an HTTP method condition. Specify only when Field is http-request-method.
+	HttpRequestMethodConfig *HttpRequestMethodConditionConfig
+
+	// Information for a path pattern condition. Specify only when Field is path-pattern.
+	PathPatternConfig *PathPatternConditionConfig
+
+	// Information for a query string condition. Specify only when Field is query-string.
+	QueryStringConfig *QueryStringConditionConfig
+
+	// Information for a source IP condition. Specify only when Field is source-ip.
+	SourceIpConfig *SourceIpConditionConfig
+}
+
+func (c *RuleCondition) validate() error {
+	switch aws.StringValue(c.Field) {
+	case FieldHostHeader:
+		if c.HostHeaderConfig == nil {
+			return errors.New("missing HostHeaderConfig")
+		}
+		if err := c.HostHeaderConfig.validate(); err != nil {
+			return errors.Wrap(err, "invalid HostHeaderConfig")
+		}
+	case FieldPathPattern:
+		if c.PathPatternConfig == nil {
+			return errors.New("missing PathPatternConfig")
+		}
+		if err := c.PathPatternConfig.validate(); err != nil {
+			return errors.Wrap(err, "invalid PathPatternConfig")
+		}
+	case FieldHTTPHeader:
+		if c.HttpHeaderConfig == nil {
+			return errors.New("missing HttpHeaderConfig")
+		}
+		if err := c.HttpHeaderConfig.validate(); err != nil {
+			return errors.Wrap(err, "invalid HttpHeaderConfig")
+		}
+	case FieldHTTPRequestMethod:
+		if c.HttpRequestMethodConfig == nil {
+			return errors.New("missing HttpRequestMethodConfig")
+		}
+		if err := c.HttpRequestMethodConfig.validate(); err != nil {
+			return errors.Wrap(err, "invalid HttpRequestMethodConfig")
+		}
+	case FieldQueryString:
+		if c.QueryStringConfig == nil {
+			return errors.New("missing QueryStringConfig")
+		}
+		if err := c.QueryStringConfig.validate(); err != nil {
+			return errors.Wrap(err, "invalid QueryStringConfig")
+		}
+	case FieldSourceIP:
+		if c.SourceIpConfig == nil {
+			return errors.New("missing SourceIpConfig")
+		}
+		if err := c.SourceIpConfig.validate(); err != nil {
+			return errors.Wrap(err, "invalid SourceIpConfig")
+		}
+	}
+	return nil
+}

--- a/mocks/EC2API.go
+++ b/mocks/EC2API.go
@@ -95,6 +95,84 @@ func (_m *EC2API) AcceptReservedInstancesExchangeQuoteWithContext(_a0 context.Co
 	return r0, r1
 }
 
+// AcceptTransitGatewayPeeringAttachment provides a mock function with given fields: _a0
+func (_m *EC2API) AcceptTransitGatewayPeeringAttachment(_a0 *ec2.AcceptTransitGatewayPeeringAttachmentInput) (*ec2.AcceptTransitGatewayPeeringAttachmentOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.AcceptTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(0).(func(*ec2.AcceptTransitGatewayPeeringAttachmentInput) *ec2.AcceptTransitGatewayPeeringAttachmentOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.AcceptTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.AcceptTransitGatewayPeeringAttachmentInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AcceptTransitGatewayPeeringAttachmentRequest provides a mock function with given fields: _a0
+func (_m *EC2API) AcceptTransitGatewayPeeringAttachmentRequest(_a0 *ec2.AcceptTransitGatewayPeeringAttachmentInput) (*request.Request, *ec2.AcceptTransitGatewayPeeringAttachmentOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.AcceptTransitGatewayPeeringAttachmentInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.AcceptTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(1).(func(*ec2.AcceptTransitGatewayPeeringAttachmentInput) *ec2.AcceptTransitGatewayPeeringAttachmentOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.AcceptTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// AcceptTransitGatewayPeeringAttachmentWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) AcceptTransitGatewayPeeringAttachmentWithContext(_a0 context.Context, _a1 *ec2.AcceptTransitGatewayPeeringAttachmentInput, _a2 ...request.Option) (*ec2.AcceptTransitGatewayPeeringAttachmentOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.AcceptTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.AcceptTransitGatewayPeeringAttachmentInput, ...request.Option) *ec2.AcceptTransitGatewayPeeringAttachmentOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.AcceptTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.AcceptTransitGatewayPeeringAttachmentInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // AcceptTransitGatewayVpcAttachment provides a mock function with given fields: _a0
 func (_m *EC2API) AcceptTransitGatewayVpcAttachment(_a0 *ec2.AcceptTransitGatewayVpcAttachmentInput) (*ec2.AcceptTransitGatewayVpcAttachmentOutput, error) {
 	ret := _m.Called(_a0)
@@ -1257,6 +1335,84 @@ func (_m *EC2API) AssociateSubnetCidrBlockWithContext(_a0 context.Context, _a1 *
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *ec2.AssociateSubnetCidrBlockInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AssociateTransitGatewayMulticastDomain provides a mock function with given fields: _a0
+func (_m *EC2API) AssociateTransitGatewayMulticastDomain(_a0 *ec2.AssociateTransitGatewayMulticastDomainInput) (*ec2.AssociateTransitGatewayMulticastDomainOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.AssociateTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(0).(func(*ec2.AssociateTransitGatewayMulticastDomainInput) *ec2.AssociateTransitGatewayMulticastDomainOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.AssociateTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.AssociateTransitGatewayMulticastDomainInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AssociateTransitGatewayMulticastDomainRequest provides a mock function with given fields: _a0
+func (_m *EC2API) AssociateTransitGatewayMulticastDomainRequest(_a0 *ec2.AssociateTransitGatewayMulticastDomainInput) (*request.Request, *ec2.AssociateTransitGatewayMulticastDomainOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.AssociateTransitGatewayMulticastDomainInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.AssociateTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(1).(func(*ec2.AssociateTransitGatewayMulticastDomainInput) *ec2.AssociateTransitGatewayMulticastDomainOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.AssociateTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// AssociateTransitGatewayMulticastDomainWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) AssociateTransitGatewayMulticastDomainWithContext(_a0 context.Context, _a1 *ec2.AssociateTransitGatewayMulticastDomainInput, _a2 ...request.Option) (*ec2.AssociateTransitGatewayMulticastDomainOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.AssociateTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.AssociateTransitGatewayMulticastDomainInput, ...request.Option) *ec2.AssociateTransitGatewayMulticastDomainOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.AssociateTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.AssociateTransitGatewayMulticastDomainInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
@@ -4385,6 +4541,162 @@ func (_m *EC2API) CreateLaunchTemplateWithContext(_a0 context.Context, _a1 *ec2.
 	return r0, r1
 }
 
+// CreateLocalGatewayRoute provides a mock function with given fields: _a0
+func (_m *EC2API) CreateLocalGatewayRoute(_a0 *ec2.CreateLocalGatewayRouteInput) (*ec2.CreateLocalGatewayRouteOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.CreateLocalGatewayRouteOutput
+	if rf, ok := ret.Get(0).(func(*ec2.CreateLocalGatewayRouteInput) *ec2.CreateLocalGatewayRouteOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.CreateLocalGatewayRouteOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.CreateLocalGatewayRouteInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateLocalGatewayRouteRequest provides a mock function with given fields: _a0
+func (_m *EC2API) CreateLocalGatewayRouteRequest(_a0 *ec2.CreateLocalGatewayRouteInput) (*request.Request, *ec2.CreateLocalGatewayRouteOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.CreateLocalGatewayRouteInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.CreateLocalGatewayRouteOutput
+	if rf, ok := ret.Get(1).(func(*ec2.CreateLocalGatewayRouteInput) *ec2.CreateLocalGatewayRouteOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.CreateLocalGatewayRouteOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// CreateLocalGatewayRouteTableVpcAssociation provides a mock function with given fields: _a0
+func (_m *EC2API) CreateLocalGatewayRouteTableVpcAssociation(_a0 *ec2.CreateLocalGatewayRouteTableVpcAssociationInput) (*ec2.CreateLocalGatewayRouteTableVpcAssociationOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.CreateLocalGatewayRouteTableVpcAssociationOutput
+	if rf, ok := ret.Get(0).(func(*ec2.CreateLocalGatewayRouteTableVpcAssociationInput) *ec2.CreateLocalGatewayRouteTableVpcAssociationOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.CreateLocalGatewayRouteTableVpcAssociationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.CreateLocalGatewayRouteTableVpcAssociationInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateLocalGatewayRouteTableVpcAssociationRequest provides a mock function with given fields: _a0
+func (_m *EC2API) CreateLocalGatewayRouteTableVpcAssociationRequest(_a0 *ec2.CreateLocalGatewayRouteTableVpcAssociationInput) (*request.Request, *ec2.CreateLocalGatewayRouteTableVpcAssociationOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.CreateLocalGatewayRouteTableVpcAssociationInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.CreateLocalGatewayRouteTableVpcAssociationOutput
+	if rf, ok := ret.Get(1).(func(*ec2.CreateLocalGatewayRouteTableVpcAssociationInput) *ec2.CreateLocalGatewayRouteTableVpcAssociationOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.CreateLocalGatewayRouteTableVpcAssociationOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// CreateLocalGatewayRouteTableVpcAssociationWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) CreateLocalGatewayRouteTableVpcAssociationWithContext(_a0 context.Context, _a1 *ec2.CreateLocalGatewayRouteTableVpcAssociationInput, _a2 ...request.Option) (*ec2.CreateLocalGatewayRouteTableVpcAssociationOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.CreateLocalGatewayRouteTableVpcAssociationOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.CreateLocalGatewayRouteTableVpcAssociationInput, ...request.Option) *ec2.CreateLocalGatewayRouteTableVpcAssociationOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.CreateLocalGatewayRouteTableVpcAssociationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.CreateLocalGatewayRouteTableVpcAssociationInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateLocalGatewayRouteWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) CreateLocalGatewayRouteWithContext(_a0 context.Context, _a1 *ec2.CreateLocalGatewayRouteInput, _a2 ...request.Option) (*ec2.CreateLocalGatewayRouteOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.CreateLocalGatewayRouteOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.CreateLocalGatewayRouteInput, ...request.Option) *ec2.CreateLocalGatewayRouteOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.CreateLocalGatewayRouteOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.CreateLocalGatewayRouteInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CreateNatGateway provides a mock function with given fields: _a0
 func (_m *EC2API) CreateNatGateway(_a0 *ec2.CreateNatGatewayInput) (*ec2.CreateNatGatewayOutput, error) {
 	ret := _m.Called(_a0)
@@ -5883,6 +6195,162 @@ func (_m *EC2API) CreateTransitGateway(_a0 *ec2.CreateTransitGatewayInput) (*ec2
 	var r1 error
 	if rf, ok := ret.Get(1).(func(*ec2.CreateTransitGatewayInput) error); ok {
 		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateTransitGatewayMulticastDomain provides a mock function with given fields: _a0
+func (_m *EC2API) CreateTransitGatewayMulticastDomain(_a0 *ec2.CreateTransitGatewayMulticastDomainInput) (*ec2.CreateTransitGatewayMulticastDomainOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.CreateTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(0).(func(*ec2.CreateTransitGatewayMulticastDomainInput) *ec2.CreateTransitGatewayMulticastDomainOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.CreateTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.CreateTransitGatewayMulticastDomainInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateTransitGatewayMulticastDomainRequest provides a mock function with given fields: _a0
+func (_m *EC2API) CreateTransitGatewayMulticastDomainRequest(_a0 *ec2.CreateTransitGatewayMulticastDomainInput) (*request.Request, *ec2.CreateTransitGatewayMulticastDomainOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.CreateTransitGatewayMulticastDomainInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.CreateTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(1).(func(*ec2.CreateTransitGatewayMulticastDomainInput) *ec2.CreateTransitGatewayMulticastDomainOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.CreateTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// CreateTransitGatewayMulticastDomainWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) CreateTransitGatewayMulticastDomainWithContext(_a0 context.Context, _a1 *ec2.CreateTransitGatewayMulticastDomainInput, _a2 ...request.Option) (*ec2.CreateTransitGatewayMulticastDomainOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.CreateTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.CreateTransitGatewayMulticastDomainInput, ...request.Option) *ec2.CreateTransitGatewayMulticastDomainOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.CreateTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.CreateTransitGatewayMulticastDomainInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateTransitGatewayPeeringAttachment provides a mock function with given fields: _a0
+func (_m *EC2API) CreateTransitGatewayPeeringAttachment(_a0 *ec2.CreateTransitGatewayPeeringAttachmentInput) (*ec2.CreateTransitGatewayPeeringAttachmentOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.CreateTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(0).(func(*ec2.CreateTransitGatewayPeeringAttachmentInput) *ec2.CreateTransitGatewayPeeringAttachmentOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.CreateTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.CreateTransitGatewayPeeringAttachmentInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateTransitGatewayPeeringAttachmentRequest provides a mock function with given fields: _a0
+func (_m *EC2API) CreateTransitGatewayPeeringAttachmentRequest(_a0 *ec2.CreateTransitGatewayPeeringAttachmentInput) (*request.Request, *ec2.CreateTransitGatewayPeeringAttachmentOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.CreateTransitGatewayPeeringAttachmentInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.CreateTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(1).(func(*ec2.CreateTransitGatewayPeeringAttachmentInput) *ec2.CreateTransitGatewayPeeringAttachmentOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.CreateTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// CreateTransitGatewayPeeringAttachmentWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) CreateTransitGatewayPeeringAttachmentWithContext(_a0 context.Context, _a1 *ec2.CreateTransitGatewayPeeringAttachmentInput, _a2 ...request.Option) (*ec2.CreateTransitGatewayPeeringAttachmentOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.CreateTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.CreateTransitGatewayPeeringAttachmentInput, ...request.Option) *ec2.CreateTransitGatewayPeeringAttachmentOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.CreateTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.CreateTransitGatewayPeeringAttachmentInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -7817,6 +8285,162 @@ func (_m *EC2API) DeleteLaunchTemplateWithContext(_a0 context.Context, _a1 *ec2.
 	return r0, r1
 }
 
+// DeleteLocalGatewayRoute provides a mock function with given fields: _a0
+func (_m *EC2API) DeleteLocalGatewayRoute(_a0 *ec2.DeleteLocalGatewayRouteInput) (*ec2.DeleteLocalGatewayRouteOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DeleteLocalGatewayRouteOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DeleteLocalGatewayRouteInput) *ec2.DeleteLocalGatewayRouteOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeleteLocalGatewayRouteOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DeleteLocalGatewayRouteInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeleteLocalGatewayRouteRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DeleteLocalGatewayRouteRequest(_a0 *ec2.DeleteLocalGatewayRouteInput) (*request.Request, *ec2.DeleteLocalGatewayRouteOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DeleteLocalGatewayRouteInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DeleteLocalGatewayRouteOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DeleteLocalGatewayRouteInput) *ec2.DeleteLocalGatewayRouteOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DeleteLocalGatewayRouteOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DeleteLocalGatewayRouteTableVpcAssociation provides a mock function with given fields: _a0
+func (_m *EC2API) DeleteLocalGatewayRouteTableVpcAssociation(_a0 *ec2.DeleteLocalGatewayRouteTableVpcAssociationInput) (*ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DeleteLocalGatewayRouteTableVpcAssociationInput) *ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DeleteLocalGatewayRouteTableVpcAssociationInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeleteLocalGatewayRouteTableVpcAssociationRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DeleteLocalGatewayRouteTableVpcAssociationRequest(_a0 *ec2.DeleteLocalGatewayRouteTableVpcAssociationInput) (*request.Request, *ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DeleteLocalGatewayRouteTableVpcAssociationInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DeleteLocalGatewayRouteTableVpcAssociationInput) *ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DeleteLocalGatewayRouteTableVpcAssociationWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DeleteLocalGatewayRouteTableVpcAssociationWithContext(_a0 context.Context, _a1 *ec2.DeleteLocalGatewayRouteTableVpcAssociationInput, _a2 ...request.Option) (*ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DeleteLocalGatewayRouteTableVpcAssociationInput, ...request.Option) *ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeleteLocalGatewayRouteTableVpcAssociationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DeleteLocalGatewayRouteTableVpcAssociationInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeleteLocalGatewayRouteWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DeleteLocalGatewayRouteWithContext(_a0 context.Context, _a1 *ec2.DeleteLocalGatewayRouteInput, _a2 ...request.Option) (*ec2.DeleteLocalGatewayRouteOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DeleteLocalGatewayRouteOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DeleteLocalGatewayRouteInput, ...request.Option) *ec2.DeleteLocalGatewayRouteOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeleteLocalGatewayRouteOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DeleteLocalGatewayRouteInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // DeleteNatGateway provides a mock function with given fields: _a0
 func (_m *EC2API) DeleteNatGateway(_a0 *ec2.DeleteNatGatewayInput) (*ec2.DeleteNatGatewayOutput, error) {
 	ret := _m.Called(_a0)
@@ -8277,6 +8901,84 @@ func (_m *EC2API) DeletePlacementGroupWithContext(_a0 context.Context, _a1 *ec2.
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DeletePlacementGroupInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeleteQueuedReservedInstances provides a mock function with given fields: _a0
+func (_m *EC2API) DeleteQueuedReservedInstances(_a0 *ec2.DeleteQueuedReservedInstancesInput) (*ec2.DeleteQueuedReservedInstancesOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DeleteQueuedReservedInstancesOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DeleteQueuedReservedInstancesInput) *ec2.DeleteQueuedReservedInstancesOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeleteQueuedReservedInstancesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DeleteQueuedReservedInstancesInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeleteQueuedReservedInstancesRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DeleteQueuedReservedInstancesRequest(_a0 *ec2.DeleteQueuedReservedInstancesInput) (*request.Request, *ec2.DeleteQueuedReservedInstancesOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DeleteQueuedReservedInstancesInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DeleteQueuedReservedInstancesOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DeleteQueuedReservedInstancesInput) *ec2.DeleteQueuedReservedInstancesOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DeleteQueuedReservedInstancesOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DeleteQueuedReservedInstancesWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DeleteQueuedReservedInstancesWithContext(_a0 context.Context, _a1 *ec2.DeleteQueuedReservedInstancesInput, _a2 ...request.Option) (*ec2.DeleteQueuedReservedInstancesOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DeleteQueuedReservedInstancesOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DeleteQueuedReservedInstancesInput, ...request.Option) *ec2.DeleteQueuedReservedInstancesOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeleteQueuedReservedInstancesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DeleteQueuedReservedInstancesInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
@@ -9159,6 +9861,162 @@ func (_m *EC2API) DeleteTransitGateway(_a0 *ec2.DeleteTransitGatewayInput) (*ec2
 	var r1 error
 	if rf, ok := ret.Get(1).(func(*ec2.DeleteTransitGatewayInput) error); ok {
 		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeleteTransitGatewayMulticastDomain provides a mock function with given fields: _a0
+func (_m *EC2API) DeleteTransitGatewayMulticastDomain(_a0 *ec2.DeleteTransitGatewayMulticastDomainInput) (*ec2.DeleteTransitGatewayMulticastDomainOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DeleteTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DeleteTransitGatewayMulticastDomainInput) *ec2.DeleteTransitGatewayMulticastDomainOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeleteTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DeleteTransitGatewayMulticastDomainInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeleteTransitGatewayMulticastDomainRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DeleteTransitGatewayMulticastDomainRequest(_a0 *ec2.DeleteTransitGatewayMulticastDomainInput) (*request.Request, *ec2.DeleteTransitGatewayMulticastDomainOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DeleteTransitGatewayMulticastDomainInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DeleteTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DeleteTransitGatewayMulticastDomainInput) *ec2.DeleteTransitGatewayMulticastDomainOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DeleteTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DeleteTransitGatewayMulticastDomainWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DeleteTransitGatewayMulticastDomainWithContext(_a0 context.Context, _a1 *ec2.DeleteTransitGatewayMulticastDomainInput, _a2 ...request.Option) (*ec2.DeleteTransitGatewayMulticastDomainOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DeleteTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DeleteTransitGatewayMulticastDomainInput, ...request.Option) *ec2.DeleteTransitGatewayMulticastDomainOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeleteTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DeleteTransitGatewayMulticastDomainInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeleteTransitGatewayPeeringAttachment provides a mock function with given fields: _a0
+func (_m *EC2API) DeleteTransitGatewayPeeringAttachment(_a0 *ec2.DeleteTransitGatewayPeeringAttachmentInput) (*ec2.DeleteTransitGatewayPeeringAttachmentOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DeleteTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DeleteTransitGatewayPeeringAttachmentInput) *ec2.DeleteTransitGatewayPeeringAttachmentOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeleteTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DeleteTransitGatewayPeeringAttachmentInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeleteTransitGatewayPeeringAttachmentRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DeleteTransitGatewayPeeringAttachmentRequest(_a0 *ec2.DeleteTransitGatewayPeeringAttachmentInput) (*request.Request, *ec2.DeleteTransitGatewayPeeringAttachmentOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DeleteTransitGatewayPeeringAttachmentInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DeleteTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DeleteTransitGatewayPeeringAttachmentInput) *ec2.DeleteTransitGatewayPeeringAttachmentOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DeleteTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DeleteTransitGatewayPeeringAttachmentWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DeleteTransitGatewayPeeringAttachmentWithContext(_a0 context.Context, _a1 *ec2.DeleteTransitGatewayPeeringAttachmentInput, _a2 ...request.Option) (*ec2.DeleteTransitGatewayPeeringAttachmentOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DeleteTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DeleteTransitGatewayPeeringAttachmentInput, ...request.Option) *ec2.DeleteTransitGatewayPeeringAttachmentOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeleteTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DeleteTransitGatewayPeeringAttachmentInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -10305,6 +11163,162 @@ func (_m *EC2API) DeregisterImageWithContext(_a0 context.Context, _a1 *ec2.Dereg
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DeregisterImageInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeregisterTransitGatewayMulticastGroupMembers provides a mock function with given fields: _a0
+func (_m *EC2API) DeregisterTransitGatewayMulticastGroupMembers(_a0 *ec2.DeregisterTransitGatewayMulticastGroupMembersInput) (*ec2.DeregisterTransitGatewayMulticastGroupMembersOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DeregisterTransitGatewayMulticastGroupMembersOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DeregisterTransitGatewayMulticastGroupMembersInput) *ec2.DeregisterTransitGatewayMulticastGroupMembersOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeregisterTransitGatewayMulticastGroupMembersOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DeregisterTransitGatewayMulticastGroupMembersInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeregisterTransitGatewayMulticastGroupMembersRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DeregisterTransitGatewayMulticastGroupMembersRequest(_a0 *ec2.DeregisterTransitGatewayMulticastGroupMembersInput) (*request.Request, *ec2.DeregisterTransitGatewayMulticastGroupMembersOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DeregisterTransitGatewayMulticastGroupMembersInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DeregisterTransitGatewayMulticastGroupMembersOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DeregisterTransitGatewayMulticastGroupMembersInput) *ec2.DeregisterTransitGatewayMulticastGroupMembersOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DeregisterTransitGatewayMulticastGroupMembersOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DeregisterTransitGatewayMulticastGroupMembersWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DeregisterTransitGatewayMulticastGroupMembersWithContext(_a0 context.Context, _a1 *ec2.DeregisterTransitGatewayMulticastGroupMembersInput, _a2 ...request.Option) (*ec2.DeregisterTransitGatewayMulticastGroupMembersOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DeregisterTransitGatewayMulticastGroupMembersOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DeregisterTransitGatewayMulticastGroupMembersInput, ...request.Option) *ec2.DeregisterTransitGatewayMulticastGroupMembersOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeregisterTransitGatewayMulticastGroupMembersOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DeregisterTransitGatewayMulticastGroupMembersInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeregisterTransitGatewayMulticastGroupSources provides a mock function with given fields: _a0
+func (_m *EC2API) DeregisterTransitGatewayMulticastGroupSources(_a0 *ec2.DeregisterTransitGatewayMulticastGroupSourcesInput) (*ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DeregisterTransitGatewayMulticastGroupSourcesInput) *ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DeregisterTransitGatewayMulticastGroupSourcesInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeregisterTransitGatewayMulticastGroupSourcesRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DeregisterTransitGatewayMulticastGroupSourcesRequest(_a0 *ec2.DeregisterTransitGatewayMulticastGroupSourcesInput) (*request.Request, *ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DeregisterTransitGatewayMulticastGroupSourcesInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DeregisterTransitGatewayMulticastGroupSourcesInput) *ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DeregisterTransitGatewayMulticastGroupSourcesWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DeregisterTransitGatewayMulticastGroupSourcesWithContext(_a0 context.Context, _a1 *ec2.DeregisterTransitGatewayMulticastGroupSourcesInput, _a2 ...request.Option) (*ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DeregisterTransitGatewayMulticastGroupSourcesInput, ...request.Option) *ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DeregisterTransitGatewayMulticastGroupSourcesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DeregisterTransitGatewayMulticastGroupSourcesInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
@@ -11607,6 +12621,84 @@ func (_m *EC2API) DescribeClientVpnTargetNetworksWithContext(_a0 context.Context
 	return r0, r1
 }
 
+// DescribeCoipPools provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeCoipPools(_a0 *ec2.DescribeCoipPoolsInput) (*ec2.DescribeCoipPoolsOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeCoipPoolsOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeCoipPoolsInput) *ec2.DescribeCoipPoolsOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeCoipPoolsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeCoipPoolsInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeCoipPoolsRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeCoipPoolsRequest(_a0 *ec2.DescribeCoipPoolsInput) (*request.Request, *ec2.DescribeCoipPoolsOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeCoipPoolsInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeCoipPoolsOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeCoipPoolsInput) *ec2.DescribeCoipPoolsOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeCoipPoolsOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeCoipPoolsWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeCoipPoolsWithContext(_a0 context.Context, _a1 *ec2.DescribeCoipPoolsInput, _a2 ...request.Option) (*ec2.DescribeCoipPoolsOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeCoipPoolsOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeCoipPoolsInput, ...request.Option) *ec2.DescribeCoipPoolsOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeCoipPoolsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeCoipPoolsInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // DescribeConversionTasks provides a mock function with given fields: _a0
 func (_m *EC2API) DescribeConversionTasks(_a0 *ec2.DescribeConversionTasksInput) (*ec2.DescribeConversionTasksOutput, error) {
 	ret := _m.Called(_a0)
@@ -12090,6 +13182,41 @@ func (_m *EC2API) DescribeExportImageTasks(_a0 *ec2.DescribeExportImageTasksInpu
 	return r0, r1
 }
 
+// DescribeExportImageTasksPages provides a mock function with given fields: _a0, _a1
+func (_m *EC2API) DescribeExportImageTasksPages(_a0 *ec2.DescribeExportImageTasksInput, _a1 func(*ec2.DescribeExportImageTasksOutput, bool) bool) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeExportImageTasksInput, func(*ec2.DescribeExportImageTasksOutput, bool) bool) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DescribeExportImageTasksPagesWithContext provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *EC2API) DescribeExportImageTasksPagesWithContext(_a0 context.Context, _a1 *ec2.DescribeExportImageTasksInput, _a2 func(*ec2.DescribeExportImageTasksOutput, bool) bool, _a3 ...request.Option) error {
+	_va := make([]interface{}, len(_a3))
+	for _i := range _a3 {
+		_va[_i] = _a3[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1, _a2)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeExportImageTasksInput, func(*ec2.DescribeExportImageTasksOutput, bool) bool, ...request.Option) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DescribeExportImageTasksRequest provides a mock function with given fields: _a0
 func (_m *EC2API) DescribeExportImageTasksRequest(_a0 *ec2.DescribeExportImageTasksInput) (*request.Request, *ec2.DescribeExportImageTasksOutput) {
 	ret := _m.Called(_a0)
@@ -12215,6 +13342,119 @@ func (_m *EC2API) DescribeExportTasksWithContext(_a0 context.Context, _a1 *ec2.D
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeExportTasksInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeFastSnapshotRestores provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeFastSnapshotRestores(_a0 *ec2.DescribeFastSnapshotRestoresInput) (*ec2.DescribeFastSnapshotRestoresOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeFastSnapshotRestoresOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeFastSnapshotRestoresInput) *ec2.DescribeFastSnapshotRestoresOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeFastSnapshotRestoresOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeFastSnapshotRestoresInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeFastSnapshotRestoresPages provides a mock function with given fields: _a0, _a1
+func (_m *EC2API) DescribeFastSnapshotRestoresPages(_a0 *ec2.DescribeFastSnapshotRestoresInput, _a1 func(*ec2.DescribeFastSnapshotRestoresOutput, bool) bool) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeFastSnapshotRestoresInput, func(*ec2.DescribeFastSnapshotRestoresOutput, bool) bool) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DescribeFastSnapshotRestoresPagesWithContext provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *EC2API) DescribeFastSnapshotRestoresPagesWithContext(_a0 context.Context, _a1 *ec2.DescribeFastSnapshotRestoresInput, _a2 func(*ec2.DescribeFastSnapshotRestoresOutput, bool) bool, _a3 ...request.Option) error {
+	_va := make([]interface{}, len(_a3))
+	for _i := range _a3 {
+		_va[_i] = _a3[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1, _a2)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeFastSnapshotRestoresInput, func(*ec2.DescribeFastSnapshotRestoresOutput, bool) bool, ...request.Option) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DescribeFastSnapshotRestoresRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeFastSnapshotRestoresRequest(_a0 *ec2.DescribeFastSnapshotRestoresInput) (*request.Request, *ec2.DescribeFastSnapshotRestoresOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeFastSnapshotRestoresInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeFastSnapshotRestoresOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeFastSnapshotRestoresInput) *ec2.DescribeFastSnapshotRestoresOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeFastSnapshotRestoresOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeFastSnapshotRestoresWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeFastSnapshotRestoresWithContext(_a0 context.Context, _a1 *ec2.DescribeFastSnapshotRestoresInput, _a2 ...request.Option) (*ec2.DescribeFastSnapshotRestoresOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeFastSnapshotRestoresOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeFastSnapshotRestoresInput, ...request.Option) *ec2.DescribeFastSnapshotRestoresOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeFastSnapshotRestoresOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeFastSnapshotRestoresInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
@@ -14090,6 +15330,162 @@ func (_m *EC2API) DescribeInstanceStatusWithContext(_a0 context.Context, _a1 *ec
 	return r0, r1
 }
 
+// DescribeInstanceTypeOfferings provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeInstanceTypeOfferings(_a0 *ec2.DescribeInstanceTypeOfferingsInput) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeInstanceTypeOfferingsOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeInstanceTypeOfferingsInput) *ec2.DescribeInstanceTypeOfferingsOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeInstanceTypeOfferingsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeInstanceTypeOfferingsInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeInstanceTypeOfferingsRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeInstanceTypeOfferingsRequest(_a0 *ec2.DescribeInstanceTypeOfferingsInput) (*request.Request, *ec2.DescribeInstanceTypeOfferingsOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeInstanceTypeOfferingsInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeInstanceTypeOfferingsOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeInstanceTypeOfferingsInput) *ec2.DescribeInstanceTypeOfferingsOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeInstanceTypeOfferingsOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeInstanceTypeOfferingsWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeInstanceTypeOfferingsWithContext(_a0 context.Context, _a1 *ec2.DescribeInstanceTypeOfferingsInput, _a2 ...request.Option) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeInstanceTypeOfferingsOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeInstanceTypeOfferingsInput, ...request.Option) *ec2.DescribeInstanceTypeOfferingsOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeInstanceTypeOfferingsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeInstanceTypeOfferingsInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeInstanceTypes provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeInstanceTypes(_a0 *ec2.DescribeInstanceTypesInput) (*ec2.DescribeInstanceTypesOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeInstanceTypesOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeInstanceTypesInput) *ec2.DescribeInstanceTypesOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeInstanceTypesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeInstanceTypesInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeInstanceTypesRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeInstanceTypesRequest(_a0 *ec2.DescribeInstanceTypesInput) (*request.Request, *ec2.DescribeInstanceTypesOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeInstanceTypesInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeInstanceTypesOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeInstanceTypesInput) *ec2.DescribeInstanceTypesOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeInstanceTypesOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeInstanceTypesWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeInstanceTypesWithContext(_a0 context.Context, _a1 *ec2.DescribeInstanceTypesInput, _a2 ...request.Option) (*ec2.DescribeInstanceTypesOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeInstanceTypesOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeInstanceTypesInput, ...request.Option) *ec2.DescribeInstanceTypesOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeInstanceTypesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeInstanceTypesInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // DescribeInstances provides a mock function with given fields: _a0
 func (_m *EC2API) DescribeInstances(_a0 *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
 	ret := _m.Called(_a0)
@@ -14612,6 +16008,474 @@ func (_m *EC2API) DescribeLaunchTemplatesWithContext(_a0 context.Context, _a1 *e
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeLaunchTemplatesInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations(_a0 *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) (*ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest(_a0 *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) (*request.Request, *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput) *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsWithContext(_a0 context.Context, _a1 *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput, _a2 ...request.Option) (*ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput, ...request.Option) *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayRouteTableVpcAssociations provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGatewayRouteTableVpcAssociations(_a0 *ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput) (*ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput) *ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayRouteTableVpcAssociationsRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGatewayRouteTableVpcAssociationsRequest(_a0 *ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput) (*request.Request, *ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput) *ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayRouteTableVpcAssociationsWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeLocalGatewayRouteTableVpcAssociationsWithContext(_a0 context.Context, _a1 *ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput, _a2 ...request.Option) (*ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput, ...request.Option) *ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewayRouteTableVpcAssociationsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayRouteTables provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGatewayRouteTables(_a0 *ec2.DescribeLocalGatewayRouteTablesInput) (*ec2.DescribeLocalGatewayRouteTablesOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeLocalGatewayRouteTablesOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewayRouteTablesInput) *ec2.DescribeLocalGatewayRouteTablesOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewayRouteTablesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewayRouteTablesInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayRouteTablesRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGatewayRouteTablesRequest(_a0 *ec2.DescribeLocalGatewayRouteTablesInput) (*request.Request, *ec2.DescribeLocalGatewayRouteTablesOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewayRouteTablesInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeLocalGatewayRouteTablesOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewayRouteTablesInput) *ec2.DescribeLocalGatewayRouteTablesOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeLocalGatewayRouteTablesOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayRouteTablesWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeLocalGatewayRouteTablesWithContext(_a0 context.Context, _a1 *ec2.DescribeLocalGatewayRouteTablesInput, _a2 ...request.Option) (*ec2.DescribeLocalGatewayRouteTablesOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeLocalGatewayRouteTablesOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeLocalGatewayRouteTablesInput, ...request.Option) *ec2.DescribeLocalGatewayRouteTablesOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewayRouteTablesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeLocalGatewayRouteTablesInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayVirtualInterfaceGroups provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGatewayVirtualInterfaceGroups(_a0 *ec2.DescribeLocalGatewayVirtualInterfaceGroupsInput) (*ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewayVirtualInterfaceGroupsInput) *ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewayVirtualInterfaceGroupsInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayVirtualInterfaceGroupsRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGatewayVirtualInterfaceGroupsRequest(_a0 *ec2.DescribeLocalGatewayVirtualInterfaceGroupsInput) (*request.Request, *ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewayVirtualInterfaceGroupsInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewayVirtualInterfaceGroupsInput) *ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayVirtualInterfaceGroupsWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeLocalGatewayVirtualInterfaceGroupsWithContext(_a0 context.Context, _a1 *ec2.DescribeLocalGatewayVirtualInterfaceGroupsInput, _a2 ...request.Option) (*ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeLocalGatewayVirtualInterfaceGroupsInput, ...request.Option) *ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewayVirtualInterfaceGroupsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeLocalGatewayVirtualInterfaceGroupsInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayVirtualInterfaces provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGatewayVirtualInterfaces(_a0 *ec2.DescribeLocalGatewayVirtualInterfacesInput) (*ec2.DescribeLocalGatewayVirtualInterfacesOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeLocalGatewayVirtualInterfacesOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewayVirtualInterfacesInput) *ec2.DescribeLocalGatewayVirtualInterfacesOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewayVirtualInterfacesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewayVirtualInterfacesInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayVirtualInterfacesRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGatewayVirtualInterfacesRequest(_a0 *ec2.DescribeLocalGatewayVirtualInterfacesInput) (*request.Request, *ec2.DescribeLocalGatewayVirtualInterfacesOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewayVirtualInterfacesInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeLocalGatewayVirtualInterfacesOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewayVirtualInterfacesInput) *ec2.DescribeLocalGatewayVirtualInterfacesOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeLocalGatewayVirtualInterfacesOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewayVirtualInterfacesWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeLocalGatewayVirtualInterfacesWithContext(_a0 context.Context, _a1 *ec2.DescribeLocalGatewayVirtualInterfacesInput, _a2 ...request.Option) (*ec2.DescribeLocalGatewayVirtualInterfacesOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeLocalGatewayVirtualInterfacesOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeLocalGatewayVirtualInterfacesInput, ...request.Option) *ec2.DescribeLocalGatewayVirtualInterfacesOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewayVirtualInterfacesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeLocalGatewayVirtualInterfacesInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGateways provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGateways(_a0 *ec2.DescribeLocalGatewaysInput) (*ec2.DescribeLocalGatewaysOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeLocalGatewaysOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewaysInput) *ec2.DescribeLocalGatewaysOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewaysOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewaysInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewaysRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeLocalGatewaysRequest(_a0 *ec2.DescribeLocalGatewaysInput) (*request.Request, *ec2.DescribeLocalGatewaysOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeLocalGatewaysInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeLocalGatewaysOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeLocalGatewaysInput) *ec2.DescribeLocalGatewaysOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeLocalGatewaysOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeLocalGatewaysWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeLocalGatewaysWithContext(_a0 context.Context, _a1 *ec2.DescribeLocalGatewaysInput, _a2 ...request.Option) (*ec2.DescribeLocalGatewaysOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeLocalGatewaysOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeLocalGatewaysInput, ...request.Option) *ec2.DescribeLocalGatewaysOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeLocalGatewaysOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeLocalGatewaysInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
@@ -18225,6 +20089,162 @@ func (_m *EC2API) DescribeTransitGatewayAttachmentsWithContext(_a0 context.Conte
 	return r0, r1
 }
 
+// DescribeTransitGatewayMulticastDomains provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeTransitGatewayMulticastDomains(_a0 *ec2.DescribeTransitGatewayMulticastDomainsInput) (*ec2.DescribeTransitGatewayMulticastDomainsOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeTransitGatewayMulticastDomainsOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeTransitGatewayMulticastDomainsInput) *ec2.DescribeTransitGatewayMulticastDomainsOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeTransitGatewayMulticastDomainsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeTransitGatewayMulticastDomainsInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeTransitGatewayMulticastDomainsRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeTransitGatewayMulticastDomainsRequest(_a0 *ec2.DescribeTransitGatewayMulticastDomainsInput) (*request.Request, *ec2.DescribeTransitGatewayMulticastDomainsOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeTransitGatewayMulticastDomainsInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeTransitGatewayMulticastDomainsOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeTransitGatewayMulticastDomainsInput) *ec2.DescribeTransitGatewayMulticastDomainsOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeTransitGatewayMulticastDomainsOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeTransitGatewayMulticastDomainsWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeTransitGatewayMulticastDomainsWithContext(_a0 context.Context, _a1 *ec2.DescribeTransitGatewayMulticastDomainsInput, _a2 ...request.Option) (*ec2.DescribeTransitGatewayMulticastDomainsOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeTransitGatewayMulticastDomainsOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeTransitGatewayMulticastDomainsInput, ...request.Option) *ec2.DescribeTransitGatewayMulticastDomainsOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeTransitGatewayMulticastDomainsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeTransitGatewayMulticastDomainsInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeTransitGatewayPeeringAttachments provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeTransitGatewayPeeringAttachments(_a0 *ec2.DescribeTransitGatewayPeeringAttachmentsInput) (*ec2.DescribeTransitGatewayPeeringAttachmentsOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DescribeTransitGatewayPeeringAttachmentsOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeTransitGatewayPeeringAttachmentsInput) *ec2.DescribeTransitGatewayPeeringAttachmentsOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeTransitGatewayPeeringAttachmentsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeTransitGatewayPeeringAttachmentsInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeTransitGatewayPeeringAttachmentsRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DescribeTransitGatewayPeeringAttachmentsRequest(_a0 *ec2.DescribeTransitGatewayPeeringAttachmentsInput) (*request.Request, *ec2.DescribeTransitGatewayPeeringAttachmentsOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeTransitGatewayPeeringAttachmentsInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DescribeTransitGatewayPeeringAttachmentsOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DescribeTransitGatewayPeeringAttachmentsInput) *ec2.DescribeTransitGatewayPeeringAttachmentsOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DescribeTransitGatewayPeeringAttachmentsOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeTransitGatewayPeeringAttachmentsWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DescribeTransitGatewayPeeringAttachmentsWithContext(_a0 context.Context, _a1 *ec2.DescribeTransitGatewayPeeringAttachmentsInput, _a2 ...request.Option) (*ec2.DescribeTransitGatewayPeeringAttachmentsOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DescribeTransitGatewayPeeringAttachmentsOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeTransitGatewayPeeringAttachmentsInput, ...request.Option) *ec2.DescribeTransitGatewayPeeringAttachmentsOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DescribeTransitGatewayPeeringAttachmentsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DescribeTransitGatewayPeeringAttachmentsInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // DescribeTransitGatewayRouteTables provides a mock function with given fields: _a0
 func (_m *EC2API) DescribeTransitGatewayRouteTables(_a0 *ec2.DescribeTransitGatewayRouteTablesInput) (*ec2.DescribeTransitGatewayRouteTablesOutput, error) {
 	ret := _m.Called(_a0)
@@ -20743,6 +22763,84 @@ func (_m *EC2API) DisableEbsEncryptionByDefaultWithContext(_a0 context.Context, 
 	return r0, r1
 }
 
+// DisableFastSnapshotRestores provides a mock function with given fields: _a0
+func (_m *EC2API) DisableFastSnapshotRestores(_a0 *ec2.DisableFastSnapshotRestoresInput) (*ec2.DisableFastSnapshotRestoresOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DisableFastSnapshotRestoresOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DisableFastSnapshotRestoresInput) *ec2.DisableFastSnapshotRestoresOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DisableFastSnapshotRestoresOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DisableFastSnapshotRestoresInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DisableFastSnapshotRestoresRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DisableFastSnapshotRestoresRequest(_a0 *ec2.DisableFastSnapshotRestoresInput) (*request.Request, *ec2.DisableFastSnapshotRestoresOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DisableFastSnapshotRestoresInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DisableFastSnapshotRestoresOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DisableFastSnapshotRestoresInput) *ec2.DisableFastSnapshotRestoresOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DisableFastSnapshotRestoresOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DisableFastSnapshotRestoresWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DisableFastSnapshotRestoresWithContext(_a0 context.Context, _a1 *ec2.DisableFastSnapshotRestoresInput, _a2 ...request.Option) (*ec2.DisableFastSnapshotRestoresOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DisableFastSnapshotRestoresOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DisableFastSnapshotRestoresInput, ...request.Option) *ec2.DisableFastSnapshotRestoresOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DisableFastSnapshotRestoresOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DisableFastSnapshotRestoresInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // DisableTransitGatewayRouteTablePropagation provides a mock function with given fields: _a0
 func (_m *EC2API) DisableTransitGatewayRouteTablePropagation(_a0 *ec2.DisableTransitGatewayRouteTablePropagationInput) (*ec2.DisableTransitGatewayRouteTablePropagationOutput, error) {
 	ret := _m.Called(_a0)
@@ -21445,6 +23543,84 @@ func (_m *EC2API) DisassociateSubnetCidrBlockWithContext(_a0 context.Context, _a
 	return r0, r1
 }
 
+// DisassociateTransitGatewayMulticastDomain provides a mock function with given fields: _a0
+func (_m *EC2API) DisassociateTransitGatewayMulticastDomain(_a0 *ec2.DisassociateTransitGatewayMulticastDomainInput) (*ec2.DisassociateTransitGatewayMulticastDomainOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DisassociateTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DisassociateTransitGatewayMulticastDomainInput) *ec2.DisassociateTransitGatewayMulticastDomainOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DisassociateTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DisassociateTransitGatewayMulticastDomainInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DisassociateTransitGatewayMulticastDomainRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DisassociateTransitGatewayMulticastDomainRequest(_a0 *ec2.DisassociateTransitGatewayMulticastDomainInput) (*request.Request, *ec2.DisassociateTransitGatewayMulticastDomainOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DisassociateTransitGatewayMulticastDomainInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DisassociateTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DisassociateTransitGatewayMulticastDomainInput) *ec2.DisassociateTransitGatewayMulticastDomainOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DisassociateTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DisassociateTransitGatewayMulticastDomainWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DisassociateTransitGatewayMulticastDomainWithContext(_a0 context.Context, _a1 *ec2.DisassociateTransitGatewayMulticastDomainInput, _a2 ...request.Option) (*ec2.DisassociateTransitGatewayMulticastDomainOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DisassociateTransitGatewayMulticastDomainOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DisassociateTransitGatewayMulticastDomainInput, ...request.Option) *ec2.DisassociateTransitGatewayMulticastDomainOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DisassociateTransitGatewayMulticastDomainOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DisassociateTransitGatewayMulticastDomainInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // DisassociateTransitGatewayRouteTable provides a mock function with given fields: _a0
 func (_m *EC2API) DisassociateTransitGatewayRouteTable(_a0 *ec2.DisassociateTransitGatewayRouteTableInput) (*ec2.DisassociateTransitGatewayRouteTableOutput, error) {
 	ret := _m.Called(_a0)
@@ -21671,6 +23847,84 @@ func (_m *EC2API) EnableEbsEncryptionByDefaultWithContext(_a0 context.Context, _
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *ec2.EnableEbsEncryptionByDefaultInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// EnableFastSnapshotRestores provides a mock function with given fields: _a0
+func (_m *EC2API) EnableFastSnapshotRestores(_a0 *ec2.EnableFastSnapshotRestoresInput) (*ec2.EnableFastSnapshotRestoresOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.EnableFastSnapshotRestoresOutput
+	if rf, ok := ret.Get(0).(func(*ec2.EnableFastSnapshotRestoresInput) *ec2.EnableFastSnapshotRestoresOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.EnableFastSnapshotRestoresOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.EnableFastSnapshotRestoresInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// EnableFastSnapshotRestoresRequest provides a mock function with given fields: _a0
+func (_m *EC2API) EnableFastSnapshotRestoresRequest(_a0 *ec2.EnableFastSnapshotRestoresInput) (*request.Request, *ec2.EnableFastSnapshotRestoresOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.EnableFastSnapshotRestoresInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.EnableFastSnapshotRestoresOutput
+	if rf, ok := ret.Get(1).(func(*ec2.EnableFastSnapshotRestoresInput) *ec2.EnableFastSnapshotRestoresOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.EnableFastSnapshotRestoresOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// EnableFastSnapshotRestoresWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) EnableFastSnapshotRestoresWithContext(_a0 context.Context, _a1 *ec2.EnableFastSnapshotRestoresInput, _a2 ...request.Option) (*ec2.EnableFastSnapshotRestoresOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.EnableFastSnapshotRestoresOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.EnableFastSnapshotRestoresInput, ...request.Option) *ec2.EnableFastSnapshotRestoresOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.EnableFastSnapshotRestoresOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.EnableFastSnapshotRestoresInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
@@ -22459,6 +24713,84 @@ func (_m *EC2API) GetCapacityReservationUsageWithContext(_a0 context.Context, _a
 	return r0, r1
 }
 
+// GetCoipPoolUsage provides a mock function with given fields: _a0
+func (_m *EC2API) GetCoipPoolUsage(_a0 *ec2.GetCoipPoolUsageInput) (*ec2.GetCoipPoolUsageOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.GetCoipPoolUsageOutput
+	if rf, ok := ret.Get(0).(func(*ec2.GetCoipPoolUsageInput) *ec2.GetCoipPoolUsageOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.GetCoipPoolUsageOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.GetCoipPoolUsageInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetCoipPoolUsageRequest provides a mock function with given fields: _a0
+func (_m *EC2API) GetCoipPoolUsageRequest(_a0 *ec2.GetCoipPoolUsageInput) (*request.Request, *ec2.GetCoipPoolUsageOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.GetCoipPoolUsageInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.GetCoipPoolUsageOutput
+	if rf, ok := ret.Get(1).(func(*ec2.GetCoipPoolUsageInput) *ec2.GetCoipPoolUsageOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.GetCoipPoolUsageOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// GetCoipPoolUsageWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) GetCoipPoolUsageWithContext(_a0 context.Context, _a1 *ec2.GetCoipPoolUsageInput, _a2 ...request.Option) (*ec2.GetCoipPoolUsageOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.GetCoipPoolUsageOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.GetCoipPoolUsageInput, ...request.Option) *ec2.GetCoipPoolUsageOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.GetCoipPoolUsageOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.GetCoipPoolUsageInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetConsoleOutput provides a mock function with given fields: _a0
 func (_m *EC2API) GetConsoleOutput(_a0 *ec2.GetConsoleOutputInput) (*ec2.GetConsoleOutputOutput, error) {
 	ret := _m.Called(_a0)
@@ -22607,6 +24939,84 @@ func (_m *EC2API) GetConsoleScreenshotWithContext(_a0 context.Context, _a1 *ec2.
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *ec2.GetConsoleScreenshotInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetDefaultCreditSpecification provides a mock function with given fields: _a0
+func (_m *EC2API) GetDefaultCreditSpecification(_a0 *ec2.GetDefaultCreditSpecificationInput) (*ec2.GetDefaultCreditSpecificationOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.GetDefaultCreditSpecificationOutput
+	if rf, ok := ret.Get(0).(func(*ec2.GetDefaultCreditSpecificationInput) *ec2.GetDefaultCreditSpecificationOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.GetDefaultCreditSpecificationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.GetDefaultCreditSpecificationInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetDefaultCreditSpecificationRequest provides a mock function with given fields: _a0
+func (_m *EC2API) GetDefaultCreditSpecificationRequest(_a0 *ec2.GetDefaultCreditSpecificationInput) (*request.Request, *ec2.GetDefaultCreditSpecificationOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.GetDefaultCreditSpecificationInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.GetDefaultCreditSpecificationOutput
+	if rf, ok := ret.Get(1).(func(*ec2.GetDefaultCreditSpecificationInput) *ec2.GetDefaultCreditSpecificationOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.GetDefaultCreditSpecificationOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// GetDefaultCreditSpecificationWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) GetDefaultCreditSpecificationWithContext(_a0 context.Context, _a1 *ec2.GetDefaultCreditSpecificationInput, _a2 ...request.Option) (*ec2.GetDefaultCreditSpecificationOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.GetDefaultCreditSpecificationOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.GetDefaultCreditSpecificationInput, ...request.Option) *ec2.GetDefaultCreditSpecificationOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.GetDefaultCreditSpecificationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.GetDefaultCreditSpecificationInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
@@ -23188,6 +25598,84 @@ func (_m *EC2API) GetTransitGatewayAttachmentPropagationsWithContext(_a0 context
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *ec2.GetTransitGatewayAttachmentPropagationsInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetTransitGatewayMulticastDomainAssociations provides a mock function with given fields: _a0
+func (_m *EC2API) GetTransitGatewayMulticastDomainAssociations(_a0 *ec2.GetTransitGatewayMulticastDomainAssociationsInput) (*ec2.GetTransitGatewayMulticastDomainAssociationsOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.GetTransitGatewayMulticastDomainAssociationsOutput
+	if rf, ok := ret.Get(0).(func(*ec2.GetTransitGatewayMulticastDomainAssociationsInput) *ec2.GetTransitGatewayMulticastDomainAssociationsOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.GetTransitGatewayMulticastDomainAssociationsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.GetTransitGatewayMulticastDomainAssociationsInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetTransitGatewayMulticastDomainAssociationsRequest provides a mock function with given fields: _a0
+func (_m *EC2API) GetTransitGatewayMulticastDomainAssociationsRequest(_a0 *ec2.GetTransitGatewayMulticastDomainAssociationsInput) (*request.Request, *ec2.GetTransitGatewayMulticastDomainAssociationsOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.GetTransitGatewayMulticastDomainAssociationsInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.GetTransitGatewayMulticastDomainAssociationsOutput
+	if rf, ok := ret.Get(1).(func(*ec2.GetTransitGatewayMulticastDomainAssociationsInput) *ec2.GetTransitGatewayMulticastDomainAssociationsOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.GetTransitGatewayMulticastDomainAssociationsOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// GetTransitGatewayMulticastDomainAssociationsWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) GetTransitGatewayMulticastDomainAssociationsWithContext(_a0 context.Context, _a1 *ec2.GetTransitGatewayMulticastDomainAssociationsInput, _a2 ...request.Option) (*ec2.GetTransitGatewayMulticastDomainAssociationsOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.GetTransitGatewayMulticastDomainAssociationsOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.GetTransitGatewayMulticastDomainAssociationsInput, ...request.Option) *ec2.GetTransitGatewayMulticastDomainAssociationsOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.GetTransitGatewayMulticastDomainAssociationsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.GetTransitGatewayMulticastDomainAssociationsInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
@@ -24046,6 +26534,84 @@ func (_m *EC2API) ModifyClientVpnEndpointWithContext(_a0 context.Context, _a1 *e
 	return r0, r1
 }
 
+// ModifyDefaultCreditSpecification provides a mock function with given fields: _a0
+func (_m *EC2API) ModifyDefaultCreditSpecification(_a0 *ec2.ModifyDefaultCreditSpecificationInput) (*ec2.ModifyDefaultCreditSpecificationOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.ModifyDefaultCreditSpecificationOutput
+	if rf, ok := ret.Get(0).(func(*ec2.ModifyDefaultCreditSpecificationInput) *ec2.ModifyDefaultCreditSpecificationOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.ModifyDefaultCreditSpecificationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.ModifyDefaultCreditSpecificationInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ModifyDefaultCreditSpecificationRequest provides a mock function with given fields: _a0
+func (_m *EC2API) ModifyDefaultCreditSpecificationRequest(_a0 *ec2.ModifyDefaultCreditSpecificationInput) (*request.Request, *ec2.ModifyDefaultCreditSpecificationOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.ModifyDefaultCreditSpecificationInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.ModifyDefaultCreditSpecificationOutput
+	if rf, ok := ret.Get(1).(func(*ec2.ModifyDefaultCreditSpecificationInput) *ec2.ModifyDefaultCreditSpecificationOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.ModifyDefaultCreditSpecificationOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// ModifyDefaultCreditSpecificationWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) ModifyDefaultCreditSpecificationWithContext(_a0 context.Context, _a1 *ec2.ModifyDefaultCreditSpecificationInput, _a2 ...request.Option) (*ec2.ModifyDefaultCreditSpecificationOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.ModifyDefaultCreditSpecificationOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.ModifyDefaultCreditSpecificationInput, ...request.Option) *ec2.ModifyDefaultCreditSpecificationOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.ModifyDefaultCreditSpecificationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.ModifyDefaultCreditSpecificationInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ModifyEbsDefaultKmsKeyId provides a mock function with given fields: _a0
 func (_m *EC2API) ModifyEbsDefaultKmsKeyId(_a0 *ec2.ModifyEbsDefaultKmsKeyIdInput) (*ec2.ModifyEbsDefaultKmsKeyIdOutput, error) {
 	ret := _m.Called(_a0)
@@ -24896,6 +27462,84 @@ func (_m *EC2API) ModifyInstanceEventStartTimeWithContext(_a0 context.Context, _
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *ec2.ModifyInstanceEventStartTimeInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ModifyInstanceMetadataOptions provides a mock function with given fields: _a0
+func (_m *EC2API) ModifyInstanceMetadataOptions(_a0 *ec2.ModifyInstanceMetadataOptionsInput) (*ec2.ModifyInstanceMetadataOptionsOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.ModifyInstanceMetadataOptionsOutput
+	if rf, ok := ret.Get(0).(func(*ec2.ModifyInstanceMetadataOptionsInput) *ec2.ModifyInstanceMetadataOptionsOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.ModifyInstanceMetadataOptionsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.ModifyInstanceMetadataOptionsInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ModifyInstanceMetadataOptionsRequest provides a mock function with given fields: _a0
+func (_m *EC2API) ModifyInstanceMetadataOptionsRequest(_a0 *ec2.ModifyInstanceMetadataOptionsInput) (*request.Request, *ec2.ModifyInstanceMetadataOptionsOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.ModifyInstanceMetadataOptionsInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.ModifyInstanceMetadataOptionsOutput
+	if rf, ok := ret.Get(1).(func(*ec2.ModifyInstanceMetadataOptionsInput) *ec2.ModifyInstanceMetadataOptionsOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.ModifyInstanceMetadataOptionsOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// ModifyInstanceMetadataOptionsWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) ModifyInstanceMetadataOptionsWithContext(_a0 context.Context, _a1 *ec2.ModifyInstanceMetadataOptionsInput, _a2 ...request.Option) (*ec2.ModifyInstanceMetadataOptionsOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.ModifyInstanceMetadataOptionsOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.ModifyInstanceMetadataOptionsInput, ...request.Option) *ec2.ModifyInstanceMetadataOptionsOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.ModifyInstanceMetadataOptionsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.ModifyInstanceMetadataOptionsInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
@@ -27322,6 +29966,240 @@ func (_m *EC2API) RegisterImageWithContext(_a0 context.Context, _a1 *ec2.Registe
 	return r0, r1
 }
 
+// RegisterTransitGatewayMulticastGroupMembers provides a mock function with given fields: _a0
+func (_m *EC2API) RegisterTransitGatewayMulticastGroupMembers(_a0 *ec2.RegisterTransitGatewayMulticastGroupMembersInput) (*ec2.RegisterTransitGatewayMulticastGroupMembersOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.RegisterTransitGatewayMulticastGroupMembersOutput
+	if rf, ok := ret.Get(0).(func(*ec2.RegisterTransitGatewayMulticastGroupMembersInput) *ec2.RegisterTransitGatewayMulticastGroupMembersOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.RegisterTransitGatewayMulticastGroupMembersOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.RegisterTransitGatewayMulticastGroupMembersInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RegisterTransitGatewayMulticastGroupMembersRequest provides a mock function with given fields: _a0
+func (_m *EC2API) RegisterTransitGatewayMulticastGroupMembersRequest(_a0 *ec2.RegisterTransitGatewayMulticastGroupMembersInput) (*request.Request, *ec2.RegisterTransitGatewayMulticastGroupMembersOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.RegisterTransitGatewayMulticastGroupMembersInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.RegisterTransitGatewayMulticastGroupMembersOutput
+	if rf, ok := ret.Get(1).(func(*ec2.RegisterTransitGatewayMulticastGroupMembersInput) *ec2.RegisterTransitGatewayMulticastGroupMembersOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.RegisterTransitGatewayMulticastGroupMembersOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// RegisterTransitGatewayMulticastGroupMembersWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) RegisterTransitGatewayMulticastGroupMembersWithContext(_a0 context.Context, _a1 *ec2.RegisterTransitGatewayMulticastGroupMembersInput, _a2 ...request.Option) (*ec2.RegisterTransitGatewayMulticastGroupMembersOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.RegisterTransitGatewayMulticastGroupMembersOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.RegisterTransitGatewayMulticastGroupMembersInput, ...request.Option) *ec2.RegisterTransitGatewayMulticastGroupMembersOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.RegisterTransitGatewayMulticastGroupMembersOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.RegisterTransitGatewayMulticastGroupMembersInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RegisterTransitGatewayMulticastGroupSources provides a mock function with given fields: _a0
+func (_m *EC2API) RegisterTransitGatewayMulticastGroupSources(_a0 *ec2.RegisterTransitGatewayMulticastGroupSourcesInput) (*ec2.RegisterTransitGatewayMulticastGroupSourcesOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.RegisterTransitGatewayMulticastGroupSourcesOutput
+	if rf, ok := ret.Get(0).(func(*ec2.RegisterTransitGatewayMulticastGroupSourcesInput) *ec2.RegisterTransitGatewayMulticastGroupSourcesOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.RegisterTransitGatewayMulticastGroupSourcesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.RegisterTransitGatewayMulticastGroupSourcesInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RegisterTransitGatewayMulticastGroupSourcesRequest provides a mock function with given fields: _a0
+func (_m *EC2API) RegisterTransitGatewayMulticastGroupSourcesRequest(_a0 *ec2.RegisterTransitGatewayMulticastGroupSourcesInput) (*request.Request, *ec2.RegisterTransitGatewayMulticastGroupSourcesOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.RegisterTransitGatewayMulticastGroupSourcesInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.RegisterTransitGatewayMulticastGroupSourcesOutput
+	if rf, ok := ret.Get(1).(func(*ec2.RegisterTransitGatewayMulticastGroupSourcesInput) *ec2.RegisterTransitGatewayMulticastGroupSourcesOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.RegisterTransitGatewayMulticastGroupSourcesOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// RegisterTransitGatewayMulticastGroupSourcesWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) RegisterTransitGatewayMulticastGroupSourcesWithContext(_a0 context.Context, _a1 *ec2.RegisterTransitGatewayMulticastGroupSourcesInput, _a2 ...request.Option) (*ec2.RegisterTransitGatewayMulticastGroupSourcesOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.RegisterTransitGatewayMulticastGroupSourcesOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.RegisterTransitGatewayMulticastGroupSourcesInput, ...request.Option) *ec2.RegisterTransitGatewayMulticastGroupSourcesOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.RegisterTransitGatewayMulticastGroupSourcesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.RegisterTransitGatewayMulticastGroupSourcesInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RejectTransitGatewayPeeringAttachment provides a mock function with given fields: _a0
+func (_m *EC2API) RejectTransitGatewayPeeringAttachment(_a0 *ec2.RejectTransitGatewayPeeringAttachmentInput) (*ec2.RejectTransitGatewayPeeringAttachmentOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.RejectTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(0).(func(*ec2.RejectTransitGatewayPeeringAttachmentInput) *ec2.RejectTransitGatewayPeeringAttachmentOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.RejectTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.RejectTransitGatewayPeeringAttachmentInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RejectTransitGatewayPeeringAttachmentRequest provides a mock function with given fields: _a0
+func (_m *EC2API) RejectTransitGatewayPeeringAttachmentRequest(_a0 *ec2.RejectTransitGatewayPeeringAttachmentInput) (*request.Request, *ec2.RejectTransitGatewayPeeringAttachmentOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.RejectTransitGatewayPeeringAttachmentInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.RejectTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(1).(func(*ec2.RejectTransitGatewayPeeringAttachmentInput) *ec2.RejectTransitGatewayPeeringAttachmentOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.RejectTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// RejectTransitGatewayPeeringAttachmentWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) RejectTransitGatewayPeeringAttachmentWithContext(_a0 context.Context, _a1 *ec2.RejectTransitGatewayPeeringAttachmentInput, _a2 ...request.Option) (*ec2.RejectTransitGatewayPeeringAttachmentOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.RejectTransitGatewayPeeringAttachmentOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.RejectTransitGatewayPeeringAttachmentInput, ...request.Option) *ec2.RejectTransitGatewayPeeringAttachmentOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.RejectTransitGatewayPeeringAttachmentOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.RejectTransitGatewayPeeringAttachmentInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // RejectTransitGatewayVpcAttachment provides a mock function with given fields: _a0
 func (_m *EC2API) RejectTransitGatewayVpcAttachment(_a0 *ec2.RejectTransitGatewayVpcAttachmentInput) (*ec2.RejectTransitGatewayVpcAttachmentOutput, error) {
 	ret := _m.Called(_a0)
@@ -29350,6 +32228,162 @@ func (_m *EC2API) RunScheduledInstancesWithContext(_a0 context.Context, _a1 *ec2
 	return r0, r1
 }
 
+// SearchLocalGatewayRoutes provides a mock function with given fields: _a0
+func (_m *EC2API) SearchLocalGatewayRoutes(_a0 *ec2.SearchLocalGatewayRoutesInput) (*ec2.SearchLocalGatewayRoutesOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.SearchLocalGatewayRoutesOutput
+	if rf, ok := ret.Get(0).(func(*ec2.SearchLocalGatewayRoutesInput) *ec2.SearchLocalGatewayRoutesOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.SearchLocalGatewayRoutesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.SearchLocalGatewayRoutesInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SearchLocalGatewayRoutesRequest provides a mock function with given fields: _a0
+func (_m *EC2API) SearchLocalGatewayRoutesRequest(_a0 *ec2.SearchLocalGatewayRoutesInput) (*request.Request, *ec2.SearchLocalGatewayRoutesOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.SearchLocalGatewayRoutesInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.SearchLocalGatewayRoutesOutput
+	if rf, ok := ret.Get(1).(func(*ec2.SearchLocalGatewayRoutesInput) *ec2.SearchLocalGatewayRoutesOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.SearchLocalGatewayRoutesOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// SearchLocalGatewayRoutesWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) SearchLocalGatewayRoutesWithContext(_a0 context.Context, _a1 *ec2.SearchLocalGatewayRoutesInput, _a2 ...request.Option) (*ec2.SearchLocalGatewayRoutesOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.SearchLocalGatewayRoutesOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.SearchLocalGatewayRoutesInput, ...request.Option) *ec2.SearchLocalGatewayRoutesOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.SearchLocalGatewayRoutesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.SearchLocalGatewayRoutesInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SearchTransitGatewayMulticastGroups provides a mock function with given fields: _a0
+func (_m *EC2API) SearchTransitGatewayMulticastGroups(_a0 *ec2.SearchTransitGatewayMulticastGroupsInput) (*ec2.SearchTransitGatewayMulticastGroupsOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.SearchTransitGatewayMulticastGroupsOutput
+	if rf, ok := ret.Get(0).(func(*ec2.SearchTransitGatewayMulticastGroupsInput) *ec2.SearchTransitGatewayMulticastGroupsOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.SearchTransitGatewayMulticastGroupsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.SearchTransitGatewayMulticastGroupsInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SearchTransitGatewayMulticastGroupsRequest provides a mock function with given fields: _a0
+func (_m *EC2API) SearchTransitGatewayMulticastGroupsRequest(_a0 *ec2.SearchTransitGatewayMulticastGroupsInput) (*request.Request, *ec2.SearchTransitGatewayMulticastGroupsOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.SearchTransitGatewayMulticastGroupsInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.SearchTransitGatewayMulticastGroupsOutput
+	if rf, ok := ret.Get(1).(func(*ec2.SearchTransitGatewayMulticastGroupsInput) *ec2.SearchTransitGatewayMulticastGroupsOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.SearchTransitGatewayMulticastGroupsOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// SearchTransitGatewayMulticastGroupsWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) SearchTransitGatewayMulticastGroupsWithContext(_a0 context.Context, _a1 *ec2.SearchTransitGatewayMulticastGroupsInput, _a2 ...request.Option) (*ec2.SearchTransitGatewayMulticastGroupsOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.SearchTransitGatewayMulticastGroupsOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.SearchTransitGatewayMulticastGroupsInput, ...request.Option) *ec2.SearchTransitGatewayMulticastGroupsOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.SearchTransitGatewayMulticastGroupsOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.SearchTransitGatewayMulticastGroupsInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // SearchTransitGatewayRoutes provides a mock function with given fields: _a0
 func (_m *EC2API) SearchTransitGatewayRoutes(_a0 *ec2.SearchTransitGatewayRoutesInput) (*ec2.SearchTransitGatewayRoutesOutput, error) {
 	ret := _m.Called(_a0)
@@ -29576,6 +32610,84 @@ func (_m *EC2API) StartInstancesWithContext(_a0 context.Context, _a1 *ec2.StartI
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *ec2.StartInstancesInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// StartVpcEndpointServicePrivateDnsVerification provides a mock function with given fields: _a0
+func (_m *EC2API) StartVpcEndpointServicePrivateDnsVerification(_a0 *ec2.StartVpcEndpointServicePrivateDnsVerificationInput) (*ec2.StartVpcEndpointServicePrivateDnsVerificationOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.StartVpcEndpointServicePrivateDnsVerificationOutput
+	if rf, ok := ret.Get(0).(func(*ec2.StartVpcEndpointServicePrivateDnsVerificationInput) *ec2.StartVpcEndpointServicePrivateDnsVerificationOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.StartVpcEndpointServicePrivateDnsVerificationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.StartVpcEndpointServicePrivateDnsVerificationInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// StartVpcEndpointServicePrivateDnsVerificationRequest provides a mock function with given fields: _a0
+func (_m *EC2API) StartVpcEndpointServicePrivateDnsVerificationRequest(_a0 *ec2.StartVpcEndpointServicePrivateDnsVerificationInput) (*request.Request, *ec2.StartVpcEndpointServicePrivateDnsVerificationOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.StartVpcEndpointServicePrivateDnsVerificationInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.StartVpcEndpointServicePrivateDnsVerificationOutput
+	if rf, ok := ret.Get(1).(func(*ec2.StartVpcEndpointServicePrivateDnsVerificationInput) *ec2.StartVpcEndpointServicePrivateDnsVerificationOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.StartVpcEndpointServicePrivateDnsVerificationOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// StartVpcEndpointServicePrivateDnsVerificationWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) StartVpcEndpointServicePrivateDnsVerificationWithContext(_a0 context.Context, _a1 *ec2.StartVpcEndpointServicePrivateDnsVerificationInput, _a2 ...request.Option) (*ec2.StartVpcEndpointServicePrivateDnsVerificationOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.StartVpcEndpointServicePrivateDnsVerificationOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.StartVpcEndpointServicePrivateDnsVerificationInput, ...request.Option) *ec2.StartVpcEndpointServicePrivateDnsVerificationOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.StartVpcEndpointServicePrivateDnsVerificationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.StartVpcEndpointServicePrivateDnsVerificationInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)
@@ -30830,6 +33942,41 @@ func (_m *EC2API) WaitUntilPasswordDataAvailableWithContext(_a0 context.Context,
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, *ec2.GetPasswordDataInput, ...request.WaiterOption) error); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// WaitUntilSecurityGroupExists provides a mock function with given fields: _a0
+func (_m *EC2API) WaitUntilSecurityGroupExists(_a0 *ec2.DescribeSecurityGroupsInput) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*ec2.DescribeSecurityGroupsInput) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// WaitUntilSecurityGroupExistsWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) WaitUntilSecurityGroupExistsWithContext(_a0 context.Context, _a1 *ec2.DescribeSecurityGroupsInput, _a2 ...request.WaiterOption) error {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DescribeSecurityGroupsInput, ...request.WaiterOption) error); ok {
 		r0 = rf(_a0, _a1, _a2...)
 	} else {
 		r0 = ret.Error(0)

--- a/mocks/ResourceGroupsTaggingAPIAPI.go
+++ b/mocks/ResourceGroupsTaggingAPIAPI.go
@@ -16,6 +16,197 @@ type ResourceGroupsTaggingAPIAPI struct {
 	mock.Mock
 }
 
+// DescribeReportCreation provides a mock function with given fields: _a0
+func (_m *ResourceGroupsTaggingAPIAPI) DescribeReportCreation(_a0 *resourcegroupstaggingapi.DescribeReportCreationInput) (*resourcegroupstaggingapi.DescribeReportCreationOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *resourcegroupstaggingapi.DescribeReportCreationOutput
+	if rf, ok := ret.Get(0).(func(*resourcegroupstaggingapi.DescribeReportCreationInput) *resourcegroupstaggingapi.DescribeReportCreationOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcegroupstaggingapi.DescribeReportCreationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*resourcegroupstaggingapi.DescribeReportCreationInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DescribeReportCreationRequest provides a mock function with given fields: _a0
+func (_m *ResourceGroupsTaggingAPIAPI) DescribeReportCreationRequest(_a0 *resourcegroupstaggingapi.DescribeReportCreationInput) (*request.Request, *resourcegroupstaggingapi.DescribeReportCreationOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*resourcegroupstaggingapi.DescribeReportCreationInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *resourcegroupstaggingapi.DescribeReportCreationOutput
+	if rf, ok := ret.Get(1).(func(*resourcegroupstaggingapi.DescribeReportCreationInput) *resourcegroupstaggingapi.DescribeReportCreationOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*resourcegroupstaggingapi.DescribeReportCreationOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DescribeReportCreationWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *ResourceGroupsTaggingAPIAPI) DescribeReportCreationWithContext(_a0 context.Context, _a1 *resourcegroupstaggingapi.DescribeReportCreationInput, _a2 ...request.Option) (*resourcegroupstaggingapi.DescribeReportCreationOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *resourcegroupstaggingapi.DescribeReportCreationOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *resourcegroupstaggingapi.DescribeReportCreationInput, ...request.Option) *resourcegroupstaggingapi.DescribeReportCreationOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcegroupstaggingapi.DescribeReportCreationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *resourcegroupstaggingapi.DescribeReportCreationInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetComplianceSummary provides a mock function with given fields: _a0
+func (_m *ResourceGroupsTaggingAPIAPI) GetComplianceSummary(_a0 *resourcegroupstaggingapi.GetComplianceSummaryInput) (*resourcegroupstaggingapi.GetComplianceSummaryOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *resourcegroupstaggingapi.GetComplianceSummaryOutput
+	if rf, ok := ret.Get(0).(func(*resourcegroupstaggingapi.GetComplianceSummaryInput) *resourcegroupstaggingapi.GetComplianceSummaryOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcegroupstaggingapi.GetComplianceSummaryOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*resourcegroupstaggingapi.GetComplianceSummaryInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetComplianceSummaryPages provides a mock function with given fields: _a0, _a1
+func (_m *ResourceGroupsTaggingAPIAPI) GetComplianceSummaryPages(_a0 *resourcegroupstaggingapi.GetComplianceSummaryInput, _a1 func(*resourcegroupstaggingapi.GetComplianceSummaryOutput, bool) bool) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*resourcegroupstaggingapi.GetComplianceSummaryInput, func(*resourcegroupstaggingapi.GetComplianceSummaryOutput, bool) bool) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// GetComplianceSummaryPagesWithContext provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *ResourceGroupsTaggingAPIAPI) GetComplianceSummaryPagesWithContext(_a0 context.Context, _a1 *resourcegroupstaggingapi.GetComplianceSummaryInput, _a2 func(*resourcegroupstaggingapi.GetComplianceSummaryOutput, bool) bool, _a3 ...request.Option) error {
+	_va := make([]interface{}, len(_a3))
+	for _i := range _a3 {
+		_va[_i] = _a3[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1, _a2)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *resourcegroupstaggingapi.GetComplianceSummaryInput, func(*resourcegroupstaggingapi.GetComplianceSummaryOutput, bool) bool, ...request.Option) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// GetComplianceSummaryRequest provides a mock function with given fields: _a0
+func (_m *ResourceGroupsTaggingAPIAPI) GetComplianceSummaryRequest(_a0 *resourcegroupstaggingapi.GetComplianceSummaryInput) (*request.Request, *resourcegroupstaggingapi.GetComplianceSummaryOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*resourcegroupstaggingapi.GetComplianceSummaryInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *resourcegroupstaggingapi.GetComplianceSummaryOutput
+	if rf, ok := ret.Get(1).(func(*resourcegroupstaggingapi.GetComplianceSummaryInput) *resourcegroupstaggingapi.GetComplianceSummaryOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*resourcegroupstaggingapi.GetComplianceSummaryOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// GetComplianceSummaryWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *ResourceGroupsTaggingAPIAPI) GetComplianceSummaryWithContext(_a0 context.Context, _a1 *resourcegroupstaggingapi.GetComplianceSummaryInput, _a2 ...request.Option) (*resourcegroupstaggingapi.GetComplianceSummaryOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *resourcegroupstaggingapi.GetComplianceSummaryOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *resourcegroupstaggingapi.GetComplianceSummaryInput, ...request.Option) *resourcegroupstaggingapi.GetComplianceSummaryOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcegroupstaggingapi.GetComplianceSummaryOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *resourcegroupstaggingapi.GetComplianceSummaryInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetResources provides a mock function with given fields: _a0
 func (_m *ResourceGroupsTaggingAPIAPI) GetResources(_a0 *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
 	ret := _m.Called(_a0)
@@ -347,6 +538,84 @@ func (_m *ResourceGroupsTaggingAPIAPI) GetTagValuesWithContext(_a0 context.Conte
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *resourcegroupstaggingapi.GetTagValuesInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// StartReportCreation provides a mock function with given fields: _a0
+func (_m *ResourceGroupsTaggingAPIAPI) StartReportCreation(_a0 *resourcegroupstaggingapi.StartReportCreationInput) (*resourcegroupstaggingapi.StartReportCreationOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *resourcegroupstaggingapi.StartReportCreationOutput
+	if rf, ok := ret.Get(0).(func(*resourcegroupstaggingapi.StartReportCreationInput) *resourcegroupstaggingapi.StartReportCreationOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcegroupstaggingapi.StartReportCreationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*resourcegroupstaggingapi.StartReportCreationInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// StartReportCreationRequest provides a mock function with given fields: _a0
+func (_m *ResourceGroupsTaggingAPIAPI) StartReportCreationRequest(_a0 *resourcegroupstaggingapi.StartReportCreationInput) (*request.Request, *resourcegroupstaggingapi.StartReportCreationOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*resourcegroupstaggingapi.StartReportCreationInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *resourcegroupstaggingapi.StartReportCreationOutput
+	if rf, ok := ret.Get(1).(func(*resourcegroupstaggingapi.StartReportCreationInput) *resourcegroupstaggingapi.StartReportCreationOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*resourcegroupstaggingapi.StartReportCreationOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// StartReportCreationWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *ResourceGroupsTaggingAPIAPI) StartReportCreationWithContext(_a0 context.Context, _a1 *resourcegroupstaggingapi.StartReportCreationInput, _a2 ...request.Option) (*resourcegroupstaggingapi.StartReportCreationOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *resourcegroupstaggingapi.StartReportCreationOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *resourcegroupstaggingapi.StartReportCreationInput, ...request.Option) *resourcegroupstaggingapi.StartReportCreationOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcegroupstaggingapi.StartReportCreationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *resourcegroupstaggingapi.StartReportCreationInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)


### PR DESCRIPTION
# Supports Advanced routing:  fix https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/909

We will add a new annotation called `alb.ingress.kubernetes.io/conditions.<use-annotation-service>` to let customer specify routing conditions in additional to original host+path condition.
```
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: simple-ingress-example
  annotations:
    alb.ingress.kubernetes.io/conditions.advanced-routing: '[{"Field": "http-request-method", "HttpRequestMethodConfig": {"Values" : ["POST"]}}, {"Field": "query-string", "QueryStringConfig": {"Values" : [{"Key": "user", "Value": "m00nf1sh"}]}}]'
spec:
  rules:
  - host: m00nf1sh.example.com
    http:
      paths:
      - path: /foo
        backend:
          serviceName: advanced-routing
          servicePort: use-annotation
```
The one-line json for 'advanced-routing' above expands to
```
[
   {
      "Field": "http-request-method",
      "HttpRequestMethodConfig": {
         "Values": [
            "POST"
         ]
      }
   },
   {
      "Field": "query-string",
      "QueryStringConfig": {
         "Values": [
            {
               "Key": "user",
               "Value": "m00nf1sh"
            }
         ]
      }
   }
]
```
By merging in original HOST+PATH condition in Ingress, the result routing condition matches an HTTP request of "POST m00nf1sh.example.com/foo?user=m00nf1sh". 

Note:
1. The conditions JSON configuration schema is an close match of ALB's condition API to allow us keep up with future ALB enhancements quickly: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-conditions.html
1. The original HTTP+PATH condition in Ingress will be merged into the conditions specified via annotation. E.g. If customer also specified HOST conditions via annotation, either the HOST in Ingress or HOST in annotation will be matched.  This is intended to honer the Ingress specification.
1. when magic string `use-annotation` is specified, the `alb.ingress.kubernetes.io/conditions.<use-annotation-service>` will be an optional annotation while `alb.ingress.kubernetes.io/actions.<use-annotation-service>` is an required annotation. both annotation can be used together.



#  Supports weighted loadBalancing: fix https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/1078

We extend our original `alb.ingress.kubernetes.io/actions.<use-annotation-service>` annotation to supported added [ForwardConfig](https://github.com/boto/botocore/blob/develop/botocore/data/elbv2/2015-12-01/service-2.json#L1697). Sample Ingress below:
```
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: simple-ingress-example
  annotations:
    alb.ingress.kubernetes.io/actions.weighted-routing: '{"Type":"forward","ForwardConfig":{"TargetGroupStickinessConfig":{"Enabled":"True","DurationSeconds":100},"TargetGroups":[{"Weight":20,"ServiceName":"Service1","ServicePort":"80"},{"Weight":80,"TargetGroupArn":"arn:aws:******/external-legecy-tg"}]}}'
spec:
  rules:
  - host: m00nf1sh.example.com
    http:
      paths:
      - path: /foo
        backend:
          serviceName: weighted-routing
          servicePort: use-annotation
```
The one-line json for 'weighted-routing' above expands to
```
{ 
   "Type":"forward",
   "ForwardConfig":{ 
      "TargetGroupStickinessConfig":{ 
         "Enabled":"True",
         "DurationSeconds":100
      },
      "TargetGroups":[ 
         { 
            "Weight":20,
            "ServiceName":"service1",
            "ServicePort":"80"
         },
         { 
            "Weight":80,
            "TargetGroupArn":"arn:aws:******/external-legecy-tg"
         }
      ]
   }
}
```
The above configuration result in HTTP request to "m00nf1sh.example.com/foo" been routed to service1:80 with 20% possibility and an external-provisioned target group("arn:aws:******/external-legecy-tg") with 80% possibility. The routing decision will be stick per client for 100 second.

Note:
1. The actions JSON configuration schema is a close match of ALB's action API to allow us keep up with future ALB enhancements quickly.
1. The TargetGroups within ForwardConfig have been extended to allow use both Kubernetes Service and TargetGroupArn. Customers can configure backend with Kubernetes Service only / TargetGroupArn only / mix of two(for migration use case)
1. **limitation**: the auth annotation on service if not honored if it's using use-annotation forward-action.It's intentionally not supported since the ALB's API can only configure auth per rule instead of per targetGroup(in weighted routing). So auth actions shouldn't be bound to services). Use cases like have different auth configuration based on path along with use advanced-routing/weighted-routing have to wait for ingressGroup(in V2).