### PR TITLE
fix for pod condition type too long

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/mock v1.2.0
 	github.com/golangci/golangci-lint v1.21.0 // indirect
+	github.com/google/go-cmp v0.4.1
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubernetes-sigs/aws-alb-ingress-controller
 
 require (
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 // indirect
-	github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20191205114352-5bcf20ecd383 // indirect
+	github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20200603230341-7330f5b419cc // indirect
 	github.com/aws/aws-sdk-go v1.27.3
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/glogr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -143,7 +143,10 @@ github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4/go.mod h1:Izgrg
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
+github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -392,6 +395,8 @@ golang.org/x/tools v0.0.0-20190930201159-7c411dea38b0/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191010075000-0337d82405ff h1:XdBG6es/oFDr1HwaxkxgVve7NB281QhxgK/i4voubFs=
 golang.org/x/tools v0.0.0-20191010075000-0337d82405ff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,11 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 h1:Kn3rqvbUFqSepE2OqVu0Pn1CbDw9IuMlONapol0zuwk=
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30/go.mod h1:4AJxUpXUhv4N+ziTvIcWWXgeorXpxPZOfk9HdEVr96M=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/aws/aws-k8s-tester v1.3.0 h1:J3v0DeWvx6PtK01fzAlWE2+/OLWm7h7KW7nxYo+fY5w=
+github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20191205114352-5bcf20ecd383 h1:0ZF830kkP4LvV7mEEm4c4nI4UM1LRqVntW2jPfC3GFc=
 github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20191205114352-5bcf20ecd383/go.mod h1:DJkIJa8BA0LCJWjl01jsEl8vm/fjei0uWJFzZol0KUI=
+github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20200603230341-7330f5b419cc h1:k3ULeEufqKLvL/b+8A6XXE6mb7cTot7WnWfKS24ZcbM=
+github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20200603230341-7330f5b419cc/go.mod h1:DJkIJa8BA0LCJWjl01jsEl8vm/fjei0uWJFzZol0KUI=
 github.com/aws/aws-sdk-go v1.15.39/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.23.21 h1:eVJT2C99cAjZlBY8+CJovf6AwrSANzAcYNuxdCB+SPk=
 github.com/aws/aws-sdk-go v1.23.21/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/go.sum
+++ b/go.sum
@@ -11,13 +11,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 h1:Kn3rqvbUFqSepE2OqVu0Pn1CbDw9IuMlONapol0zuwk=
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30/go.mod h1:4AJxUpXUhv4N+ziTvIcWWXgeorXpxPZOfk9HdEVr96M=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/aws/aws-k8s-tester v0.4.5-0.20191203073900-e5a28058b567 h1:tzabayjAiOaNO1nEoy+Fj9JHs1X3+LYqrRHbJRfVwqg=
-github.com/aws/aws-k8s-tester v0.5.1-0.20191205114352-5bcf20ecd383 h1:d6+rwKyAFMAyb7az2fq4sfDhCB1ykCgLkpogwDepns0=
-github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20190907061006-260b0e114d90 h1:FRpHLOVjM/FO/sl84ilNQWATtRd1FR6uk7UUs8MUl5Y=
-github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20190907061006-260b0e114d90/go.mod h1:xCa3ZGICI7/IqtJdYjEsM3QL9vwlLHxgwSA/MD09Zgo=
-github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20191203073900-e5a28058b567 h1:6zSO87AbCbY3doj1VEaqIs9Z81QxzNX0LWF7o2P6liU=
-github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20191203073900-e5a28058b567/go.mod h1:DJkIJa8BA0LCJWjl01jsEl8vm/fjei0uWJFzZol0KUI=
-github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20191205114352-5bcf20ecd383 h1:0ZF830kkP4LvV7mEEm4c4nI4UM1LRqVntW2jPfC3GFc=
 github.com/aws/aws-k8s-tester/e2e/tester v0.0.0-20191205114352-5bcf20ecd383/go.mod h1:DJkIJa8BA0LCJWjl01jsEl8vm/fjei0uWJFzZol0KUI=
 github.com/aws/aws-sdk-go v1.15.39/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.23.21 h1:eVJT2C99cAjZlBY8+CJovf6AwrSANzAcYNuxdCB+SPk=

--- a/internal/alb/lb/loadbalancer.go
+++ b/internal/alb/lb/loadbalancer.go
@@ -402,10 +402,6 @@ func subnetIsUsable(new *ec2.Subnet, existing []*ec2.Subnet) bool {
 			return false
 		}
 	}
