### PR TITLE
Detect unconditional redirects and ignore any rules defined afterwards

### DIFF
--- a/internal/alb/ls/rules.go
+++ b/internal/alb/ls/rules.go
@@ -128,7 +128,13 @@ func (c *rulesController) getDesiredRules(ctx context.Context, listener *elbv2.L
 			continue
 		}
 
+		seenUnconditionalRedirect := false
+
 		for _, path := range ingressRule.HTTP.Paths {
+			if seenUnconditionalRedirect {
+				// Ignore rules that follow a unconditional redirect, they are moot
+				continue
+			}
 			authCfg, err := c.authModule.NewConfig(ctx, ingress, path.Backend, aws.StringValue(listener.Protocol))
 			if err != nil {
 				return nil, err
@@ -146,6 +152,8 @@ func (c *rulesController) getDesiredRules(ctx context.Context, listener *elbv2.L
 			}
 			if createsRedirectLoop(listener, elbRule) {
 				continue
+			} else if isUnconditionalRedirect(listener, elbRule) {
+				seenUnconditionalRedirect = true
 			}
 			output = append(output, elbRule)
 			nextPriority++
@@ -525,6 +533,45 @@ func createsRedirectLoop(listener *elbv2.Listener, r elbv2.Rule) bool {
 		if aws.StringValue(rc.Protocol) != "#{protocol}" && aws.StringValue(rc.Protocol) != aws.StringValue(listener.Protocol) {
 			return false
 		}
+		return true
+	}
+	return false
+}
+
+// isUnconditionalRedirect checks whether specified rule always redirects
+// We consider the rule is a unconditional redirect if
+// 1) The Path condition is nil, or at least one Path condition is /*
+// 2) All other rule conditions are nil (ignoring the Host condition).
+// 3) RedirectConfig is not nil.
+func isUnconditionalRedirect(listener *elbv2.Listener, r elbv2.Rule) bool {
+	for _, action := range r.Actions {
+		rc := action.RedirectConfig
+		if rc == nil {
+			continue
+		}
+
+		var paths []string
+		for _, c := range r.Conditions {
+			switch aws.StringValue(c.Field) {
+			case conditions.FieldPathPattern:
+				paths = append(paths, aws.StringValueSlice(c.PathPatternConfig.Values)...)
+			case conditions.FieldHTTPRequestMethod, conditions.FieldSourceIP, conditions.FieldHTTPHeader, conditions.FieldQueryString:
+				// If there are any conditions, then the redirect is not unconditional
+				return false
+			}
+		}
+
+		if len(paths) != 0 {
+			// ALB path conditions are ORed, so if any of them are a wildcard, the redirect is unconditional
+			for _, path := range paths {
+				if path == "/*" {
+					return true
+				}
+			}
+			// The redirect isn't unconditional if none of the path conditions are a wildcard
+			return false
+		}
+
 		return true
 	}
 	return false


### PR DESCRIPTION
(_this is my first PR for GoLang code and for Kubernetes-related projects, so bear with me if I make mistakes or faux pas_)

ALBs only support 100 rules and we have hit the limit in our project -  we are looking for a way to reduce rules and have identified that the aws alb controller is creating some unneeded ALB rules.

We use a annotation to redirect port 80 requests to port 443. This is the annotation documentation: https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/guide/tasks/ssl_redirect.md

If a unconditional redirect rule is present in the configuration then all following rules within the same listener are not needed. This PR changes things so they are skipped thereby conserving rules.

For the biggest benefit, it is best to define the redirect rule first in the config. Because only subsequent rules are skipped. This is in line with the ssl-redirect annotation which [says](https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/guide/tasks/ssl_redirect.md):
> the ssl-redirect action must be be first rule(which will be evaluated first by ALB)

---

I have tested on our project, with success. But please let me know if I can make any improvements.

If this is not something that fits with the direction of the project, no problem, please close this PR. I only created it in case it's useful - I'm 100% happy to close if not the case.

---

Relvant GitHub issue https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/853#issuecomment-578547468