### PR TITLE
Add reminder to stickiness annotation to check target group type

### DIFF
--- a/docs/guide/ingress/annotation.md
+++ b/docs/guide/ingress/annotation.md
@@ -634,7 +634,7 @@ Custom attributes to LoadBalancers and TargetGroups can be controlled with follo
             ```
             alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
             ```
-        - enable sticky sessions
+        - enable sticky sessions (Please remember to check the target group type to have the appropriate behavior).
             ```
             alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=60
             ```


### PR DESCRIPTION
Add a reminder in the documentation to check the target group type when enabling stickiness? Not setting the target group type to IP is often a problem people face to have full pod stickiness.