### PR TITLE
add ResourceFieldStringToken and stack implementation

### DIFF
--- a/pkg/model/core/graph/resource_graph.go
+++ b/pkg/model/core/graph/resource_graph.go
@@ -1,0 +1,60 @@
+package graph
+
+import "reflect"
+
+// unique ID for a resource.
+type ResourceUID struct {
+	ResType reflect.Type
+	ResID   string
+}
+
+// ResourceGraph is an abstraction of resource DAG.
+type ResourceGraph interface {
+	// Add a node into ResourceGraph.
+	AddNode(node ResourceUID)
+
+	// Add a edge into ResourceGraph, where dstNode depends on srcNode.
+	AddEdge(srcNode ResourceUID, dstNode ResourceUID)
+
+	// Nodes returns all nodes in ResourceGraph.
+	Nodes() []ResourceUID
+
+	// OutEdgeNodes returns all nodes that depends on this node.
+	OutEdgeNodes(node ResourceUID) []ResourceUID
+}
+
+// NewDefaultResourceGraph constructs new defaultResourceGraph.
+func NewDefaultResourceGraph() *defaultResourceGraph {
+	return &defaultResourceGraph{
+		nodes:    nil,
+		outEdges: make(map[ResourceUID][]ResourceUID),
+	}
+}
+
+var _ ResourceGraph = &defaultResourceGraph{}
+
+// defaultResourceGraph is the default implementation for ResourceGraph.
+type defaultResourceGraph struct {
+	nodes    []ResourceUID
+	outEdges map[ResourceUID][]ResourceUID
+}
+
+// Add a node into ResourceGraph.
+func (g *defaultResourceGraph) AddNode(node ResourceUID) {
+	g.nodes = append(g.nodes, node)
+}
+
+// Add a edge into ResourceGraph, where dstNode depends on srcNode.
+func (g *defaultResourceGraph) AddEdge(srcNode ResourceUID, dstNode ResourceUID) {
+	g.outEdges[srcNode] = append(g.outEdges[srcNode], dstNode)
+}
+
+// Nodes returns all nodes in ResourceGraph.
+func (g *defaultResourceGraph) Nodes() []ResourceUID {
+	return g.nodes
+}
+
+// OutEdgeNodes returns all nodes that depends on this node.
+func (g *defaultResourceGraph) OutEdgeNodes(node ResourceUID) []ResourceUID {
+	return g.outEdges[node]
+}

--- a/pkg/model/core/graph/resource_graph_test.go
+++ b/pkg/model/core/graph/resource_graph_test.go
@@ -1,0 +1,86 @@
+package graph
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func fakeResourceUID(resID string) ResourceUID {
+	return ResourceUID{ResID: resID}
+}
+
+func Test_defaultResourceGraph_Operations(t *testing.T) {
+	tests := []struct {
+		name                   string
+		operations             func(graph ResourceGraph)
+		wantNodes              []ResourceUID
+		wantOutEdgeNodesByNode map[ResourceUID][]ResourceUID
+	}{
+		{
+			name: "add a single node",
+			operations: func(graph ResourceGraph) {
+				graph.AddNode(fakeResourceUID("node-A"))
+			},
+			wantNodes: []ResourceUID{fakeResourceUID("node-A")},
+			wantOutEdgeNodesByNode: map[ResourceUID][]ResourceUID{
+				fakeResourceUID("node-A"): nil,
+			},
+		},
+		{
+			name: "add two single node, and edge between them",
+			operations: func(graph ResourceGraph) {
+				graph.AddNode(fakeResourceUID("node-A"))
+				graph.AddNode(fakeResourceUID("node-B"))
+				graph.AddEdge(fakeResourceUID("node-A"), fakeResourceUID("node-B"))
+			},
+			wantNodes: []ResourceUID{fakeResourceUID("node-A"), fakeResourceUID("node-B")},
+			wantOutEdgeNodesByNode: map[ResourceUID][]ResourceUID{
+				fakeResourceUID("node-A"): {fakeResourceUID("node-B")},
+				fakeResourceUID("node-B"): nil,
+			},
+		},
+		{
+			name: "add three single node - case 1",
+			operations: func(graph ResourceGraph) {
+				graph.AddNode(fakeResourceUID("node-A"))
+				graph.AddNode(fakeResourceUID("node-B"))
+				graph.AddNode(fakeResourceUID("node-C"))
+				graph.AddEdge(fakeResourceUID("node-A"), fakeResourceUID("node-B"))
+				graph.AddEdge(fakeResourceUID("node-B"), fakeResourceUID("node-C"))
+			},
+			wantNodes: []ResourceUID{fakeResourceUID("node-A"), fakeResourceUID("node-B"), fakeResourceUID("node-C")},
+			wantOutEdgeNodesByNode: map[ResourceUID][]ResourceUID{
+				fakeResourceUID("node-A"): {fakeResourceUID("node-B")},
+				fakeResourceUID("node-B"): {fakeResourceUID("node-C")},
+				fakeResourceUID("node-C"): nil,
+			},
+		},
+		{
+			name: "add three single node - case 2",
+			operations: func(graph ResourceGraph) {
+				graph.AddNode(fakeResourceUID("node-A"))
+				graph.AddNode(fakeResourceUID("node-B"))
+				graph.AddNode(fakeResourceUID("node-C"))
+				graph.AddEdge(fakeResourceUID("node-A"), fakeResourceUID("node-B"))
+				graph.AddEdge(fakeResourceUID("node-A"), fakeResourceUID("node-C"))
+			},
+			wantNodes: []ResourceUID{fakeResourceUID("node-A"), fakeResourceUID("node-B"), fakeResourceUID("node-C")},
+			wantOutEdgeNodesByNode: map[ResourceUID][]ResourceUID{
+				fakeResourceUID("node-A"): {fakeResourceUID("node-B"), fakeResourceUID("node-C")},
+				fakeResourceUID("node-B"): nil,
+				fakeResourceUID("node-C"): nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewDefaultResourceGraph()
+			tt.operations(g)
+			assert.Equal(t, tt.wantNodes, g.Nodes())
+			for node, wantOutEdgeNodes := range tt.wantOutEdgeNodesByNode {
+				gotOutEdgeNodes := g.OutEdgeNodes(node)
+				assert.Equal(t, wantOutEdgeNodes, gotOutEdgeNodes)
+			}
+		})
+	}
+}

