### PR TITLE
Rewrite GetClusterSubnets() using EC2 specific API

### DIFF
--- a/internal/aws/ec2.go
+++ b/internal/aws/ec2.go
@@ -44,6 +44,9 @@ type EC2API interface {
 	// GetSecurityGroupsByName retrieves securityGroups by securityGroupName(SecurityGroup names within vpc are unique)
 	GetSecurityGroupsByName(context.Context, []string) ([]*ec2.SecurityGroup, error)
 
+	// GetClusterSubnets retrieves the subnets associated with the cluster, by matching tags
+	GetClusterSubnets(string) ([]*ec2.Subnet, error)
+
 	// DeleteSecurityGroupByID delete securityGroup by securityGroupID
 	DeleteSecurityGroupByID(context.Context, string) error
 
@@ -164,6 +167,26 @@ func (c *Cloud) GetSubnetsByNameOrID(ctx context.Context, nameOrIDs []string) (s
 	return
 }
 
+func (c *Cloud) GetClusterSubnets(tagSubnetType string) ([]*ec2.Subnet, error) {
+	in := &ec2.DescribeSubnetsInput{Filters: []*ec2.Filter{
+		{
+			Name:   aws.String("tag:kubernetes.io/cluster/" + c.clusterName),
+			Values: aws.StringSlice([]string{"owned", "shared"}),
+		},
+		{
+			Name:   aws.String("tag:" + tagSubnetType),
+			Values: aws.StringSlice([]string{"", "1"}),
+		},
+	}}
+
+	result, err := c.describeSubnetsHelper(in)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (c *Cloud) GetSecurityGroupsByName(ctx context.Context, names []string) (groups []*ec2.SecurityGroup, err error) {
 	in := &ec2.DescribeSecurityGroupsInput{Filters: []*ec2.Filter{
 		{
@@ -270,6 +293,16 @@ func (c *Cloud) describeSecurityGroupsHelper(params *ec2.DescribeSecurityGroupsI
 	}
 	err = p.Err()
 	return results, err
+}
+
+// describeSubnetsHelper is a helper to handle pagination for DescribeSubnets API call
+func (c *Cloud) describeSubnetsHelper(params *ec2.DescribeSubnetsInput) (result []*ec2.Subnet, err error) {
+	err = c.ec2.DescribeSubnetsPages(params, func(output *ec2.DescribeSubnetsOutput, _ bool) bool {
+		result = append(result, output.Subnets...)
+		return true
+	})
+
+	return result, err
 }
 
 func (c *Cloud) describeInstancesHelper(params *ec2.DescribeInstancesInput) (result []*ec2.Reservation, err error) {

--- a/internal/aws/rgt.go
+++ b/internal/aws/rgt.go
@@ -2,15 +2,9 @@ package aws
 
 import (
 	"context"
-	"strings"
-
-	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/aws/aws-sdk-go/aws"
-
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
-
-	util "github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/util/types"
 )
 
 const (
@@ -20,8 +14,6 @@ const (
 )
 
 type ResourceGroupsTaggingAPIAPI interface {
-	GetClusterSubnets() (map[string]util.EC2Tags, error)
-
 	// GetResourcesByFilters fetches resources ARNs by tagFilters and 0 or more resourceTypesFilters
 	GetResourcesByFilters(tagFilters map[string][]string, resourceTypeFilters ...string) ([]string, error)
 
@@ -34,76 +26,6 @@ func (c *Cloud) TagResourcesWithContext(ctx context.Context, i *resourcegroupsta
 }
 func (c *Cloud) UntagResourcesWithContext(ctx context.Context, i *resourcegroupstaggingapi.UntagResourcesInput) (*resourcegroupstaggingapi.UntagResourcesOutput, error) {
 	return c.rgt.UntagResourcesWithContext(ctx, i)
-}
-
-// GetClusterSubnets looks up all subnets in AWS that are tagged for the cluster.
-func (c *Cloud) GetClusterSubnets() (map[string]util.EC2Tags, error) {
-	subnets := make(map[string]util.EC2Tags)
-
-	paramSets := []*resourcegroupstaggingapi.GetResourcesInput{
-		{
-			ResourcesPerPage: aws.Int64(50),
-			ResourceTypeFilters: []*string{
-				aws.String("ec2"),
-			},
-			TagFilters: []*resourcegroupstaggingapi.TagFilter{
-				{
-					Key:    aws.String("kubernetes.io/role/internal-elb"),
-					Values: []*string{aws.String(""), aws.String("1")},
-				},
-				{
-					Key:    aws.String("kubernetes.io/cluster/" + c.clusterName),
-					Values: []*string{aws.String("owned"), aws.String("shared")},
-				},
-			},
-		},
-		{
-			ResourcesPerPage: aws.Int64(50),
-			ResourceTypeFilters: []*string{
-				aws.String("ec2"),
-			},
-			TagFilters: []*resourcegroupstaggingapi.TagFilter{
-				{
-					Key:    aws.String("kubernetes.io/role/elb"),
-					Values: []*string{aws.String(""), aws.String("1")},
-				},
-				{
-					Key:    aws.String("kubernetes.io/cluster/" + c.clusterName),
-					Values: []*string{aws.String("owned"), aws.String("shared")},
-				},
-			},
-		},
-	}
-
-	for _, paramSet := range paramSets {
-		err := c.rgt.GetResourcesPages(paramSet, func(page *resourcegroupstaggingapi.GetResourcesOutput, lastPage bool) bool {
-			if page == nil {
-				return false
-			}
-			for _, rtm := range page.ResourceTagMappingList {
-				switch {
-				case strings.Contains(*rtm.ResourceARN, ":subnet/"):
-					subnets[*rtm.ResourceARN] = rgtTagAsEC2Tag(rtm.Tags)
-				}
-			}
-			return true
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return subnets, nil
-}
-
-func rgtTagAsEC2Tag(in []*resourcegroupstaggingapi.Tag) (tags util.EC2Tags) {
-	for _, t := range in {
-		tags = append(tags, &ec2.Tag{
-			Key:   t.Key,
-			Value: t.Value,
-		})
-	}
-	return tags
 }
 
 func (c *Cloud) GetResourcesByFilters(tagFilters map[string][]string, resourceTypeFilters ...string) ([]string, error) {

--- a/internal/aws/rgt_test.go
+++ b/internal/aws/rgt_test.go
@@ -7,10 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/mocks"
-	util "github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/util/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -55,132 +53,6 @@ func TestCloud_UntagResourcesWithContext(t *testing.T) {
 		assert.Equal(t, b, e)
 		svc.AssertExpectations(t)
 	})
-}
-
-func tag(k, v string) *resourcegroupstaggingapi.Tag {
-	return &resourcegroupstaggingapi.Tag{Key: String(k), Value: String(v)}
-}
-
-func tags(t ...*resourcegroupstaggingapi.Tag) []*resourcegroupstaggingapi.Tag {
-	return t
-}
-
-func ec2Tag(k, v string) *ec2.Tag {
-	return &ec2.Tag{Key: aws.String(k), Value: aws.String(v)}
-}
-
-func TestCloud_GetClusterSubnets(t *testing.T) {
-	clusterName := "clusterName"
-	paramSets := []*resourcegroupstaggingapi.GetResourcesInput{
-		{
-			ResourcesPerPage: aws.Int64(50),
-			ResourceTypeFilters: []*string{
-				aws.String("ec2"),
-			},
-			TagFilters: []*resourcegroupstaggingapi.TagFilter{
-				{
-					Key:    aws.String("kubernetes.io/role/internal-elb"),
-					Values: []*string{aws.String(""), aws.String("1")},
-				},
-				{
-					Key:    aws.String("kubernetes.io/cluster/" + clusterName),
-					Values: []*string{aws.String("owned"), aws.String("shared")},
-				},
-			},
-		},
-		{
-			ResourcesPerPage: aws.Int64(50),
-			ResourceTypeFilters: []*string{
-				aws.String("ec2"),
-			},
-			TagFilters: []*resourcegroupstaggingapi.TagFilter{
-				{
-					Key:    aws.String("kubernetes.io/role/elb"),
-					Values: []*string{aws.String(""), aws.String("1")},
-				},
-				{
-					Key:    aws.String("kubernetes.io/cluster/" + clusterName),
-					Values: []*string{aws.String("owned"), aws.String("shared")},
-				},
-			},
-		},
-	}
-	for _, tc := range []struct {
-		Name               string
-		GetResourcesOutput *resourcegroupstaggingapi.GetResourcesOutput
-		GetResourcesError  awserr.Error
-		Params             int
-		ExpectedResult     map[string]util.EC2Tags
-		ExpectedError      error
-	}{
-		{
-			Name:   "No subnets returned",
-			Params: 2,
-			GetResourcesOutput: &resourcegroupstaggingapi.GetResourcesOutput{
-				ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
-					{
-						ResourceARN: aws.String("arn1"),
-						Tags:        tags(tag("tag1", "val1")),
-					},
-				},
-			},
-			ExpectedResult: map[string]util.EC2Tags{},
-		},
-		{
-			Name:   "Three subnets returned",
-			Params: 2,
-			GetResourcesOutput: &resourcegroupstaggingapi.GetResourcesOutput{
-				ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
-					{
-						ResourceARN: aws.String("arn:aws:ec2:region:account-id:subnet/subnet-id1"),
-						Tags:        tags(tag("tag1", "val1")),
-					},
-					{
-						ResourceARN: aws.String("arn:aws:ec2:region:account-id:subnet/subnet-id2"),
-						Tags:        tags(tag("tag2", "val2")),
-					},
-					{
-						ResourceARN: aws.String("arn:aws:ec2:region:account-id:subnet/subnet-id3"),
-						Tags:        tags(tag("tag3", "val3")),
-					},
-				},
-			},
-			ExpectedResult: map[string]util.EC2Tags{
-				"arn:aws:ec2:region:account-id:subnet/subnet-id1": {ec2Tag("tag1", "val1")},
-				"arn:aws:ec2:region:account-id:subnet/subnet-id2": {ec2Tag("tag2", "val2")},
-				"arn:aws:ec2:region:account-id:subnet/subnet-id3": {ec2Tag("tag3", "val3")},
-			},
-		},
-		{
-			Name:              "API throws an error",
-			Params:            1,
-			GetResourcesError: awserr.New(request.ErrCodeResponseTimeout, "timeout", nil),
-			ExpectedError:     awserr.New(request.ErrCodeResponseTimeout, "timeout", nil),
-		},
-	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			rgtsvc := &mocks.ResourceGroupsTaggingAPIAPI{}
-
-			for paramSet := 0; paramSet < tc.Params; paramSet++ {
-				rgtsvc.On("GetResourcesPages",
-					paramSets[paramSet],
-					mock.AnythingOfType("func(*resourcegroupstaggingapi.GetResourcesOutput, bool) bool"),
-				).Return(tc.GetResourcesError).Run(func(args mock.Arguments) {
-					arg := args.Get(1).(func(*resourcegroupstaggingapi.GetResourcesOutput, bool) bool)
-					arg(tc.GetResourcesOutput, false)
-				})
-			}
-
-			cloud := &Cloud{
-				clusterName: clusterName,
-				rgt:         rgtsvc,
-			}
-			subnets, err := cloud.GetClusterSubnets()
-			assert.Equal(t, tc.ExpectedResult, subnets)
-			assert.Equal(t, tc.ExpectedError, err)
-			rgtsvc.AssertExpectations(t)
-		})
-	}
 }
 
 func TestCloud_GetResourcesByFilters(t *testing.T) {

--- a/mocks/CloudAPI.go
+++ b/mocks/CloudAPI.go
@@ -15,8 +15,6 @@ import (
 
 	resourcegroupstaggingapi "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 
-	types "github.com/kubernetes-sigs/aws-alb-ingress-controller/pkg/util/types"
-
 	waf "github.com/aws/aws-sdk-go/service/waf"
 
 	wafregional "github.com/aws/aws-sdk-go/service/wafregional"
@@ -618,21 +616,21 @@ func (_m *CloudAPI) GetClusterName() string {
 }
 
 // GetClusterSubnets provides a mock function with given fields:
-func (_m *CloudAPI) GetClusterSubnets() (map[string]types.EC2Tags, error) {
+func (_m *CloudAPI) GetClusterSubnets(_a0 string) ([]*ec2.Subnet, error) {
 	ret := _m.Called()
 
-	var r0 map[string]types.EC2Tags
-	if rf, ok := ret.Get(0).(func() map[string]types.EC2Tags); ok {
-		r0 = rf()
+	var r0 []*ec2.Subnet
+	if rf, ok := ret.Get(0).(func(string) []*ec2.Subnet); ok {
+		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]types.EC2Tags)
+			r0 = ret.Get(0).([]*ec2.Subnet)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
This PR moves `rgt.GetClusterSubnets()` to `ec2.GetClusterSubnets()` and updates the `GetClusterSubnets()` function to use `EC2 specific API` instead of `Resource Groups Tagging API`.

Since there is no VPC endpoint for  `Resource Groups Tagging API`, this change will make the controller be able to run inside an internal VPC subnet without `internet gateway` or `nat gateway`.
Please let me know if I need to update anything.

Thanks,