### PR TITLE
add json model builder

### DIFF
--- a/pkg/deploy/stack_marshaller.go
+++ b/pkg/deploy/stack_marshaller.go
@@ -1,0 +1,32 @@
+package deploy
+
+import (
+	"encoding/json"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+)
+
+// StackMarshaller will marshall a resource stack into JSON.
+type StackMarshaller interface {
+	Marshal(stack core.Stack) (string, error)
+}
+
+func NewDefaultStackMarshaller() *defaultStackMarshaller {
+	return &defaultStackMarshaller{}
+}
+
+var _ StackMarshaller = &defaultStackMarshaller{}
+
+type defaultStackMarshaller struct{}
+
+func (d *defaultStackMarshaller) Marshal(stack core.Stack) (string, error) {
+	builder := NewStackSchemaBuilder()
+	if err := stack.TopologicalTraversal(builder); err != nil {
+		return "", err
+	}
+	stackSchema := builder.Build()
+	payload, err := json.Marshal(stackSchema)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}

--- a/pkg/deploy/stack_marshaller_test.go
+++ b/pkg/deploy/stack_marshaller_test.go
@@ -1,0 +1,58 @@
+package deploy
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+	"testing"
+)
+
+func Test_defaultDeployer_Deploy(t *testing.T) {
+	tests := []struct {
+		name           string
+		modelBuildFunc func() core.Stack
+		want           string
+		wantErr        error
+	}{
+		{
+			name: "single resource",
+			modelBuildFunc: func() core.Stack {
+				stack := core.NewDefaultStack()
+				_ = core.NewFakeResource(stack, "typeX", "resA", core.FakeResourceSpec{
+					FieldA: []core.StringToken{core.LiteralStringToken("valueA")},
+				}, nil)
+				return stack
+			},
+			want: `{"resources":{"typeX":{"resA":{"spec":{"fieldA":["valueA"]}}}}}`,
+		},
+		{
+			name: "multiple resources",
+			modelBuildFunc: func() core.Stack {
+				stack := core.NewDefaultStack()
+				resA := core.NewFakeResource(stack, "typeX", "resA", core.FakeResourceSpec{
+					FieldA: []core.StringToken{core.LiteralStringToken("valueA")},
+				}, nil)
+				resB := core.NewFakeResource(stack, "typeX", "resB", core.FakeResourceSpec{
+					FieldA: []core.StringToken{resA.FieldB()},
+				}, nil)
+				_ = core.NewFakeResource(stack, "typeY", "resC", core.FakeResourceSpec{
+					FieldA: []core.StringToken{core.LiteralStringToken("valueA"), resB.FieldB()},
+				}, nil)
+				return stack
+			},
+			want: `{"resources":{"typeX":{"resA":{"spec":{"fieldA":["valueA"]}},"resB":{"spec":{"fieldA":[{"$ref":"#/resources/typeX/resA/status/fieldB"}]}}},"typeY":{"resC":{"spec":{"fieldA":["valueA",{"$ref":"#/resources/typeX/resB/status/fieldB"}]}}}}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDefaultDeployer()
+			stack := tt.modelBuildFunc()
+			got, err := d.Deploy(stack)
+			assert.Equal(t, tt.want, got)
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			}
+		})
+	}
+}

--- a/pkg/deploy/stack_schema_builder.go
+++ b/pkg/deploy/stack_schema_builder.go
@@ -1,0 +1,40 @@
+package deploy
+
+import (
+	coremodel "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+)
+
+// StackSchema represents the JSON model for stack.
+type StackSchema struct {
+	// all resources within stack.
+	Resources map[string]map[string]interface{} `json:"resources"`
+}
+
+// NewStackSchemaBuilder constructs new stackSchemaBuilder.
+func NewStackSchemaBuilder() *stackSchemaBuilder {
+	return &stackSchemaBuilder{
+		resources: make(map[string]map[string]interface{}),
+	}
+}
+
+var _ coremodel.ResourceVisitor = &stackSchemaBuilder{}
+
+type stackSchemaBuilder struct {
+	resources map[string]map[string]interface{}
+}
+
+// Visit will visit a resource.
+func (b *stackSchemaBuilder) Visit(res coremodel.Resource) error {
+	if _, ok := b.resources[res.Type()]; !ok {
+		b.resources[res.Type()] = make(map[string]interface{})
+	}
+	b.resources[res.Type()][res.ID()] = res
+	return nil
+}
+
+// Build will build StackSchema based on resources visited.
+func (b *stackSchemaBuilder) Build() StackSchema {
+	return StackSchema{
+		Resources: b.resources,
+	}
+}

--- a/pkg/deploy/stack_schema_builder_test.go
+++ b/pkg/deploy/stack_schema_builder_test.go
@@ -1,0 +1,76 @@
+package deploy
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+	"testing"
+)
+
+func Test_stackSchemaBuilder_Visit(t *testing.T) {
+	stack := core.NewDefaultStack()
+	resA := core.NewFakeResource(stack, "typeX", "resA", core.FakeResourceSpec{
+		FieldA: []core.StringToken{core.LiteralStringToken("valueA")},
+	}, nil)
+	resB := core.NewFakeResource(stack, "typeX", "resB", core.FakeResourceSpec{
+		FieldA: []core.StringToken{resA.FieldB()},
+	}, nil)
+	resC := core.NewFakeResource(stack, "typeY", "resC", core.FakeResourceSpec{
+		FieldA: []core.StringToken{core.LiteralStringToken("valueA"), resB.FieldB()},
+	}, nil)
+
+	type args struct {
+		res core.Resource
+	}
+	tests := []struct {
+		name            string
+		args            []args
+		wantStackSchema StackSchema
+	}{
+		{
+			name: "single resource",
+			args: []args{
+				{
+					res: resA,
+				},
+			},
+			wantStackSchema: StackSchema{Resources: map[string]map[string]interface{}{
+				"typeX": {
+					"resA": resA,
+				},
+			}},
+		},
+		{
+			name: "multiple resources",
+			args: []args{
+				{
+					res: resA,
+				},
+				{
+					res: resB,
+				},
+				{
+					res: resC,
+				},
+			},
+			wantStackSchema: StackSchema{Resources: map[string]map[string]interface{}{
+				"typeX": {
+					"resA": resA,
+					"resB": resB,
+				},
+				"typeY": {
+					"resC": resC,
+				},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewStackSchemaBuilder()
+			for _, arg := range tt.args {
+				b.Visit(arg.res)
+			}
+			gotStackSchema := b.Build()
+			assert.Equal(t, tt.wantStackSchema, gotStackSchema)
+		})
+	}
+}

--- a/pkg/model/core/fake_resource.go
+++ b/pkg/model/core/fake_resource.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"context"
+	"github.com/pkg/errors"
+)
+
+var _ Resource = &FakeResource{}
+
+func NewFakeResource(stack Stack, resType string, id string, spec FakeResourceSpec, status *FakeResourceStatus) *FakeResource {
+	r := &FakeResource{
+		resType: resType,
+		id:      id,
+		Spec:    spec,
+		Status:  status,
+	}
+	stack.AddResource(r)
+	return r
+}
+
+func (r *FakeResource) Type() string {
+	return r.resType
+}
+
+func (r *FakeResource) ID() string {
+	return r.id
+}
+
+// register dependencies for LoadBalancer.
+func (r *FakeResource) registerDependencies(stack Stack) {
+	for _, field := range r.Spec.FieldA {
+		for _, dep := range field.Dependencies() {
+			stack.AddDependency(dep, r)
+		}
+	}
+}
+
+func (r *FakeResource) FieldB() StringToken {
+	return NewResourceFieldStringToken(r, "status/fieldB",
+		func(ctx context.Context, res Resource, fieldPath string) (s string, err error) {
+			r := res.(*FakeResource)
+			if r.Status == nil {
+				return "", errors.Errorf("FakeResource is not fulfilled yet: %v", r.ID())
+			}
+			return r.Status.FieldB, nil
+		},
+	)
+}
+
+type FakeResource struct {
+	resType string
+	id      string
+
+	Spec   FakeResourceSpec    `json:"spec"`
+	Status *FakeResourceStatus `json:"status,omitempty"`
+}
+
+type FakeResourceSpec struct {
+	FieldA []StringToken `json:"fieldA"`
+}
+
+type FakeResourceStatus struct {
+	FieldB string `json:"fieldB"`
+}

--- a/pkg/model/core/resource.go
+++ b/pkg/model/core/resource.go
@@ -2,6 +2,9 @@ package core
 
 // Resource represents a deployment unit.
 type Resource interface {
+	// resource's Type.
+	Type() string
+
 	// resource's ID within stack.
 	ID() string
 }

--- a/pkg/model/core/token_types.go
+++ b/pkg/model/core/token_types.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 )
 
 // Token represent a value that can be resolved at resolution time.
@@ -54,4 +55,9 @@ func (t *ResourceFieldStringToken) Resolve(ctx context.Context) (string, error) 
 
 func (t *ResourceFieldStringToken) Dependencies() []Resource {
 	return []Resource{t.res}
+}
+
+func (t *ResourceFieldStringToken) MarshalJSON() ([]byte, error) {
+	payload := fmt.Sprintf(`{"$ref": "#/resources/%v/%v/%v"}`, t.res.Type(), t.res.ID(), t.fieldPath)
+	return []byte(payload), nil
 }

--- a/pkg/model/ec2/security_group.go
+++ b/pkg/model/ec2/security_group.go
@@ -14,21 +14,26 @@ type SecurityGroup struct {
 	id string
 
 	//  desired state of SecurityGroup
-	spec SecurityGroupSpec `json:"spec"`
+	Spec SecurityGroupSpec `json:"spec"`
 
 	// observed state of SecurityGroup
-	status *SecurityGroupStatus `json:"status,omitempty"`
+	Status *SecurityGroupStatus `json:"status,omitempty"`
 }
 
 // NewSecurityGroup constructs new SecurityGroup resource.
 func NewSecurityGroup(stack core.Stack, id string, spec SecurityGroupSpec) *SecurityGroup {
 	sg := &SecurityGroup{
 		id:     id,
-		spec:   spec,
-		status: nil,
+		Spec:   spec,
+		Status: nil,
 	}
 	stack.AddResource(sg)
 	return sg
+}
+
+// Type returns resource's Type.
+func (sg *SecurityGroup) Type() string {
+	return "AWS::EC2::SecurityGroup"
 }
 
 // ID returns resource's ID within stack.
@@ -41,10 +46,10 @@ func (sg *SecurityGroup) GroupID() core.StringToken {
 	return core.NewResourceFieldStringToken(sg, "status/groupID",
 		func(ctx context.Context, res core.Resource, fieldPath string) (s string, err error) {
 			sg := res.(*SecurityGroup)
-			if sg.status == nil {
+			if sg.Status == nil {
 				return "", errors.Errorf("SecurityGroup is not fulfilled yet: %v", sg.ID())
 			}
-			return sg.status.GroupID, nil
+			return sg.Status.GroupID, nil
 		},
 	)
 }

--- a/pkg/model/elbv2/listener.go
+++ b/pkg/model/elbv2/listener.go
@@ -12,23 +12,28 @@ type Listener struct {
 	id string
 
 	// desired state of LoadBalancer
-	spec ListenerSpec `json:"spec"`
+	Spec ListenerSpec `json:"spec"`
 
 	// observed state of LoadBalancer
 	// +optional
-	status *ListenerStatus `json:"status,omitempty"`
+	Status *ListenerStatus `json:"status,omitempty"`
 }
 
 // NewListener constructs new Listener resource.
 func NewListener(stack core.Stack, id string, spec ListenerSpec) *Listener {
 	ls := &Listener{
 		id:     id,
-		spec:   spec,
-		status: nil,
+		Spec:   spec,
+		Status: nil,
 	}
 	stack.AddResource(ls)
 	ls.registerDependencies(stack)
 	return ls
+}
+
+// Type returns resource's Type.
+func (ls *Listener) Type() string {
+	return "AWS::ElasticLoadBalancingV2::Listener"
 }
 
 // ID returns resource's ID within stack.
@@ -38,7 +43,7 @@ func (ls *Listener) ID() string {
 
 // register dependencies for Listener.
 func (ls *Listener) registerDependencies(stack core.Stack) {
-	for _, dep := range ls.spec.LoadBalancerARN.Dependencies() {
+	for _, dep := range ls.Spec.LoadBalancerARN.Dependencies() {
 		stack.AddDependency(dep, ls)
 	}
 }

--- a/pkg/model/elbv2/load_balancer.go
+++ b/pkg/model/elbv2/load_balancer.go
@@ -14,23 +14,28 @@ type LoadBalancer struct {
 	id string
 
 	// desired state of LoadBalancer
-	spec LoadBalancerSpec `json:"spec"`
+	Spec LoadBalancerSpec `json:"spec"`
 
 	// observed state of LoadBalancer
 	// +optional
-	status *LoadBalancerStatus `json:"status,omitempty"`
+	Status *LoadBalancerStatus `json:"status,omitempty"`
 }
 
 // NewLoadBalancer constructs new LoadBalancer resource.
 func NewLoadBalancer(stack core.Stack, id string, spec LoadBalancerSpec) *LoadBalancer {
 	lb := &LoadBalancer{
 		id:     id,
-		spec:   spec,
-		status: nil,
+		Spec:   spec,
+		Status: nil,
 	}
 	stack.AddResource(lb)
 	lb.registerDependencies(stack)
 	return lb
+}
+
+// Type returns resource's Type.
+func (lb *LoadBalancer) Type() string {
+	return "AWS::ElasticLoadBalancingV2::LoadBalancer"
 }
 
 // ID returns resource's ID within stack.
@@ -43,10 +48,10 @@ func (lb *LoadBalancer) LoadBalancerARN() core.StringToken {
 	return core.NewResourceFieldStringToken(lb, "status/loadBalancerARN",
 		func(ctx context.Context, res core.Resource, fieldPath string) (s string, err error) {
 			lb := res.(*LoadBalancer)
-			if lb.status == nil {
+			if lb.Status == nil {
 				return "", errors.Errorf("LoadBalancer is not fulfilled yet: %v", lb.ID())
 			}
-			return lb.status.LoadBalancerARN, nil
+			return lb.Status.LoadBalancerARN, nil
 		},
 	)
 }
@@ -56,17 +61,17 @@ func (lb *LoadBalancer) DNSName() core.StringToken {
 	return core.NewResourceFieldStringToken(lb, "status/dnsName",
 		func(ctx context.Context, res core.Resource, fieldPath string) (s string, err error) {
 			lb := res.(*LoadBalancer)
-			if lb.status == nil {
+			if lb.Status == nil {
 				return "", errors.Errorf("LoadBalancer is not fulfilled yet: %v", lb.ID())
 			}
-			return lb.status.DNSName, nil
+			return lb.Status.DNSName, nil
 		},
 	)
 }
 
 // register dependencies for LoadBalancer.
 func (lb *LoadBalancer) registerDependencies(stack core.Stack) {
-	for _, sgToken := range lb.spec.SecurityGroups {
+	for _, sgToken := range lb.Spec.SecurityGroups {
 		for _, dep := range sgToken.Dependencies() {
 			stack.AddDependency(dep, lb)
 		}

--- a/pkg/model/elbv2/target_group.go
+++ b/pkg/model/elbv2/target_group.go
@@ -15,22 +15,27 @@ type TargetGroup struct {
 	id string
 
 	// desired state of TargetGroup
-	spec TargetGroupSpec `json:"spec"`
+	Spec TargetGroupSpec `json:"spec"`
 
 	// observed state of TargetGroup
 	// +optional
-	status *TargetGroupStatus `json:"status,omitempty"`
+	Status *TargetGroupStatus `json:"status,omitempty"`
 }
 
 // NewTargetGroup constructs new TargetGroup resource.
 func NewTargetGroup(stack core.Stack, id string, spec TargetGroupSpec) *TargetGroup {
 	tg := &TargetGroup{
 		id:     id,
-		spec:   spec,
-		status: nil,
+		Spec:   spec,
+		Status: nil,
 	}
 	stack.AddResource(tg)
 	return tg
+}
+
+// Type returns resource's Type.
+func (tg *TargetGroup) Type() string {
+	return "AWS::ElasticLoadBalancingV2::TargetGroup"
 }
 
 // ID returns resource's ID within stack.
@@ -43,10 +48,10 @@ func (tg *TargetGroup) TargetGroupARN() core.StringToken {
 	return core.NewResourceFieldStringToken(tg, "status/targetGroupARN",
 		func(ctx context.Context, res core.Resource, fieldPath string) (s string, err error) {
 			tg := res.(*TargetGroup)
-			if tg.status == nil {
+			if tg.Status == nil {
 				return "", errors.Errorf("TargetGroup is not fulfilled yet: %v", tg.ID())
 			}
-			return tg.status.TargetGroupARN, nil
+			return tg.Status.TargetGroupARN, nil
 		},
 	)
 }

--- a/pkg/model/elbv2/target_group_binding.go
+++ b/pkg/model/elbv2/target_group_binding.go
@@ -15,23 +15,28 @@ type TargetGroupBindingResource struct {
 	id string
 
 	// desired state of TargetGroupBindingResource
-	spec TargetGroupBindingResourceSpec `json:"spec"`
+	Spec TargetGroupBindingResourceSpec `json:"spec"`
 
 	// observed state of TargetGroupBindingResource
 	// +optional
-	status *TargetGroupBindingResourceStatus `json:"status,omitempty"`
+	Status *TargetGroupBindingResourceStatus `json:"status,omitempty"`
 }
 
 // NewTargetGroupBindingResource constructs new TargetGroupBindingResource resource.
 func NewTargetGroupBindingResource(stack core.Stack, id string, spec TargetGroupBindingResourceSpec) *TargetGroupBindingResource {
 	tgb := &TargetGroupBindingResource{
 		id:     id,
-		spec:   spec,
-		status: nil,
+		Spec:   spec,
+		Status: nil,
 	}
 	stack.AddResource(tgb)
 	tgb.registerDependencies(stack)
 	return tgb
+}
+
+// Type returns resource's Type.
+func (tgb *TargetGroupBindingResource) Type() string {
+	return "K8S::ElasticLoadBalancingV2::TargetGroupBinding"
 }
 
 // ID returns resource's ID within stack.
@@ -41,7 +46,7 @@ func (tgb *TargetGroupBindingResource) ID() string {
 
 // register dependencies for TargetGroupBindingResource.
 func (tgb *TargetGroupBindingResource) registerDependencies(stack core.Stack) {
-	for _, dep := range tgb.spec.TargetGroupARN.Dependencies() {
+	for _, dep := range tgb.Spec.TargetGroupARN.Dependencies() {
 		stack.AddDependency(dep, tgb)
 	}
 }


### PR DESCRIPTION
Add JSON model deployer for resource stack, which will dump stack as JSON.
References between references are encoded with [JSONReference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03)
e.g. 
```
stack := core.NewDefaultStack()
	sg := ec2model.NewSecurityGroup(stack, "LB-SG", ec2model.SecurityGroupSpec{
		GroupName:   "my-sg-abc",
		Description: awssdk.String("SecurityGroup for LB"),
		Tags:        map[string]string{},
	})

	elbv2model.NewLoadBalancer(stack, "LB", elbv2model.LoadBalancerSpec{
		Name:           "my-lb-name",
		Type:           elbv2model.LoadBalancerTypeNetwork,
		SecurityGroups: []core.StringToken{sg.GroupID(), core.LiteralStringToken("hello")},
	})

	marshaller := deploy.NewDefaultStackMarshaller()
	payload, err := marshaller.Marshal(stack)
	fmt.Println(payload, err)
```
```json
{
   "resources":{
      "AWS::EC2::SecurityGroup":{
         "LB-SG":{
            "spec":{
               "groupName":"my-sg-abc",
               "description":"SecurityGroup for LB"
            }
         }
      },
      "AWS::ElasticLoadBalancingV2::LoadBalancer":{
         "LB":{
            "spec":{
               "name":"my-lb-name",
               "type":"network",
               "securityGroups":[
                  {
                     "$ref":"#/resources/AWS::EC2::SecurityGroup/LB-SG/status/groupID"
                  },
                  "hello"
               ]
            }
         }
      }
   }
}
```