--- a/pkg/model/core/graph/typological_traversal.go
+++ b/pkg/model/core/graph/typological_traversal.go
@@ -1,0 +1,50 @@
+package graph
+
+import (
+	"github.com/pkg/errors"
+)
+
+// TopologicalTraversal will traversal nodes in typological order.
+// @TODO: change this traversal to be parallel.
+func TopologicalTraversal(graph ResourceGraph, visitFunc func(uid ResourceUID) error) error {
+	nodes := graph.Nodes()
+	indegreeByNode := make(map[ResourceUID]int, len(nodes))
+	for _, node := range nodes {
+		if _, ok := indegreeByNode[node]; !ok {
+			indegreeByNode[node] = 0
+		}
+		for _, outEdgeNode := range graph.OutEdgeNodes(node) {
+			indegreeByNode[outEdgeNode]++
+		}
+
+	}
+
+	var queue []ResourceUID
+	for node, indegree := range indegreeByNode {
+		if indegree == 0 {
+			queue = append(queue, node)
+		}
+	}
+
+	for len(queue) > 0 {
+		node := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		if err := visitFunc(node); err != nil {
+			return err
+		}
+
+		for _, outEdgeNode := range graph.OutEdgeNodes(node) {
+			indegreeByNode[outEdgeNode]--
+			if indegreeByNode[outEdgeNode] == 0 {
+				queue = append(queue, outEdgeNode)
+			}
+		}
+	}
+
+	for _, indegree := range indegreeByNode {
+		if indegree > 0 {
+			return errors.New("ResourceGraph is not a DAG")
+		}
+	}
+	return nil
+}

--- a/pkg/model/core/resource.go
+++ b/pkg/model/core/resource.go
@@ -5,3 +5,8 @@ type Resource interface {
 	// resource's ID within stack.
 	ID() string
 }
+
+// ResourceVisitor represents a functor that can operate on a resource.
+type ResourceVisitor interface {
+	Visit(res Resource) error
+}

--- a/pkg/model/core/stack.go
+++ b/pkg/model/core/stack.go
@@ -1,10 +1,59 @@
 package core
 
