### PR TITLE
ignore fargate nodes for instance target type

### DIFF
--- a/internal/ingress/annotations/class/main.go
+++ b/internal/ingress/annotations/class/main.go
@@ -43,6 +43,9 @@ func IsValidIngress(ingressClass string, ingress *extensions.Ingress) bool {
 // TODO: change this to in-sync with https://github.com/kubernetes/kubernetes/blob/13705ac81e00f154434b5c66c1ad92ac84960d7f/pkg/controller/service/service_controller.go#L592(relies on node's ready condition instead of AWS API)
 // IsValidNode returns true if the given Node has valid annotations
 func IsValidNode(n *corev1.Node) bool {
+	if s, ok := n.ObjectMeta.Labels["eks.amazonaws.com/compute-type"]; ok && s == "fargate" {
+		return false
+	}
 	if _, ok := n.ObjectMeta.Labels["node-role.kubernetes.io/master"]; ok {
 		return false
 	}


### PR DESCRIPTION
Ignore fargate nodes when using instance target-type.
This allows to use instance target-type under mixed setup(both EC2 pods & fargate pods)
Fixes #1113 

