### PR TITLE
redact oidc

### DIFF
--- a/internal/alb/ls/listener.go
+++ b/internal/alb/ls/listener.go
@@ -160,7 +160,9 @@ func (controller *defaultController) LSInstanceNeedsModification(ctx context.Con
 		needModification = true
 	}
 	if !actionsMatches(instance.DefaultActions, config.DefaultActions) {
-		albctx.GetLogger(ctx).DebugLevelf(1, "listener defaultActions needs modification: %v => %v", awsutil.Prettify(instance.DefaultActions), awsutil.Prettify(config.DefaultActions))
+		albctx.GetLogger(ctx).DebugLevelf(1, "listener defaultActions needs modification",
+			awsutil.Prettify(redactActions(instance.DefaultActions)),
+			awsutil.Prettify(redactActions(config.DefaultActions)))
 		needModification = true
 	}
 	return needModification

--- a/pkg/util/deepcopy.go
+++ b/pkg/util/deepcopy.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"bytes"
+	"encoding/gob"
+)
+
+func DeepCopyInto(to interface{}, from interface{}) {
+	buff := new(bytes.Buffer)
+	enc := gob.NewEncoder(buff)
+	dec := gob.NewDecoder(buff)
+	_ = enc.Encode(from)
+	_ = dec.Decode(to)
+}

--- a/pkg/util/deepcopy_test.go
+++ b/pkg/util/deepcopy_test.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type structA struct {
+	Name string
+}
+
+type structB struct {
+	Name string
+	A    *structA
+}
+
+func TestDeepCopyInto(t *testing.T) {
+	obj := structB{
+		Name: "parent",
+		A: &structA{
+			Name: "child-1",
+		},
+	}
+	objClone := structB{}
+	DeepCopyInto(&objClone, obj)
+	obj.A.Name = "child-2"
+
+	assert.Equal(t, structB{
+		Name: "parent",
+		A: &structA{
+			Name: "child-2",
+		},
+	}, obj)
+	assert.Equal(t, structB{
+		Name: "parent",
+		A: &structA{
+			Name: "child-1",
+		},
+	}, objClone)
+}


### PR DESCRIPTION
Fix https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/1227
redact oidc clientID and secret in logs.