+import (
+	"reflect"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core/graph"
+)
+
 // Stack presents a resource graph, where resources can depend on each other.
 type Stack interface {
-	// Add a resource.
+	// Add a resource into stack.
 	AddResource(res Resource)
 
 	// Add a dependency relationship between resources.
-	AddDependency(src Resource, dst Resource)
+	AddDependency(dependee Resource, depender Resource)
+
+	// TopologicalTraversal visits resources in stack in topological order.
+	TopologicalTraversal(visitor ResourceVisitor) error
+}
+
+func NewDefaultStack() *defaultStack {
+	return &defaultStack{
+		resources:     make(map[graph.ResourceUID]Resource),
+		resourceGraph: graph.NewDefaultResourceGraph(),
+	}
+}
+
+// default implementation for stack.
+type defaultStack struct {
+	resources     map[graph.ResourceUID]Resource
+	resourceGraph graph.ResourceGraph
+}
+
+// Add a resource.
+func (s *defaultStack) AddResource(res Resource) {
+	resUID := s.computeResourceUID(res)
+	s.resources[resUID] = res
+	s.resourceGraph.AddNode(resUID)
+}
+
+// Add a dependency relationship between resources.
+func (s *defaultStack) AddDependency(dependee Resource, depender Resource) {
+	dependeeResUID := s.computeResourceUID(dependee)
+	dependerResUID := s.computeResourceUID(depender)
+	s.resourceGraph.AddEdge(dependeeResUID, dependerResUID)
+}
+
+func (s *defaultStack) TopologicalTraversal(visitor ResourceVisitor) error {
+	return graph.TopologicalTraversal(s.resourceGraph, func(uid graph.ResourceUID) error {
+		return visitor.Visit(s.resources[uid])
+	})
+}
+
+// computeResourceUID returns the UID for resources.
+func (s *defaultStack) computeResourceUID(res Resource) graph.ResourceUID {
+	return graph.ResourceUID{
+		ResType: reflect.TypeOf(res),
+		ResID:   res.ID(),
+	}
 }

--- a/pkg/model/core/token_types.go
+++ b/pkg/model/core/token_types.go
@@ -1,6 +1,8 @@
 package core
 
