### PR TITLE
Updates the image version of examples/external-dns.yaml

### DIFF
--- a/docs/examples/external-dns.yaml
+++ b/docs/examples/external-dns.yaml
@@ -52,7 +52,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.9
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.7.1
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Fixes: #1245

As a test, I've confirmed that the Route53 hosted zone was successfully updated.