### PR TITLE
bug fix for #1274

### DIFF
--- a/internal/alb/ls/rules.go
+++ b/internal/alb/ls/rules.go
@@ -154,7 +154,7 @@ func (c *rulesController) getDesiredRules(ctx context.Context, listener *elbv2.L
 			}
 			if createsRedirectLoop(listener, elbRule) {
 				continue
-			} else if isUnconditionalRedirect(listener, elbRule) {
+			} else if isUnconditionalRedirect(listener, elbRule, ingressRule.Host) {
 				seenUnconditionalRedirect = true
 			}
 			output = append(output, elbRule)
@@ -543,22 +543,31 @@ func createsRedirectLoop(listener *elbv2.Listener, r elbv2.Rule) bool {
 // isUnconditionalRedirect checks whether specified rule always redirects
 // We consider the rule is a unconditional redirect if
 // 1) The Path condition is nil, or at least one Path condition is /*
-// 2) All other rule conditions are nil (ignoring the Host condition).
-// 3) RedirectConfig is not nil.
-func isUnconditionalRedirect(listener *elbv2.Listener, r elbv2.Rule) bool {
+// 2) The Host condition don't contain any other element than host passed-in
+// 3) All other rule conditions are nil.
+// 4) RedirectConfig is not nil.
+func isUnconditionalRedirect(listener *elbv2.Listener, r elbv2.Rule, ruleHost string) bool {
 	for _, action := range r.Actions {
 		rc := action.RedirectConfig
 		if rc == nil {
 			continue
 		}
 
+		var hosts []string
 		var paths []string
 		for _, c := range r.Conditions {
 			switch aws.StringValue(c.Field) {
 			case conditions.FieldPathPattern:
 				paths = append(paths, aws.StringValueSlice(c.PathPatternConfig.Values)...)
+			case conditions.FieldHostHeader:
+				hosts = append(hosts, aws.StringValueSlice(c.HostHeaderConfig.Values)...)
 			case conditions.FieldHTTPRequestMethod, conditions.FieldSourceIP, conditions.FieldHTTPHeader, conditions.FieldQueryString:
 				// If there are any conditions, then the redirect is not unconditional
+				return false
+			}
+		}
+		for _, host := range hosts {
+			if host != ruleHost {
 				return false
 			}
 		}
@@ -573,7 +582,6 @@ func isUnconditionalRedirect(listener *elbv2.Listener, r elbv2.Rule) bool {
 			// The redirect isn't unconditional if none of the path conditions are a wildcard
 			return false
 		}
-
 		return true
 	}
 	return false


### PR DESCRIPTION
Fix https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/1274

Only ignore hostHeader when decide whether its unconditional redirect if no additional hostHeader is introduced by annotation.