-	
-	if aws.Int64Value(new.AvailableIpAddressCount) < 8 {
-		return false
-	}
-	
-	return true
+
+	return aws.Int64Value(new.AvailableIpAddressCount) >= 8
 }

--- a/internal/alb/tg/targethealth.go
+++ b/internal/alb/tg/targethealth.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	staticConditionType = api.PodConditionType("target-health.alb.ingress.k8s.aws/load-balancer-tg-ready")
+	staticConditionType = api.PodConditionType("target-health.alb.ingress.k8s.aws/load-balancer-any-tg-ready")
 )
 
 type targetGroupWatch struct {

--- a/internal/alb/tg/targethealth.go
+++ b/internal/alb/tg/targethealth.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	staticConditionType               = api.PodConditionType("target-health.alb.ingress.k8s.aws/load-balancer-tg-ready")
+	staticConditionType = api.PodConditionType("target-health.alb.ingress.k8s.aws/load-balancer-tg-ready")
 )
 
 type targetGroupWatch struct {
@@ -84,7 +84,7 @@ func (c *targetHealthController) SyncTargetsForReconciliation(ctx context.Contex
 	if err != nil {
 		return err
 	}
-    // use static condition type if no targets to reconcile with the old type
+	// use static condition type if no targets to reconcile with the old type
 	useStaticConditionType := len(targetsToReconcile) == 0
 	if useStaticConditionType {
 		// new condition type uses a static string
@@ -146,7 +146,7 @@ func (c *targetHealthController) RemovePodConditions(ctx context.Context, t *Tar
 			// check for old condition type
 			i, cond := podConditionForReadinessGate(pod, conditionType)
 			// else check for new condition type
-			if cond == nil{
+			if cond == nil {
 				i, cond = podConditionForReadinessGate(pod, staticConditionType)
 			}
 			if cond != nil {

--- a/internal/alb/tg/targethealth_test.go
+++ b/internal/alb/tg/targethealth_test.go
@@ -3,9 +3,10 @@ package tg
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"

--- a/internal/alb/tg/targethealth_test.go
+++ b/internal/alb/tg/targethealth_test.go
@@ -3,6 +3,8 @@ package tg
 import (
 	"context"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,6 +12,7 @@ import (
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/healthcheck"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/annotations/targetgroup"
+	backendpkg "github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/backend"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/controller/dummy"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/internal/ingress/controller/store"
 	"github.com/kubernetes-sigs/aws-alb-ingress-controller/mocks"
@@ -75,7 +78,7 @@ func Test_SyncTargetsForReconciliation(t *testing.T) {
 		},
 	}
 
-	pods := podsWithReadinessGateAndStatus(podConditionTypeForIngressBackend(ingress, backend), noConditionType, api.ConditionUnknown)
+	pods := podsWithReadinessGateAndStatus(backendpkg.PodReadinessGateConditionType(ingress, backend), noConditionType, api.ConditionUnknown)
 
 	for _, tc := range []struct {
 		Name            string
@@ -165,7 +168,7 @@ func Test_RemovePodConditions(t *testing.T) {
 		},
 	}
 
-	conditionType := podConditionTypeForIngressBackend(ingress, backend)
+	conditionType := backendpkg.PodReadinessGateConditionType(ingress, backend)
 
 	podsWithoutCondition := podsWithReadinessGateAndStatus(conditionType, noConditionType, api.ConditionUnknown)
 	podsWithCondition := podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionTrue)
@@ -265,7 +268,7 @@ func Test_reconcilePodConditionsLoop(t *testing.T) {
 		tgWatch.cancel()
 	}()
 
-	controller.reconcilePodConditionsLoop(ctx, "arn", "something", tgWatch)
+	controller.reconcilePodConditionsLoop(ctx, "arn", tgWatch, "something")
 	// verifies that the loop breaks when the context is canceled, otherwise this will hang
 }
 
@@ -902,7 +905,7 @@ func Test_reconcilePodConditions(t *testing.T) {
 		}
 
 		controller := NewTargetHealthController(cloud, store, endpointResolver, client).(*targetHealthController)
-		notReadyTargets, err := controller.reconcilePodConditions(context.Background(), tc.tgARN, conditionType, tc.ingress, tc.backend, tc.targetsToReconcile)
+		notReadyTargets, err := controller.reconcilePodConditions(context.Background(), tc.tgARN, tc.ingress, tc.backend, tc.targetsToReconcile, conditionType)
 		if tc.expectedError != nil {
 			assert.EqualError(t, err, tc.expectedError.Error())
 		} else {
@@ -927,94 +930,79 @@ func Test_reconcilePodConditions(t *testing.T) {
 	}
 }
 
-func Test_reconcilePodCondition(t *testing.T) {
+func Test_updatePodReadinessCondition(t *testing.T) {
 	conditionType := api.PodConditionType("target-health.alb.ingress.k8s.aws/ingress1_name_123")
 
 	for _, tc := range []struct {
-		Name          string
-		TargetHealth  string
-		PodsBefore    []*api.Pod
-		PodsAfter     []*api.Pod
-		ExpectedError error
+		Name                  string
+		TargetHealth          string
+		PodsBefore            []*api.Pod
+		PodsAfter             []*api.Pod
+		ExpectedBecomeHealthy bool
 	}{
 		{
-			Name:         "Pod without condition and targetHealth = initial gets condition status = false",
-			TargetHealth: elbv2.TargetHealthStateEnumInitial,
-			PodsBefore:   podsWithReadinessGateAndStatus(conditionType, noConditionType, api.ConditionUnknown),
-			PodsAfter:    podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			Name:                  "Pod without condition and targetHealth = initial gets condition status = false",
+			TargetHealth:          elbv2.TargetHealthStateEnumInitial,
+			PodsBefore:            podsWithReadinessGateAndStatus(conditionType, noConditionType, api.ConditionUnknown),
+			PodsAfter:             podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			ExpectedBecomeHealthy: false,
 		},
 		{
-			Name:         "Pod without condition and targetHealth = unhealthy gets condition status = false",
-			TargetHealth: elbv2.TargetHealthStateEnumUnhealthy,
-			PodsBefore:   podsWithReadinessGateAndStatus(conditionType, noConditionType, api.ConditionUnknown),
-			PodsAfter:    podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			Name:                  "Pod without condition and targetHealth = unhealthy gets condition status = false",
+			TargetHealth:          elbv2.TargetHealthStateEnumUnhealthy,
+			PodsBefore:            podsWithReadinessGateAndStatus(conditionType, noConditionType, api.ConditionUnknown),
+			PodsAfter:             podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			ExpectedBecomeHealthy: false,
 		},
 		{
-			Name:         "Pod without condition and targetHealth = draining gets condition status = false",
-			TargetHealth: elbv2.TargetHealthStateEnumDraining,
-			PodsBefore:   podsWithReadinessGateAndStatus(conditionType, noConditionType, api.ConditionUnknown),
-			PodsAfter:    podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			Name:                  "Pod without condition and targetHealth = draining gets condition status = false",
+			TargetHealth:          elbv2.TargetHealthStateEnumDraining,
+			PodsBefore:            podsWithReadinessGateAndStatus(conditionType, noConditionType, api.ConditionUnknown),
+			PodsAfter:             podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			ExpectedBecomeHealthy: false,
 		},
 		{
-			Name:         "Pod without condition and targetHealth = unavailable gets condition status = unknown",
-			TargetHealth: elbv2.TargetHealthStateEnumUnavailable,
-			PodsBefore:   podsWithReadinessGateAndStatus(conditionType, noConditionType, api.ConditionUnknown),
-			PodsAfter:    podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionUnknown),
+			Name:                  "Pod without condition and targetHealth = unavailable gets condition status = unknown",
+			TargetHealth:          elbv2.TargetHealthStateEnumUnavailable,
+			PodsBefore:            podsWithReadinessGateAndStatus(conditionType, noConditionType, api.ConditionUnknown),
+			PodsAfter:             podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionUnknown),
+			ExpectedBecomeHealthy: false,
 		},
 		{
-			Name:         "Pod without condition and targetHealth = healthy gets condition status = true",
-			TargetHealth: elbv2.TargetHealthStateEnumHealthy,
-			PodsBefore:   podsWithReadinessGateAndStatus(conditionType, noConditionType, api.ConditionUnknown),
-			PodsAfter:    podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionTrue),
+			Name:                  "Pod without condition and targetHealth = healthy gets condition status = true",
+			TargetHealth:          elbv2.TargetHealthStateEnumHealthy,
+			PodsBefore:            podsWithReadinessGateAndStatus(conditionType, noConditionType, api.ConditionUnknown),
+			PodsAfter:             podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionTrue),
+			ExpectedBecomeHealthy: true,
 		},
 		{
-			Name:         "Pod condition gets updated correctly false -> true",
-			TargetHealth: elbv2.TargetHealthStateEnumHealthy,
-			PodsBefore:   podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
-			PodsAfter:    podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionTrue),
+			Name:                  "Pod condition gets updated correctly false -> true",
+			TargetHealth:          elbv2.TargetHealthStateEnumHealthy,
+			PodsBefore:            podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			PodsAfter:             podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionTrue),
+			ExpectedBecomeHealthy: true,
 		},
 		{
-			Name:         "Pod condition gets updated correctly true -> false",
-			TargetHealth: elbv2.TargetHealthStateEnumUnhealthy,
-			PodsBefore:   podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionTrue),
-			PodsAfter:    podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			Name:                  "Pod condition gets updated correctly true -> false",
+			TargetHealth:          elbv2.TargetHealthStateEnumUnhealthy,
+			PodsBefore:            podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionTrue),
+			PodsAfter:             podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			ExpectedBecomeHealthy: false,
 		},
 		{
-			Name:         "Pod condition doesn't get updated if target health didn't change",
-			TargetHealth: elbv2.TargetHealthStateEnumUnhealthy,
-			PodsBefore:   podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
-			PodsAfter:    podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			Name:                  "Pod condition doesn't get updated if target health didn't change",
+			TargetHealth:          elbv2.TargetHealthStateEnumUnhealthy,
+			PodsBefore:            podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			PodsAfter:             podsWithReadinessGateAndStatus(conditionType, conditionType, api.ConditionFalse),
+			ExpectedBecomeHealthy: false,
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			ctx := context.Background()
-			endpointResolver := &mocks.EndpointResolver{}
-
-			cloud := &mocks.CloudAPI{}
-			store := &store.MockStorer{}
-			client := testclient.NewFakeClient()
-			for _, actualPod := range tc.PodsBefore {
-				assert.NoError(t, client.Create(ctx, actualPod))
-			}
-
-			controller := NewTargetHealthController(cloud, store, endpointResolver, client).(*targetHealthController)
-			err := controller.reconcilePodCondition(ctx, conditionType, tc.PodsBefore[0].DeepCopy(), &elbv2.TargetHealth{State: aws.String(tc.TargetHealth)}, false)
-
-			if tc.ExpectedError != nil {
-				assert.Equal(t, tc.ExpectedError, err)
-			} else {
-				assert.NoError(t, err)
-			}
-			cloud.AssertExpectations(t)
-			endpointResolver.AssertExpectations(t)
-
-			for _, expectedPod := range tc.PodsAfter {
-				var actualPod api.Pod
-				key, err := realclient.ObjectKeyFromObject(expectedPod)
-				assert.NoError(t, err)
-				assert.NoError(t, client.Get(ctx, key, &actualPod))
-				assert.Equal(t, *expectedPod, actualPod)
-			}
+			pod := tc.PodsBefore[0].DeepCopy()
+			becomeHealthy := updatePodReadinessCondition(pod, &elbv2.TargetHealth{State: aws.String(tc.TargetHealth)}, conditionType)
+			assert.Equal(t, tc.ExpectedBecomeHealthy, becomeHealthy)
+			opts := cmpopts.IgnoreTypes(v1.Time{})
+			assert.True(t, cmp.Equal(pod, tc.PodsAfter[0], opts), "diff", cmp.Diff(pod, tc.PodsAfter[0], opts))
 		})
 	}
 }
