### PR TITLE
add resource model for securityGroup and Loadbalancer

### DIFF
--- a/pkg/model/core/resource.go
+++ b/pkg/model/core/resource.go
@@ -1,0 +1,7 @@
+package core
+
+// Resource represents a deployment unit.
+type Resource interface {
+	// resource's ID within stack.
+	ID() string
+}

--- a/pkg/model/core/stack.go
+++ b/pkg/model/core/stack.go
@@ -1,0 +1,10 @@
+package core
+
+// Stack presents a resource graph, where resources can depend on each other.
+type Stack interface {
+	// Add a resource.
+	AddResource(res Resource)
+
+	// Add a dependency relationship between resources.
+	AddDependency(src Resource, dst Resource)
+}

--- a/pkg/model/core/token_types.go
+++ b/pkg/model/core/token_types.go
@@ -1,0 +1,15 @@
+package core
+
+import "context"
+
+// Token represent a value that can be resolved at resolution time.
+type Token interface {
+	// token's value resolution may depends on 0 or more Resources.
+	Dependencies() []Resource
+}
+
+// StringToken represent a string value that can be resolved at resolution time.
+type StringToken interface {
+	Token
+	Resolve(ctx context.Context) string
+}

--- a/pkg/model/ec2/security_group.go
+++ b/pkg/model/ec2/security_group.go
@@ -8,8 +8,13 @@ var _ core.Resource = &SecurityGroup{}
 
 // SecurityGroup represents a EC2 SecurityGroup.
 type SecurityGroup struct {
-	id     string
-	spec   SecurityGroupSpec
+	// resource id
+	id string
+
+	//  desired state of SecurityGroup
+	spec SecurityGroupSpec
+
+	// observed state of SecurityGroup
 	status *SecurityGroupStatus
 }
 

--- a/pkg/model/ec2/security_group.go
+++ b/pkg/model/ec2/security_group.go
@@ -1,0 +1,56 @@
+package ec2
+
+import (
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+)
+
+var _ core.Resource = &SecurityGroup{}
+
+// SecurityGroup represents a EC2 SecurityGroup.
+type SecurityGroup struct {
+	id     string
+	spec   SecurityGroupSpec
+	status *SecurityGroupStatus
+}
+
+// NewSecurityGroup constructs new SecurityGroup resource.
+func NewSecurityGroup(stack core.Stack, id string, spec SecurityGroupSpec) *SecurityGroup {
+	sg := &SecurityGroup{
+		id:     id,
+		spec:   spec,
+		status: nil,
+	}
+	stack.AddResource(sg)
+	return sg
+}
+
+// ID returns resource's ID within stack.
+func (sg *SecurityGroup) ID() string {
+	return sg.id
+}
+
+// GroupID returns a token for this SecurityGroup's groupID.
+func (sg *SecurityGroup) GroupID() core.StringToken {
+	// TODO
+	return nil
+}
+
+// SecurityGroupSpec defines the desired state of SecurityGroup
+type SecurityGroupSpec struct {
+	// The name of the security group.
+	GroupName string `json:"groupName"`
+
+	// A description for the security group.
+	// +optional
+	Description *string `json:"description,omitempty"`
+
+	// +optional
+	Tags map[string]string `json:"tags,omitempty"`
+}
+
+// SecurityGroupStatus defines the observed state of SecurityGroup
+type SecurityGroupStatus struct {
+	// The ID of the security group.
+	// +optional
+	GroupID *string `json:"groupID,omitempty"`
+}

