### PR TITLE
Check for sufficient available free IP space before marking a subnet as useable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 
 all: container
 
-TAG?=v1.1.6
+TAG?=v1.1.7
 PREFIX?=amazon/aws-alb-ingress-controller
 ARCH?=amd64
 OS?=linux

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # AWS ALB Ingress Controller
 
-**NOTE:** The current image version is `v1.1.6`. Please file any issues you find and note the version used.
+**NOTE:** The current image version is `v1.1.7`. Please file any issues you find and note the version used.
 
 The AWS ALB Ingress Controller satisfies Kubernetes [ingress resources](https://kubernetes.io/docs/user-guide/ingress) by provisioning [Application Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html).
 

--- a/docs/examples/alb-ingress-controller.yaml
+++ b/docs/examples/alb-ingress-controller.yaml
@@ -67,5 +67,5 @@ spec:
             # - name: AWS_SECRET_ACCESS_KEY
             #   value: SECRETVALUE
           # Repository location of the ALB Ingress Controller.
-          image: docker.io/amazon/aws-alb-ingress-controller:v1.1.6
+          image: docker.io/amazon/aws-alb-ingress-controller:v1.1.7
       serviceAccountName: alb-ingress-controller

--- a/docs/examples/kustomization.yaml
+++ b/docs/examples/kustomization.yaml
@@ -3,7 +3,7 @@ commonLabels:
 
 imageTags:
 - name: docker.io/amazon/aws-alb-ingress-controller
-  newTag: v1.1.6
+  newTag: v1.1.7
 
 namespace: kube-system
 

--- a/docs/guide/controller/setup.md
+++ b/docs/guide/controller/setup.md
@@ -32,7 +32,7 @@ More docs on [hub.helm.sh](https://hub.helm.sh/charts/incubator/aws-alb-ingress-
 ### Kubectl
 1. Download sample ALB ingress controller manifest
     ``` bash
-    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.6/docs/examples/alb-ingress-controller.yaml
+    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.7/docs/examples/alb-ingress-controller.yaml
     ```
 
 2. Configure the ALB ingress controller manifest
@@ -50,7 +50,7 @@ More docs on [hub.helm.sh](https://hub.helm.sh/charts/incubator/aws-alb-ingress-
 3. Deploy the RBAC roles manifest
 
     ```bash
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.6/docs/examples/rbac-role.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.7/docs/examples/rbac-role.yaml
     ```
 
 4. Deploy the ALB ingress controller manifest

--- a/docs/guide/external-dns/setup.md
+++ b/docs/guide/external-dns/setup.md
@@ -9,7 +9,7 @@ Adequate roles and policies must be configured in AWS and available to the node(
 1. Download sample `external-dns` manifest
 
     ```bash
-    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.6/docs/examples/external-dns.yaml
+    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.7/docs/examples/external-dns.yaml
     ```
 
 2. Edit the `--domain-filter` flag to include your hosted zone(s)

--- a/docs/guide/walkthrough/echoserver.md
+++ b/docs/guide/walkthrough/echoserver.md
@@ -43,8 +43,8 @@ In this walkthrough, you'll
 1. Download the example alb-ingress-manifest locally.
 
     ```bash
-    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.6/docs/examples/alb-ingress-controller.yaml
-    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.6/docs/examples/rbac-role.yaml
+    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.7/docs/examples/alb-ingress-controller.yaml
+    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.7/docs/examples/rbac-role.yaml
     ```
 
 1. Edit the manifest and set the following parameters and environment variables.
@@ -100,9 +100,9 @@ In this walkthrough, you'll
 1.  Deploy all the echoserver resources (namespace, service, deployment)
 
     ```bash
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.6/docs/examples/echoservice/echoserver-namespace.yaml &&\
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.6/docs/examples/echoservice/echoserver-service.yaml &&\
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.6/docs/examples/echoservice/echoserver-deployment.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.7/docs/examples/echoservice/echoserver-namespace.yaml &&\
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.7/docs/examples/echoservice/echoserver-service.yaml &&\
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.7/docs/examples/echoservice/echoserver-deployment.yaml
     ```
 
 1.  List all the resources to ensure they were created.
@@ -126,7 +126,7 @@ In this walkthrough, you'll
 1.  Download the echoserver ingress manifest locally.
 
     ```bash
-    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.6/docs/examples/echoservice/echoserver-ingress.yaml
+    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.7/docs/examples/echoservice/echoserver-ingress.yaml
     ```
 
 1.  Configure the subnets, either by add annotation to the ingress or add tags to subnets.
@@ -235,7 +235,7 @@ In this walkthrough, you'll
 1.  Download external-dns to manage Route 53.
 
     ```bash
-    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.6/docs/examples/external-dns.yaml
+    wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.7/docs/examples/external-dns.yaml
     ```
 
 1.  Edit the `--domain-filter` flag to include your hosted zone(s)
@@ -306,7 +306,7 @@ In this walkthrough, you'll
 follow below steps if you want to use kube2iam to provide the AWS credentials
 
 1. configure the proper policy
-    The policy to be used can be fetched from https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.6/docs/examples/iam-policy.json
+    The policy to be used can be fetched from https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.7/docs/examples/iam-policy.json
 
 1. configure the proper role and create the trust relationship
     You have to find which role is associated with your K8S nodes. Once you found take note of the full arn:

--- a/internal/alb/ls/listener.go
+++ b/internal/alb/ls/listener.go
@@ -160,7 +160,9 @@ func (controller *defaultController) LSInstanceNeedsModification(ctx context.Con
 		needModification = true
 	}
 	if !actionsMatches(instance.DefaultActions, config.DefaultActions) {
-		albctx.GetLogger(ctx).DebugLevelf(1, "listener defaultActions needs modification: %v => %v", awsutil.Prettify(instance.DefaultActions), awsutil.Prettify(config.DefaultActions))
+		albctx.GetLogger(ctx).DebugLevelf(1, "listener defaultActions needs modification",
+			awsutil.Prettify(redactActions(instance.DefaultActions)),
+			awsutil.Prettify(redactActions(config.DefaultActions)))
 		needModification = true
 	}
 	return needModification

--- a/pkg/util/deepcopy.go
+++ b/pkg/util/deepcopy.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"bytes"
+	"encoding/gob"
+)
+
+func DeepCopyInto(to interface{}, from interface{}) {
+	buff := new(bytes.Buffer)
+	enc := gob.NewEncoder(buff)
+	dec := gob.NewDecoder(buff)
+	_ = enc.Encode(from)
+	_ = dec.Decode(to)
+}

--- a/pkg/util/deepcopy_test.go
+++ b/pkg/util/deepcopy_test.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type structA struct {
+	Name string
+}
+
+type structB struct {
+	Name string
+	A    *structA
+}
+
+func TestDeepCopyInto(t *testing.T) {
+	obj := structB{
+		Name: "parent",
+		A: &structA{
+			Name: "child-1",
+		},
+	}
+	objClone := structB{}
+	DeepCopyInto(&objClone, obj)
+	obj.A.Name = "child-2"
+
+	assert.Equal(t, structB{
+		Name: "parent",
+		A: &structA{
+			Name: "child-2",
+		},
+	}, obj)
+	assert.Equal(t, structB{
+		Name: "parent",
+		A: &structA{
+			Name: "child-1",
+		},
+	}, objClone)
+}


### PR DESCRIPTION
Fix constant errors like this when an IP space is low in a subnet.
```
InvalidSubnet: Not enough IP space available in subnet-XXXXXXXX. ELB requires at least 8 free IP addresses in each subnet.\n\tstatus code: 400
```

