### PR TITLE
On Endpoints changes, only queue reconciliation of ingress if it's related to the changed Endpoints object

### DIFF
--- a/internal/ingress/controller/handlers/endpoints.go
+++ b/internal/ingress/controller/handlers/endpoints.go
@@ -90,7 +90,7 @@ func IsEndpointsBackendForIngress(endpoints *corev1.Endpoints, ingress *extensio
 
 // EndpointsBelongsToBackend checks if the given endpoints object is associated with the given backend of the given ingress
 func EndpointsBelongsToBackend(endpoints *corev1.Endpoints, ingress *extensions.Ingress, backend *extensions.IngressBackend) bool {
-	if backend.ServiceName == "use-annotation" {
+	if backend.ServicePort.String() == "use-annotation" {
 		config, err := action.NewParser(nil).Parse(&ingress.ObjectMeta)
 		if err != nil {
 			return false


### PR DESCRIPTION
@OmerKahani I saw your pull request and we had the same problem, so I implemented the missing functionality.

Closes #1173.