### PR TITLE
Typo in the "alb-ingress-controller.yaml" if env variables are to be used

### DIFF
--- a/docs/examples/alb-ingress-controller.yaml
+++ b/docs/examples/alb-ingress-controller.yaml
@@ -53,7 +53,7 @@ spec:
             # Maximum number of times to retry the aws calls.
             # defaults to 10.
             # - --aws-max-retries=10
-          # env:
+          env:
             # AWS key id for authenticating with the AWS API.
             # This is only here for examples. It's recommended you instead use
             # a project like kube2iam for granting access.


### PR DESCRIPTION
If the access key / secret key are to be used, the "env:" line must be uncommented as well -- otherwise the resulting YAML is not valid.