### PR TITLE
fix for pod condition type too long

### DIFF
--- a/internal/ingress/backend/endpoint.go
+++ b/internal/ingress/backend/endpoint.go
@@ -146,7 +146,8 @@ func (resolver *endpointResolver) resolveIP(ingress *extensions.Ingress, backend
 	}
 
 	conditionType := api.PodConditionType(fmt.Sprintf("target-health.alb.ingress.k8s.aws/%s_%s_%s", ingress.Name, backend.ServiceName, backend.ServicePort.String()))
-
+	// new condition type uses a static string
+	staticConditionType := api.PodConditionType("target-health.alb.ingress.k8s.aws/load-balancer-tg-ready")
 	var result []*elbv2.TargetDescription
 	for _, epSubset := range eps.Subsets {
 		for _, epPort := range epSubset.Ports {
@@ -174,6 +175,10 @@ func (resolver *endpointResolver) resolveIP(ingress *extensions.Ingress, backend
 				found := false
 				for _, gate := range pod.Spec.ReadinessGates {
 					if gate.ConditionType == conditionType {
+						found = true
+						break
+					}
+					if gate.ConditionType == staticConditionType {
 						found = true
 						break
 					}


### PR DESCRIPTION
-  existing pod condition type has the format "target-health.alb.ingress.k8s.aws/<INGRESS_NAME>_<SERVICE_NAME>_<SERVICE_PORT>". This can exceed the max. allowed length if the <INGRESS_NAME>_<SERVICE_NAME>_<SERVICE_PORT> part exceeds 63 characters. To work around this problem, added support for static pod condition type string. The string is "target-health.alb.ingress.k8s.aws/load-balancer-tg-ready"
- both old and new format are supported. Only one should be used at a time though.

Testing done
- created the required objects in a cluster and verified old format still works
- created the required objects in a cluster verified new format works as well
- verified a deployment transition from old format to new format

resolves #1217 