### PR TITLE
Use external-dns image from docker hub & bitnami.

### DIFF
--- a/docs/examples/external-dns.yaml
+++ b/docs/examples/external-dns.yaml
@@ -52,7 +52,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.9
+        image: bitnami/external-dns:0.5.9
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Not sure who or what zalan.do is...
at any case https://zalan.do/ shows a cert error... which is probably not good.
So switching the image source to docker hub and bitnami.
https://hub.docker.com/r/bitnami/external-dns/tags
<img width="1214" alt="Screenshot 2020-05-18 19 23 36" src="https://user-images.githubusercontent.com/1268088/82278055-2cfcab80-993e-11ea-9a07-eff77e403d3d.png">