@@ -1034,7 +1022,7 @@ func Test_filterTargetsNeedingReconciliation(t *testing.T) {
 	}
 	desiredTargets := []*elbv2.TargetDescription{{Id: aws.String("10.0.0.1")}}
 	targets := &Targets{TgArn: tgArn, Ingress: ingress, Backend: backend, TargetType: elbv2.TargetTypeEnumInstance}
-	conditionType := podConditionTypeForIngressBackend(ingress, backend)
+	conditionType := backendpkg.PodReadinessGateConditionType(ingress, backend)
 
 	for _, tc := range []struct {
 		Name                    string
@@ -1047,13 +1035,13 @@ func Test_filterTargetsNeedingReconciliation(t *testing.T) {
 			Name:                    "Unready target without pod readiness gate gets ignored",
 			DesiredTargets:          desiredTargets,
 			Pods:                    podsWithReadinessGateAndStatus(noConditionType, noConditionType, api.ConditionUnknown),
-			ExpectedFilteredTargets: []*elbv2.TargetDescription{},
+			ExpectedFilteredTargets: nil,
 		},
 		{
 			Name:                    "Unready target without matching pod readiness gate gets ignored",
 			DesiredTargets:          desiredTargets,
-			Pods:                    podsWithReadinessGateAndStatus(podConditionTypeForIngressBackend(ingress2, backend), noConditionType, api.ConditionUnknown),
-			ExpectedFilteredTargets: []*elbv2.TargetDescription{},
+			Pods:                    podsWithReadinessGateAndStatus(backendpkg.PodReadinessGateConditionType(ingress2, backend), noConditionType, api.ConditionUnknown),
+			ExpectedFilteredTargets: nil,
 		},
 		{
 			Name:                    "Unready target with matching pod readiness gate and without condition status gets picked",
@@ -1079,7 +1067,7 @@ func Test_filterTargetsNeedingReconciliation(t *testing.T) {
 				conditionType,
 				api.ConditionTrue,
 			),
-			ExpectedFilteredTargets: []*elbv2.TargetDescription{},
+			ExpectedFilteredTargets: nil,
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -1093,7 +1081,7 @@ func Test_filterTargetsNeedingReconciliation(t *testing.T) {
 			client := testclient.NewFakeClient()
 
 			controller := NewTargetHealthController(cloud, store, endpointResolver, client).(*targetHealthController)
-			filteredTargets, err := controller.filterTargetsNeedingReconciliation(conditionType, targets, tc.DesiredTargets)
+			filteredTargets, err := controller.filterTargetsNeedingReconciliation(targets, tc.DesiredTargets, conditionType)
 
 			if tc.ExpectedError != nil {
 				assert.Equal(t, tc.ExpectedError, err)

--- a/internal/ingress/backend/endpoint.go
+++ b/internal/ingress/backend/endpoint.go
@@ -145,9 +145,10 @@ func (resolver *endpointResolver) resolveIP(ingress *extensions.Ingress, backend
 		return nil, fmt.Errorf("Unable to find service endpoints for %s: %v", serviceKey, err.Error())
 	}
 
-	conditionType := api.PodConditionType(fmt.Sprintf("target-health.alb.ingress.k8s.aws/%s_%s_%s", ingress.Name, backend.ServiceName, backend.ServicePort.String()))
-	// new condition type uses a static string
-	staticConditionType := api.PodConditionType("target-health.alb.ingress.k8s.aws/load-balancer-any-tg-ready")
+	readinessConditionTypes := []api.PodConditionType{
+		PodReadinessGateConditionType(ingress, backend),
+		AnyLBTGReadyConditionType,
+	}
 	var result []*elbv2.TargetDescription
 	for _, epSubset := range eps.Subsets {
 		for _, epPort := range epSubset.Ports {
@@ -158,7 +159,7 @@ func (resolver *endpointResolver) resolveIP(ingress *extensions.Ingress, backend
 
 			addresses := epSubset.Addresses
 
-			// we need to loop over all unready pods to check if the ALB readiness gate is the only condition preventing the pod from being ready;
+			// we need to loop over all unready pods to check if the ALB readiness gate is the condition preventing the pod from being ready;
 			// if this is the case, we return the pod as a desired target although its not in `Addresses`
 			for _, epAddr := range epSubset.NotReadyAddresses {
 				if epAddr.TargetRef == nil || epAddr.TargetRef.Kind != "Pod" {
@@ -167,30 +168,21 @@ func (resolver *endpointResolver) resolveIP(ingress *extensions.Ingress, backend
 
 				podKey := ingress.Namespace + "/" + epAddr.TargetRef.Name
 				pod, err := resolver.store.GetPod(podKey)
-				if err != nil {
+				if err != nil || !IsPodSuitableAsIPTarget(pod) {
 					continue
 				}
 
 				// check if pod has a readiness gate for this ingress and backend
-				found := false
-				for _, gate := range pod.Spec.ReadinessGates {
-					if gate.ConditionType == conditionType {
-						found = true
-						break
-					}
-					if gate.ConditionType == staticConditionType {
-						found = true
+				foundAnyReadinessGate := false
+				for _, conditionType := range readinessConditionTypes {
+					if PodHasReadinessGate(pod, conditionType) {
+						foundAnyReadinessGate = true
 						break
 					}
 				}
-				if !found {
-					continue
-				}
-
-				if IsPodSuitableAsIPTarget(pod) {
+				if foundAnyReadinessGate {
 					addresses = append(addresses, epAddr)
 				}
-
 			}
 			for _, epAddr := range addresses {
 				result = append(result, &elbv2.TargetDescription{

--- a/internal/ingress/backend/endpoint.go
+++ b/internal/ingress/backend/endpoint.go
@@ -147,7 +147,7 @@ func (resolver *endpointResolver) resolveIP(ingress *extensions.Ingress, backend
 
 	conditionType := api.PodConditionType(fmt.Sprintf("target-health.alb.ingress.k8s.aws/%s_%s_%s", ingress.Name, backend.ServiceName, backend.ServicePort.String()))
 	// new condition type uses a static string
-	staticConditionType := api.PodConditionType("target-health.alb.ingress.k8s.aws/load-balancer-tg-ready")
+	staticConditionType := api.PodConditionType("target-health.alb.ingress.k8s.aws/load-balancer-any-tg-ready")
 	var result []*elbv2.TargetDescription
 	for _, epSubset := range eps.Subsets {
 		for _, epPort := range epSubset.Ports {

--- a/internal/ingress/backend/endpoint.go
+++ b/internal/ingress/backend/endpoint.go
@@ -146,7 +146,8 @@ func (resolver *endpointResolver) resolveIP(ingress *extensions.Ingress, backend
 	}
 
 	conditionType := api.PodConditionType(fmt.Sprintf("target-health.alb.ingress.k8s.aws/%s_%s_%s", ingress.Name, backend.ServiceName, backend.ServicePort.String()))
-
+	// new condition type uses a static string
+	staticConditionType := api.PodConditionType("target-health.alb.ingress.k8s.aws/load-balancer-tg-ready")
 	var result []*elbv2.TargetDescription
 	for _, epSubset := range eps.Subsets {
 		for _, epPort := range epSubset.Ports {
@@ -174,6 +175,10 @@ func (resolver *endpointResolver) resolveIP(ingress *extensions.Ingress, backend
 				found := false
 				for _, gate := range pod.Spec.ReadinessGates {
 					if gate.ConditionType == conditionType {
+						found = true
+						break
+					}
+					if gate.ConditionType == staticConditionType {
 						found = true
 						break
 					}

--- a/internal/ingress/backend/readiness.go
+++ b/internal/ingress/backend/readiness.go
@@ -1,0 +1,42 @@
+package backend
+
+import (
+	"fmt"
+	api "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+)
+
+// a special readiness condition type that will mark pod as ready if any targetGroup have the pod as healthy.
+// This is added to temporarily support Ingress/Backend with long names
+// Please don't use this if your pod will be registered in multiple targetGroups.
+// See https://github.com/kubernetes-sigs/aws-alb-ingress-controller/pull/1253
+const AnyLBTGReadyConditionType = api.PodConditionType("target-health.alb.ingress.k8s.aws/load-balancer-any-tg-ready")
+
+// PodReadinessGateConditionType returns the PodConditionType that is associated with the given ingress and backend
+func PodReadinessGateConditionType(ingress *extensions.Ingress, backend *extensions.IngressBackend) api.PodConditionType {
+	return api.PodConditionType(fmt.Sprintf(
+		"target-health.alb.ingress.k8s.aws/%s_%s_%s",
+		ingress.Name,
+		backend.ServiceName,
+		backend.ServicePort.String(),
+	))
+}
+
+// PodHasReadinessGate returns true if the given pod has a readinessGate with the given conditionType
+func PodHasReadinessGate(pod *api.Pod, conditionType api.PodConditionType) bool {
+	for _, rg := range pod.Spec.ReadinessGates {
+		if rg.ConditionType == conditionType {
+			return true
+		}
+	}
+	return false
+}
+
+func PodConditionForReadinessGate(pod *api.Pod, conditionType api.PodConditionType) (int, *api.PodCondition) {
+	for i, condition := range pod.Status.Conditions {
+		if condition.Type == conditionType {
+			return i, &condition
+		}
+	}
+	return -1, nil
+}

--- a/internal/ingress/backend/readiness.go
+++ b/internal/ingress/backend/readiness.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"fmt"
+
 	api "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 )


### PR DESCRIPTION
-  existing pod condition type has the format "target-health.alb.ingress.k8s.aws/<INGRESS_NAME>_<SERVICE_NAME>_<SERVICE_PORT>". This can exceed the max. allowed length if the <INGRESS_NAME>_<SERVICE_NAME>_<SERVICE_PORT> part exceeds 63 characters. To work around this problem, added support for static pod condition type string. The string is "target-health.alb.ingress.k8s.aws/load-balancer-tg-ready"
- both old and new format are supported. Only one should be used at a time though.

Testing done
- created the required objects in a cluster and verified old format still works
- created the required objects in a cluster verified new format works as well
- verified a deployment transition from old format to new format

resolves #1217 