### PR TITLE
Add Gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+tasks:
+  - name: Install dependencies
+    before: brew update && brew install kubectl awscli
+    command: echo "Setup is done. Check docs/BUILDING for how to use this!"

--- a/.theia/launch.json
+++ b/.theia/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+      {
+          "name": "Local controller",
+          "type": "go",
+          "request": "launch",
+          "mode": "auto",
+          "program": "${workspaceRoot}/cmd/main.go",
+          "env": {
+              "POD_NAME": "alb-ingress-controller",
+              "POD_NAMESPACE": "kube-system"
+          },
+          "args": [
+              "--election=false",
+              "--apiserver-host=http://localhost:8001",
+              "--cluster-name=example-eks",
+              "--aws-region=us-east-1",
+              "--aws-vpc-id=vpc-0a0a000aa00000000"
+           ]
+      }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-sigs/aws-alb-ingress-controller)](https://goreportcard.com/report/github.com/kubernetes-sigs/aws-alb-ingress-controller)
 [![Build Status](https://travis-ci.org/kubernetes-sigs/aws-alb-ingress-controller.svg?branch=master)](https://travis-ci.org/kubernetes-sigs/aws-alb-ingress-controller)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fcoreos%2Falb-ingress-controller.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fcoreos%2Falb-ingress-controller?ref=badge_shield)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/kubernetes-sigs/aws-alb-ingress-controller)
 
 # AWS ALB Ingress Controller
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -61,3 +61,22 @@ $ OS=darwin make server
 ```bash
 $ AWS_REGION=us-west-2 POD_NAME=alb-ingress-controller POD_NAMESPACE=kube-system go run cmd/main.go --apiserver-host=http://localhost:8001 --cluster-name=devcluster
 ```
+
+## Running in Gitpod
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/kubernetes-sigs/aws-alb-ingress-controller)
+
+For a pre-made developer environment [Gitpod](https://gitpod.io) can be used. Gitpod runs a development environemnt in the cloud, with a browser interface.
+
+Gitpod is pre-configured with several steps:
+
+- installation of `aws-cli` `kubectl`
+- a Debug profile that can run ALB Ingress Controller in debug mode. See [../.theia/launch.json] for configuration options.
+
+To use the local ALB Ingress Controller on an EKS cluster, you can follow these steps:
+
+- set your AWS credentials: `aws configure`
+- EKS connection details setup: `aws eks update-kubeconfig --name example-eks --region=us-east-1`
+- set necessary variables in [../.theia/launch.json]
+- forward the Kubernetes API: `kubectl proxy &>/dev/null &`
+- Debug -> Start Debugging


### PR DESCRIPTION
[Gitpod](https://gitpod.io) launches ready-to-code dev environments with a single click, running in the browser. 

It helped me a lot with https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/1208 when I could not launch the controller and the pre-made and clean dev envs from Gitpod ensured that any issues on my local machines will not impact my work.

This PR adds support and documentation for how to use Gitpod with this repo. A screenshot of a debugging session in progress:
<img width="1597" alt="Screen Shot 2020-03-30 at 20 04 53" src="https://user-images.githubusercontent.com/5440007/77941029-306ea180-72c2-11ea-8c7e-4ad1647329e5.png">

While Gitpod is free for open-source, it is a proprietary product so I don't know if support for it can or should be included. It's up to the maintainers to decide.

Adding support for Gitpod would significantly lower the bar for any contributors by abstracting away the whole setup.