### PR TITLE
Multiple bug fixes and doc enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test:unit-test
 
 # build & preview docs
 docs-serve:
-	pipenv run mkdocs serve
+	pipenv install && pipenv run mkdocs serve
 # deploy docs to github-pages(gh-pages branch)
 docs-deploy:
-	pipenv run mkdocs gh-deploy
+	pipenv install && pipenv run mkdocs gh-deploy

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -139,6 +139,7 @@ func getOptions() (*Options, error) {
 	options.BindFlags(fs)
 
 	_ = flag.Set("logtostderr", "true")
+	_ = flag.Set("v", "2")
 	fs.AddGoFlagSet(flag.CommandLine)
 
 	klogFs := flag.NewFlagSet("klog", flag.ExitOnError)

--- a/docs/guide/ingress/annotation.md
+++ b/docs/guide/ingress/annotation.md
@@ -139,7 +139,7 @@ Traffic Routing can be controlled with following annotations:
             alb.ingress.kubernetes.io/actions.forward-single-tg: >
               {"Type":"forward","TargetGroupArn": "arn-of-your-target-group"}
             alb.ingress.kubernetes.io/actions.forward-multiple-tg: >
-              {"Type":"forward","ForwardConfig":{"TargetGroups":[{"TargetGroupArn":""arn-of-your-target-group","Weight":80},{"ServiceName":"service-1","ServicePort":"80","Weight":20}],"TargetGroupStickinessConfig":{"Enabled":true,"DurationSeconds":200}}}
+              {"Type":"forward","ForwardConfig":{"TargetGroups":[{"ServiceName":"service-1","ServicePort":"80","Weight":20},{"ServiceName":"service-2","ServicePort":"80","Weight":20},{"TargetGroupArn":""arn-of-your-non-k8s-target-group","Weight":60}],"TargetGroupStickinessConfig":{"Enabled":true,"DurationSeconds":200}}}
         spec:
           rules:
             - http:
@@ -169,9 +169,10 @@ Traffic Routing can be controlled with following annotations:
         
         Limitation: [Auth related annotations](#authentication) on Service object won't be respected, it must be applied to Ingress object.
 
-- <a name="conditions">`alb.ingress.kubernetes.io/conditions.${conditions-name}`</a> Provides a method for specifing routing conditions **in addition to original host/path condition on Ingress spec**. 
-
-    The `conditions-name` in the annotation must match the serviceName in the ingress rules, and servicePort must be `use-annotation`.
+- <a name="conditions">`alb.ingress.kubernetes.io/conditions.${conditions-name}`</a> Provides a method for specifying routing conditions **in addition to original host/path condition on Ingress spec**. 
+    
+    The `conditions-name` in the annotation must match the serviceName in the ingress rules. 
+    It can be a either real serviceName or an annotation based action name when servicePort is "use-annotation".
 
     !!!example
         - rule-path1: 
@@ -324,6 +325,9 @@ Access control for LoadBalancer can be controlled with following annotations:
 
 ## Authentication
 ALB supports authentication with Cognito or OIDC. See [Authenticate Users Using an Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html) for more details.
+
+!!!warning "HTTPS only"
+    Authentication is only supported for HTTPS listeners, see [SSL](#ssl) for configure HTTPS listener.
 
 - <a name="auth-type">`alb.ingress.kubernetes.io/auth-type`</a> specifies the authentication type on targets.
 

--- a/internal/alb/lb/loadbalancer.go
+++ b/internal/alb/lb/loadbalancer.go
@@ -375,13 +375,8 @@ func (controller *defaultController) clusterSubnets(ctx context.Context, scheme 
 	}
 
 	if len(out) < 2 {
-		return nil, fmt.Errorf("retrieval of subnets failed to resolve 2 qualified subnets. Subnets must "+
-			"contain the %s/<cluster name> tag with a value of shared or owned and the %s tag signifying it should be used for ALBs "+
-			"Additionally, there must be at least 2 subnets with unique availability zones as required by "+
-			"ALBs. Either tag subnets to meet this requirement or use the subnets annotation on the "+
-			"ingress resource to explicitly call out what subnets to use for ALB creation. The subnets "+
-			"that did resolve were %v", aws.TagNameCluster, key,
-			log.Prettify(out))
+		return nil, fmt.Errorf(`failed to resolve 2 qualified subnet for ALB. Subnets must contains these tags: '%s/%s': ['shared' or 'owned'] and '%s': ['' or '1']. See https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/controller/config/#subnet-auto-discovery for more details. Resolved qualified subnets: '%s'`,
+			aws.TagNameCluster, controller.cloud.GetClusterName(), key, log.Prettify(out))
 	}
 
 	sort.Strings(out)

--- a/internal/alb/ls/listener.go
+++ b/internal/alb/ls/listener.go
@@ -159,7 +159,7 @@ func (controller *defaultController) LSInstanceNeedsModification(ctx context.Con
 		albctx.GetLogger(ctx).DebugLevelf(1, "listener sslPolicy needs modification: %v => %v", awsutil.Prettify(instance.SslPolicy), awsutil.Prettify(config.SslPolicy))
 		needModification = true
 	}
-	if !util.DeepEqual(instance.DefaultActions, config.DefaultActions) {
+	if !actionsMatches(instance.DefaultActions, config.DefaultActions) {
 		albctx.GetLogger(ctx).DebugLevelf(1, "listener defaultActions needs modification: %v => %v", awsutil.Prettify(instance.DefaultActions), awsutil.Prettify(config.DefaultActions))
 		needModification = true
 	}

--- a/internal/alb/tg/targetgroup_group_test.go
+++ b/internal/alb/tg/targetgroup_group_test.go
@@ -568,6 +568,29 @@ func TestDefaultGroupController_GC(t *testing.T) {
 			},
 		},
 		{
+			Name: "GC succeeds without deleting externalTargetArn even it's created by controller",
+			TGGroup: TargetGroupGroup{
+				TGByBackend: map[extensions.IngressBackend]TargetGroup{
+					{
+						ServiceName: "service1",
+						ServicePort: intstr.FromInt(80),
+					}: {Arn: "arn1"},
+				},
+				externalTGARNs: []string{"arn3"},
+				selector:       map[string]string{"key1": "value1", "key2": "value2"},
+			},
+			GetResourcesByFiltersCall: &GetResourcesByFiltersCall{
+				TagFilters:   map[string][]string{"key1": {"value1"}, "key2": {"value2"}},
+				ResourceType: aws.ResourceTypeEnumELBTargetGroup,
+				Arns:         []string{"arn1", "arn2", "arn3"},
+			},
+			DeleteTargetGroupByArnCalls: []DeleteTargetGroupByArnCall{
+				{
+					Arn: "arn2",
+				},
+			},
+		},
+		{
 			Name: "GC failed when fetch current targetGroups",
 			TGGroup: TargetGroupGroup{
 				TGByBackend: map[extensions.IngressBackend]TargetGroup{

--- a/internal/alb/tg/types.go
+++ b/internal/alb/tg/types.go
@@ -14,8 +14,12 @@ type TargetGroup struct {
 
 // TargetGroupGroup represents an collection of targetGroups for a single ingress in AWS
 type TargetGroupGroup struct {
+	// targetGroups created for serviceBackends.
 	TGByBackend map[extensions.IngressBackend]TargetGroup
-	selector    map[string]string
+
+	// external targetGroups referenced by ARN.
+	externalTGARNs []string
+	selector       map[string]string
 }
 
 // NameGenerator provides name generation functionality for tg package.

--- a/internal/ingress/backend/endpoint.go
+++ b/internal/ingress/backend/endpoint.go
@@ -160,7 +160,7 @@ func (resolver *endpointResolver) resolveIP(ingress *extensions.Ingress, backend
 			// we need to loop over all unready pods to check if the ALB readiness gate is the only condition preventing the pod from being ready;
 			// if this is the case, we return the pod as a desired target although its not in `Addresses`
 			for _, epAddr := range epSubset.NotReadyAddresses {
-				if epAddr.TargetRef == nil {
+				if epAddr.TargetRef == nil || epAddr.TargetRef.Kind != "Pod" {
 					continue
 				}
 

--- a/internal/ingress/controller/handlers/endpoints.go
+++ b/internal/ingress/controller/handlers/endpoints.go
@@ -62,7 +62,7 @@ func (h *EnqueueRequestsForEndpointsEvent) enqueueImpactedIngresses(endpoints *c
 			continue
 		}
 
-		backends, err := tg.ExtractTargetGroupBackends(&ingress)
+		backends, _, err := tg.ExtractTargetGroupBackends(&ingress)
 		if err != nil {
 			glog.Errorf("Failed to extract backend services from ingress: %v, reconcile the ingress. error: %e", ingress.Name, err)
 			queue.Add(reconcile.Request{


### PR DESCRIPTION
The PR is separated into 6 independent commit: (review each one individually by click on "Commits" tab. 

1. `fix default action comparison`: Fix #1163 . 
    The default action from ALB contains both targetGroupARN in top level Action structure, and also contain targetGroupARN in forwardAction structure. While desiredAction build only contains it in forwardAction structure. Use dedicated compare method instead of deepEqual to avoid unnecessary modification. 
2. `issue warning when an targetGroup for k8s service is referenced by ARN`: Fix #1140
   There are users used TargetGroupArn in action configuration even if the targetGroup is created for a k8s service by controller. The controller will try to delete that targetGroup(though the deletion will fail due to dependencies).
   This commit will issue a warning to user and bypass deletion under such misusage.
3. `various docs enhancements`: close #1150, close #1149 
    1. make it clear authentication is only supported for HTTPS listener
    2. make it clear that `conditions` annotation is supported for both normal serviceName and annotation based action name.
    3. make it clear that forward-multiple-tg supports multiple k8s service as well.
    4. fix `make docs-serve` and `make docs-deploy` by install dependencies first.
4. `set default log level to be 2 for more verbose message`: sets default log level to 2, which will emit "successfully reconciled" message from controller-runtime, which is useful for most ppl.
5. `make subnet resolve message more clear`: make the subnet tagging requirement message more clear: 
   ```
   failed to build LoadBalancer configuration due to failed to resolve 2 qualified subnet for ALB. Subnets must contains these tags: 'kubernetes.io/cluster/m00nf1sh-dev': ['shared' or 'owned'] and 'kubernetes.io/role/elb': ['' or '1']. See https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/controller/config/#subnet-auto-discovery for more details. Resolved qualified subnets: '[]'"
   ```
6. `bug fix for pod readiness gate`: capture 2 edge case that is not captured in original podReadinessGate PR