--- a/pkg/model/elbv2/load_balancer.go
+++ b/pkg/model/elbv2/load_balancer.go
@@ -1,0 +1,106 @@
+package elbv2
+
+import (
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+)
+
+var _ core.Resource = &LoadBalancer{}
+
+// LoadBalancer represents a ELBV2 LoadBalancer.
+type LoadBalancer struct {
+	id string
+
+	// desired state of LoadBalancer
+	spec LoadBalancerSpec `json:"spec"`
+
+	// observed state of LoadBalancer
+	// +optional
+	status *LoadBalancerStatus `json:"status,omitempty"`
+}
+
+// NewLoadBalancer constructs new LoadBalancer resource.
+func NewLoadBalancer(stack core.Stack, id string, spec LoadBalancerSpec) *LoadBalancer {
+	lb := &LoadBalancer{
+		id:     id,
+		spec:   spec,
+		status: nil,
+	}
+	stack.AddResource(lb)
+	lb.registerDependencies(stack)
+	return lb
+}
+
+// ID returns resource's ID within stack.
+func (lb *LoadBalancer) ID() string {
+	return lb.id
+}
+
+func (lb *LoadBalancer) registerDependencies(stack core.Stack) {
+	for _, sgToken := range lb.spec.SecurityGroups {
+		for _, dep := range sgToken.Dependencies() {
+			stack.AddDependency(lb, dep)
+		}
+	}
+}
+
+type IPAddressType string
+
+const (
+	IPAddressTypeIPV4      IPAddressType = "ipv4"
+	IPAddressTypeDualStack               = "dualstack"
+)
+
+type LoadBalancerScheme string
+
+const (
+	LoadBalancerSchemeInternal       LoadBalancerScheme = "internal"
+	LoadBalancerSchemeInternetFacing                    = "internet-facing"
+)
+
+// Information about a subnet mapping.
+type SubnetMapping struct {
+	// [Network Load Balancers] The allocation ID of the Elastic IP address for
+	// an internet-facing load balancer.
+	AllocationID *string `json:"allocationID,omitempty"`
+
+	// [Network Load Balancers] The private IPv4 address for an internal load balancer.
+	PrivateIPv4Address *string `json:"privateIPv4Address,omitempty"`
+
+	// The ID of the subnet.
+	SubnetID *string `json:"subnetID,omitempty"`
+}
+
+// LoadBalancerSpec defines the desired state of LoadBalancer
+type LoadBalancerSpec struct {
+	// The name of the load balancer.
+	LoadBalancerName string `json:"loadBalancerName"`
+
+	// The nodes of an Internet-facing load balancer have public IP addresses.
+	// The nodes of an internal load balancer have only private IP addresses.
+	// +optional
+	Scheme *LoadBalancerScheme `json:"scheme,omitempty"`
+
+	// The type of IP addresses used by the subnets for your load balancer.
+	// +optional
+	IPAddressType *IPAddressType `json:"ipAddressType,omitempty"`
+
+	// The IDs of the public subnets. You can specify only one subnet per Availability Zone.
+	// +optional
+	SubnetMappings []SubnetMapping `json:"scheme,omitempty"`
+
+	// [Application Load Balancers] The IDs of the security groups for the load balancer.
+	// +optional
+	SecurityGroups []core.StringToken `json:"securityGroups,omitempty"`
+
+	// +optional
+	Tags map[string]string `json:"tags,omitempty"`
+}
+
+// LoadBalancerStatus defines the observed state of LoadBalancer
+type LoadBalancerStatus struct {
+	// +optional
+	LoadBalancerARN *string `json:"loadBalancerARN,omitempty"`
+
+	// +optional
+	DNSName *string `json:"dnsName,omitempty"`
+}

--- a/pkg/model/elbv2/load_balancer.go
+++ b/pkg/model/elbv2/load_balancer.go
@@ -8,6 +8,7 @@ var _ core.Resource = &LoadBalancer{}
 
 // LoadBalancer represents a ELBV2 LoadBalancer.
 type LoadBalancer struct {
+	// resource id
 	id string
 
 	// desired state of LoadBalancer

--- a/pkg/model/elbv2/load_balancer.go
+++ b/pkg/model/elbv2/load_balancer.go
@@ -44,6 +44,13 @@ func (lb *LoadBalancer) registerDependencies(stack core.Stack) {
 	}
 }
 
+type LoadBalancerType string
+
+const (
+	LoadBalancerTypeApplication = "application"
+	LoadBalancerTypeNetwork     = "network"
+)
+
 type IPAddressType string
 
 const (
@@ -75,6 +82,9 @@ type SubnetMapping struct {
 type LoadBalancerSpec struct {
 	// The name of the load balancer.
 	LoadBalancerName string `json:"loadBalancerName"`
+
+	// The type of load balancer.
+	Type LoadBalancerType `json:"type"`
 
 	// The nodes of an Internet-facing load balancer have public IP addresses.
 	// The nodes of an internal load balancer have only private IP addresses.


### PR DESCRIPTION
Add initial resource model for securityGroup and Loadbalancer.
Dependencies among resources will be captured via the token type.
sample usage
```
func modelBuilder() core.Stack {
	var stack core.Stack
	// stack := ....
	lbSG := ec2.NewSecurityGroup(stack, "lbSG", ec2.SecurityGroupSpec{
		GroupName:   "my-sg",
		Description: awssdk.String("managed by aws-load-balancer-controller"),
		Tags: map[string]string{
			"foo": "bar",
		},
	})
	alb := elbv2.NewLoadBalancer(stack, "lb", elbv2.LoadBalancerSpec{
		LoadBalancerName: "my-lb",
		SecurityGroups:   []core.StringToken{lbSG.GroupID(), core.LiteralStringToken("sg-xxxxxxx")},
		Tags: map[string]string{
			"foo": "bar",
		},
	})
	return stack
}

```