-import "context"
+import (
+	"context"
+)
 
 // Token represent a value that can be resolved at resolution time.
 type Token interface {
@@ -14,7 +16,6 @@ type StringToken interface {
 	Resolve(ctx context.Context) (string, error)
 }
 
-var _ Token = LiteralStringToken("")
 var _ StringToken = LiteralStringToken("")
 
 // LiteralStringToken represents a literal string value.
@@ -26,4 +27,31 @@ func (t LiteralStringToken) Resolve(ctx context.Context) (string, error) {
 
 func (t LiteralStringToken) Dependencies() []Resource {
 	return nil
+}
+
+// NewResourceFieldStringToken constructs new ResourceFieldStringToken.
+// @TODO: ideally the resolverFunc can be a shared implementation which dump Resource as json and obtain the fieldPath.
+func NewResourceFieldStringToken(res Resource, fieldPath string,
+	resolverFunc func(ctx context.Context, res Resource, fieldPath string) (string, error)) *ResourceFieldStringToken {
+	return &ResourceFieldStringToken{
+		res:         res,
+		fieldPath:   fieldPath,
+		resolveFunc: resolverFunc,
+	}
+}
+
+var _ StringToken = &ResourceFieldStringToken{}
+
+type ResourceFieldStringToken struct {
+	res         Resource
+	fieldPath   string
+	resolveFunc func(ctx context.Context, res Resource, fieldPath string) (string, error)
+}
+
+func (t *ResourceFieldStringToken) Resolve(ctx context.Context) (string, error) {
+	return t.resolveFunc(ctx, t.res, t.fieldPath)
+}
+
+func (t *ResourceFieldStringToken) Dependencies() []Resource {
+	return []Resource{t.res}
 }

--- a/pkg/model/core/token_types_test.go
+++ b/pkg/model/core/token_types_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -51,6 +52,103 @@ func TestLiteralStringToken_Dependencies(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			got := tt.t.Dependencies()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+var _ Resource = &FakeResource{}
+
+type FakeResource struct {
+	status *FakeResourceStatus `json:"status,omitempty"`
+}
+
+type FakeResourceStatus struct {
+	Field string `json:"field"`
+}
+
+func (r *FakeResource) ID() string {
+	return "fake"
+}
+
+func TestResourceFieldStringToken_Resolve(t *testing.T) {
+	resWithStatus := &FakeResource{
+		status: &FakeResourceStatus{Field: "value"},
+	}
+	resWithoutStatus := &FakeResource{
+		status: nil,
+	}
+
+	tests := []struct {
+		name    string
+		t       *ResourceFieldStringToken
+		want    string
+		wantErr error
+	}{
+		{
+			name: "ResourceFieldStringToken with status fulfilled",
+			t: NewResourceFieldStringToken(resWithStatus, "status/field",
+				func(ctx context.Context, res Resource, fieldPath string) (s string, err error) {
+					fr := res.(*FakeResource)
+					if fr.status == nil {
+						return "", errors.Errorf("FakeResource is not fulfilled yet: %v", fr.ID())
+					}
+					return fr.status.Field, nil
+				},
+			),
+			want: "value",
+		},
+		{
+			name: "ResourceFieldStringToken without status fulfilled",
+			t: NewResourceFieldStringToken(resWithoutStatus, "status/field",
+				func(ctx context.Context, res Resource, fieldPath string) (s string, err error) {
+					fr := res.(*FakeResource)
+					if fr.status == nil {
+						return "", errors.Errorf("FakeResource is not fulfilled yet: %v", fr.ID())
+					}
+					return fr.status.Field, nil
+				},
+			),
+			wantErr: errors.New("FakeResource is not fulfilled yet: fake"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t1 *testing.T) {
+			got, err := tt.t.Resolve(context.Background())
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestResourceFieldStringToken_Dependencies(t *testing.T) {
+	res := &FakeResource{}
+	tests := []struct {
+		name string
+		t    *ResourceFieldStringToken
+		want []Resource
+	}{
+		{
+			name: "ResourceFieldStringToken have dependency on the resource itself",
+			t: NewResourceFieldStringToken(res, "status/field",
+				func(ctx context.Context, res Resource, fieldPath string) (s string, err error) {
+					fr := res.(*FakeResource)
+					if fr.status == nil {
+						return "", errors.Errorf("FakeResource is not fulfilled yet: %v", fr.ID())
+					}
+					return fr.status.Field, nil
+				},
+			),
+			want: []Resource{res},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t1 *testing.T) {
 			got := tt.t.Dependencies()
 			assert.Equal(t, tt.want, got)
 		})

--- a/pkg/model/elbv2/listener.go
+++ b/pkg/model/elbv2/listener.go
@@ -39,7 +39,7 @@ func (ls *Listener) ID() string {
 // register dependencies for Listener.
 func (ls *Listener) registerDependencies(stack core.Stack) {
 	for _, dep := range ls.spec.LoadBalancerARN.Dependencies() {
-		stack.AddDependency(ls, dep)
+		stack.AddDependency(dep, ls)
 	}
 }
 
@@ -293,6 +293,5 @@ type ListenerSpec struct {
 // ListenerStatus defines the observed state of Listener
 type ListenerStatus struct {
 	// The Amazon Resource Name (ARN) of the listener.
-	// +optional
-	ListenerARN *string `json:"listenerARN,omitempty"`
+	ListenerARN string `json:"listenerARN"`
 }

--- a/pkg/model/elbv2/target_group_binding.go
+++ b/pkg/model/elbv2/target_group_binding.go
@@ -42,7 +42,7 @@ func (tgb *TargetGroupBindingResource) ID() string {
 // register dependencies for TargetGroupBindingResource.
 func (tgb *TargetGroupBindingResource) registerDependencies(stack core.Stack) {
 	for _, dep := range tgb.spec.TargetGroupARN.Dependencies() {
-		stack.AddDependency(tgb, dep)
+		stack.AddDependency(dep, tgb)
 	}
 }
 
@@ -67,6 +67,5 @@ type TargetGroupBindingResourceSpec struct {
 // observed state of TargetGroupBindingResource
 type TargetGroupBindingResourceStatus struct {
 	// reference to the TargetGroupBinding Custom Resource.
-	// +optional
-	TargetGroupBindingRef *corev1.ObjectReference `json:"targetGroupBindingRef,omitempty"`
+	TargetGroupBindingRef corev1.ObjectReference `json:"targetGroupBindingRef"`
 }


### PR DESCRIPTION
Add ResourceFieldStringToken and ResourceGraph implementation.
* added `graph.ResourceGraph`, a simplified graph implementation that track nodes and edges.
* added `graph.TopologicalTraversal`, a simplified topological traversal algorithm based on Kahn's algorithm.
   NOTE: 
        1. The TopologicalTraversal interface accepts a functor, so it can be improved to visit multiple independent resources.
        2. TODO: optimize it to make it able to visit multiple resources concurrently.
3. added `core.defaultStack`, which is a default implementation of `core.Stack`, and can be used to traversal its resources in typological order.
4. added `core.ResourceFieldStringToken`, which encodes a resource's field(which can be resolved dynamically). 
    Note:
        1. TODO: the resolveFunc can be shared if every resource can dump itself as json, and then access the fieldPath from JSON.