### PR TITLE
add literal string token type

### DIFF
--- a/pkg/model/core/token_types.go
+++ b/pkg/model/core/token_types.go
@@ -11,5 +11,19 @@ type Token interface {
 // StringToken represent a string value that can be resolved at resolution time.
 type StringToken interface {
 	Token
-	Resolve(ctx context.Context) string
+	Resolve(ctx context.Context) (string, error)
+}
+
+var _ Token = LiteralStringToken("")
+var _ StringToken = LiteralStringToken("")
+
+// LiteralStringToken represents a literal string value.
+type LiteralStringToken string
+
+func (t LiteralStringToken) Resolve(ctx context.Context) (string, error) {
+	return string(t), nil
+}
+
+func (t LiteralStringToken) Dependencies() []Resource {
+	return nil
 }

--- a/pkg/model/core/token_types_test.go
+++ b/pkg/model/core/token_types_test.go
@@ -1,0 +1,58 @@
+package core
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLiteralStringToken_Resolve(t *testing.T) {
+	tests := []struct {
+		name    string
+		t       LiteralStringToken
+		want    string
+		wantErr error
+	}{
+		{
+			name: "empty string",
+			t:    LiteralStringToken(""),
+			want: "",
+		},
+		{
+			name: "non-empty string",
+			t:    LiteralStringToken("my-token"),
+			want: "my-token",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.t.Resolve(context.Background())
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestLiteralStringToken_Dependencies(t *testing.T) {
+	tests := []struct {
+		name string
+		t    LiteralStringToken
+		want []Resource
+	}{
+		{
+			name: "LiteralStringToken have no dependency",
+			t:    LiteralStringToken("my-token"),
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.t.Dependencies()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
add literal string token type

sample usage:
```
[]core.StringToken(my-sg.GroupID(), LiteralStringToken("sg-xxxx"), LiteralStringToken("sg-yyyy"))
```