### PR TITLE
add ListenerSynthesizer and deployer

### DIFF
--- a/mocks/aws/services/mock_elbv2.go
+++ b/mocks/aws/services/mock_elbv2.go
@@ -650,6 +650,21 @@ func (mr *MockELBV2MockRecorder) DescribeListenerCertificates(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeListenerCertificates", reflect.TypeOf((*MockELBV2)(nil).DescribeListenerCertificates), arg0)
 }
 
+// DescribeListenerCertificatesAsList mocks base method
+func (m *MockELBV2) DescribeListenerCertificatesAsList(arg0 context.Context, arg1 *elbv2.DescribeListenerCertificatesInput) ([]*elbv2.Certificate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeListenerCertificatesAsList", arg0, arg1)
+	ret0, _ := ret[0].([]*elbv2.Certificate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeListenerCertificatesAsList indicates an expected call of DescribeListenerCertificatesAsList
+func (mr *MockELBV2MockRecorder) DescribeListenerCertificatesAsList(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeListenerCertificatesAsList", reflect.TypeOf((*MockELBV2)(nil).DescribeListenerCertificatesAsList), arg0, arg1)
+}
+
 // DescribeListenerCertificatesRequest mocks base method
 func (m *MockELBV2) DescribeListenerCertificatesRequest(arg0 *elbv2.DescribeListenerCertificatesInput) (*request.Request, *elbv2.DescribeListenerCertificatesOutput) {
 	m.ctrl.T.Helper()
@@ -698,6 +713,21 @@ func (m *MockELBV2) DescribeListeners(arg0 *elbv2.DescribeListenersInput) (*elbv
 func (mr *MockELBV2MockRecorder) DescribeListeners(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeListeners", reflect.TypeOf((*MockELBV2)(nil).DescribeListeners), arg0)
+}
+
+// DescribeListenersAsList mocks base method
+func (m *MockELBV2) DescribeListenersAsList(arg0 context.Context, arg1 *elbv2.DescribeListenersInput) ([]*elbv2.Listener, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeListenersAsList", arg0, arg1)
+	ret0, _ := ret[0].([]*elbv2.Listener)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeListenersAsList indicates an expected call of DescribeListenersAsList
+func (mr *MockELBV2MockRecorder) DescribeListenersAsList(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeListenersAsList", reflect.TypeOf((*MockELBV2)(nil).DescribeListenersAsList), arg0, arg1)
 }
 
 // DescribeListenersPages mocks base method
@@ -929,6 +959,21 @@ func (m *MockELBV2) DescribeRules(arg0 *elbv2.DescribeRulesInput) (*elbv2.Descri
 func (mr *MockELBV2MockRecorder) DescribeRules(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRules", reflect.TypeOf((*MockELBV2)(nil).DescribeRules), arg0)
+}
+
+// DescribeRulesAsList mocks base method
+func (m *MockELBV2) DescribeRulesAsList(arg0 context.Context, arg1 *elbv2.DescribeRulesInput) ([]*elbv2.Rule, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeRulesAsList", arg0, arg1)
+	ret0, _ := ret[0].([]*elbv2.Rule)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeRulesAsList indicates an expected call of DescribeRulesAsList
+func (mr *MockELBV2MockRecorder) DescribeRulesAsList(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRulesAsList", reflect.TypeOf((*MockELBV2)(nil).DescribeRulesAsList), arg0, arg1)
 }
 
 // DescribeRulesRequest mocks base method

--- a/pkg/aws/services/elbv2.go
+++ b/pkg/aws/services/elbv2.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
@@ -15,6 +16,15 @@ type ELBV2 interface {
 
 	// wrapper to DescribeTargetGroupsPagesWithContext API, which aggregates paged results into list.
 	DescribeTargetGroupsAsList(ctx context.Context, input *elbv2.DescribeTargetGroupsInput) ([]*elbv2.TargetGroup, error)
+
+	// wrapper to DescribeListenersPagesWithContext API, which aggregates paged results into list.
+	DescribeListenersAsList(ctx context.Context, input *elbv2.DescribeListenersInput) ([]*elbv2.Listener, error)
+
+	// wrapper to DescribeListenerCertificatesWithContext API, which aggregates paged results into list.
+	DescribeListenerCertificatesAsList(ctx context.Context, input *elbv2.DescribeListenerCertificatesInput) ([]*elbv2.Certificate, error)
+
+	// wrapper to DescribeRulesWithContext API, which aggregates paged results into list.
+	DescribeRulesAsList(ctx context.Context, input *elbv2.DescribeRulesInput) ([]*elbv2.Rule, error)
 }
 
 // NewELBV2 constructs new ELBV2 implementation.
@@ -49,4 +59,49 @@ func (c *defaultELBV2) DescribeTargetGroupsAsList(ctx context.Context, input *el
 		return nil, err
 	}
 	return result, nil
+}
+
+func (c *defaultELBV2) DescribeListenersAsList(ctx context.Context, input *elbv2.DescribeListenersInput) ([]*elbv2.Listener, error) {
+	var result []*elbv2.Listener
+	if err := c.DescribeListenersPagesWithContext(ctx, input, func(output *elbv2.DescribeListenersOutput, _ bool) bool {
+		result = append(result, output.Listeners...)
+		return true
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *defaultELBV2) DescribeListenerCertificatesAsList(ctx context.Context, input *elbv2.DescribeListenerCertificatesInput) ([]*elbv2.Certificate, error) {
+	var certificates []*elbv2.Certificate
+	p := request.Pagination{
+		EndPageOnSameToken: true,
+		NewRequest: func() (*request.Request, error) {
+			req, _ := c.DescribeListenerCertificatesRequest(input)
+			req.SetContext(ctx)
+			return req, nil
+		},
+	}
+	for p.Next() {
+		page := p.Page().(*elbv2.DescribeListenerCertificatesOutput)
+		certificates = append(certificates, page.Certificates...)
+	}
+	return certificates, p.Err()
+}
+
+func (c *defaultELBV2) DescribeRulesAsList(ctx context.Context, input *elbv2.DescribeRulesInput) ([]*elbv2.Rule, error) {
+	var rules []*elbv2.Rule
+	p := request.Pagination{
+		EndPageOnSameToken: true,
+		NewRequest: func() (*request.Request, error) {
+			req, _ := c.DescribeRulesRequest(input)
+			req.SetContext(ctx)
+			return req, nil
+		},
+	}
+	for p.Next() {
+		page := p.Page().(*elbv2.DescribeRulesOutput)
+		rules = append(rules, page.Rules...)
+	}
+	return rules, p.Err()
 }

--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -1,0 +1,292 @@
+package elbv2
+
+import (
+	"context"
+	"fmt"
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
+	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws/services"
+	elbv2equality "sigs.k8s.io/aws-alb-ingress-controller/pkg/equality/elbv2"
+	elbv2model "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/elbv2"
+)
+
+// ListenerManager is responsible for create/update/delete Listener resources.
+type ListenerManager interface {
+	Create(ctx context.Context, resLS *elbv2model.Listener) (elbv2model.ListenerStatus, error)
+
+	Update(ctx context.Context, resLS *elbv2model.Listener, sdkLS *elbv2sdk.Listener) (elbv2model.ListenerStatus, error)
+
+	Delete(ctx context.Context, sdkLS *elbv2sdk.Listener) error
+}
+
+func NewDefaultListenerManager(elbv2Client services.ELBV2, logger logr.Logger) *defaultListenerManager {
+	return &defaultListenerManager{
+		elbv2Client: elbv2Client,
+		logger:      logger,
+	}
+}
+
+var _ ListenerManager = &defaultListenerManager{}
+
+// default implementation for ListenerManager
+type defaultListenerManager struct {
+	elbv2Client services.ELBV2
+	logger      logr.Logger
+}
+
+func (m *defaultListenerManager) Create(ctx context.Context, resLS *elbv2model.Listener) (elbv2model.ListenerStatus, error) {
+	req, err := buildSDKCreateListenerInput(resLS.Spec)
+	if err != nil {
+		return elbv2model.ListenerStatus{}, err
+	}
+
+	m.logger.Info("creating listener",
+		"stackID", resLS.Stack().StackID(),
+		"resourceID", resLS.ID())
+	resp, err := m.elbv2Client.CreateListenerWithContext(ctx, req)
+	if err != nil {
+		return elbv2model.ListenerStatus{}, err
+	}
+	sdkLS := resp.Listeners[0]
+	m.logger.Info("created listener",
+		"stackID", resLS.Stack().StackID(),
+		"resourceID", resLS.ID(),
+		"arn", awssdk.StringValue(sdkLS.ListenerArn))
+
+	if err := m.updateSDKListenerWithExtraCertificates(ctx, resLS, sdkLS, true); err != nil {
+		return elbv2model.ListenerStatus{}, err
+	}
+	return buildResListenerStatus(sdkLS), nil
+}
+
+func (m *defaultListenerManager) Update(ctx context.Context, resLS *elbv2model.Listener, sdkLS *elbv2sdk.Listener) (elbv2model.ListenerStatus, error) {
+	if err := m.updateSDKListenerWithSettings(ctx, resLS, sdkLS); err != nil {
+		return elbv2model.ListenerStatus{}, err
+	}
+	if err := m.updateSDKListenerWithExtraCertificates(ctx, resLS, sdkLS, false); err != nil {
+		return elbv2model.ListenerStatus{}, err
+	}
+	return buildResListenerStatus(sdkLS), nil
+}
+
+func (m *defaultListenerManager) Delete(ctx context.Context, sdkLS *elbv2sdk.Listener) error {
+	req := &elbv2sdk.DeleteListenerInput{
+		ListenerArn: sdkLS.ListenerArn,
+	}
+	m.logger.Info("deleting listener",
+		"arn", awssdk.StringValue(req.ListenerArn))
+	if _, err := m.elbv2Client.DeleteListenerWithContext(ctx, req); err != nil {
+		return err
+	}
+	m.logger.Info("deleted listener",
+		"arn", awssdk.StringValue(req.ListenerArn))
+	return nil
+}
+
+func (m *defaultListenerManager) updateSDKListenerWithSettings(ctx context.Context, resLS *elbv2model.Listener, sdkLS *elbv2sdk.Listener) error {
+	desiredDefaultActions, err := buildSDKActions(resLS.Spec.DefaultActions)
+	if err != nil {
+		return err
+	}
+	desiredDefaultCerts, _ := buildSDKCertificates(resLS.Spec.Certificates)
+	if !isSDKListenerSettingsDrifted(resLS.Spec, sdkLS, desiredDefaultActions, desiredDefaultCerts) {
+		return nil
+	}
+	req := buildSDKModifyListenerInput(resLS.Spec, desiredDefaultActions, desiredDefaultCerts)
+	req.ListenerArn = sdkLS.ListenerArn
+	m.logger.Info("modifying listener",
+		"stackID", resLS.Stack().StackID(),
+		"resourceID", resLS.ID(),
+		"arn", awssdk.StringValue(sdkLS.ListenerArn))
+	if _, err := m.elbv2Client.ModifyListenerWithContext(ctx, req); err != nil {
+		return err
+	}
+	m.logger.Info("modified listener",
+		"stackID", resLS.Stack().StackID(),
+		"resourceID", resLS.ID(),
+		"arn", awssdk.StringValue(sdkLS.ListenerArn))
+	return nil
+}
+
+// updateSDKListenerWithExtraCertificates will update the extra certificates on listener.
+// currentExtraCertificates is the current extra certificates, if it's nil, the current extra certificates will be fetched from AWS.
+func (m *defaultListenerManager) updateSDKListenerWithExtraCertificates(ctx context.Context, resLS *elbv2model.Listener,
+	sdkLS *elbv2sdk.Listener, isNewSDKListener bool) error {
+	desiredExtraCertARNs := sets.NewString()
+	_, desiredExtraCerts := buildSDKCertificates(resLS.Spec.Certificates)
+	for _, cert := range desiredExtraCerts {
+		desiredExtraCertARNs.Insert(awssdk.StringValue(cert.CertificateArn))
+	}
+	currentExtraCertARNs := sets.NewString()
+	if !isNewSDKListener {
+		certARNs, err := m.fetchSDKListenerExtraCertificateARNs(ctx, sdkLS)
+		if err != nil {
+			return err
+		}
+		currentExtraCertARNs.Insert(certARNs...)
+	}
+
+	for _, certARN := range desiredExtraCertARNs.Difference(currentExtraCertARNs).List() {
+		req := &elbv2sdk.AddListenerCertificatesInput{
+			ListenerArn: sdkLS.ListenerArn,
+			Certificates: []*elbv2sdk.Certificate{
+				{
+					CertificateArn: awssdk.String(certARN),
+				},
+			},
+		}
+		m.logger.Info("adding certificate to listener",
+			"stackID", resLS.Stack().StackID(),
+			"resourceID", resLS.ID(),
+			"arn", awssdk.StringValue(sdkLS.ListenerArn),
+			"certificateARN", certARN)
+		if _, err := m.elbv2Client.AddListenerCertificatesWithContext(ctx, req); err != nil {
+			return err
+		}
+		m.logger.Info("added certificate to listener",
+			"stackID", resLS.Stack().StackID(),
+			"resourceID", resLS.ID(),
+			"arn", awssdk.StringValue(sdkLS.ListenerArn),
+			"certificateARN", certARN)
+	}
+
+	for _, certARN := range currentExtraCertARNs.Difference(desiredExtraCertARNs).List() {
+		req := &elbv2sdk.RemoveListenerCertificatesInput{
+			ListenerArn: sdkLS.ListenerArn,
+			Certificates: []*elbv2sdk.Certificate{
+				{
+					CertificateArn: awssdk.String(certARN),
+				},
+			},
+		}
+		m.logger.Info("removing certificate from listener",
+			"stackID", resLS.Stack().StackID(),
+			"resourceID", resLS.ID(),
+			"arn", awssdk.StringValue(sdkLS.ListenerArn),
+			"certificateARN", certARN)
+		if _, err := m.elbv2Client.RemoveListenerCertificatesWithContext(ctx, req); err != nil {
+			return err
+		}
+		m.logger.Info("removed certificate from listener",
+			"stackID", resLS.Stack().StackID(),
+			"resourceID", resLS.ID(),
+			"arn", awssdk.StringValue(sdkLS.ListenerArn),
+			"certificateARN", certARN)
+	}
+
+	return nil
+}
+
+func (m *defaultListenerManager) fetchSDKListenerExtraCertificateARNs(ctx context.Context, sdkLS *elbv2sdk.Listener) ([]string, error) {
+	req := &elbv2sdk.DescribeListenerCertificatesInput{
+		ListenerArn: sdkLS.ListenerArn,
+	}
+	sdkCerts, err := m.elbv2Client.DescribeListenerCertificatesAsList(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	extraCertARNs := make([]string, 0, len(sdkCerts))
+	for _, cert := range sdkCerts {
+		if !awssdk.BoolValue(cert.IsDefault) {
+			extraCertARNs = append(extraCertARNs, awssdk.StringValue(cert.CertificateArn))
+		}
+	}
+	return extraCertARNs, nil
+}
+
+func isSDKListenerSettingsDrifted(lsSpec elbv2model.ListenerSpec, sdkLS *elbv2sdk.Listener,
+	desiredDefaultActions []*elbv2sdk.Action, desiredDefaultCerts []*elbv2sdk.Certificate) bool {
+	if lsSpec.Port != awssdk.Int64Value(sdkLS.Port) {
+		return true
+	}
+	if string(lsSpec.Protocol) != awssdk.StringValue(sdkLS.Protocol) {
+		return true
+	}
+	if !cmp.Equal(desiredDefaultActions, sdkLS.DefaultActions, elbv2equality.CompareOptionForActions()) {
+		fmt.Println("case 3", awsutil.Prettify(desiredDefaultActions), awsutil.Prettify(sdkLS.DefaultActions))
+		return true
+	}
+	if !cmp.Equal(desiredDefaultCerts, sdkLS.Certificates, elbv2equality.CompareOptionForCertificates()) {
+		fmt.Println("case 3")
+		return true
+	}
+	if lsSpec.SSLPolicy != nil && awssdk.StringValue(lsSpec.SSLPolicy) != awssdk.StringValue(sdkLS.SslPolicy) {
+		fmt.Println("case 4")
+		return true
+	}
+	if !cmp.Equal(lsSpec.ALPNPolicy, awssdk.StringValueSlice(sdkLS.AlpnPolicy), cmpopts.EquateEmpty()) {
+		fmt.Println("case 5")
+		return true
+	}
+
+	return false
+}
+
+func buildSDKCreateListenerInput(lsSpec elbv2model.ListenerSpec) (*elbv2sdk.CreateListenerInput, error) {
+	ctx := context.Background()
+	lbARN, err := lsSpec.LoadBalancerARN.Resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sdkObj := &elbv2sdk.CreateListenerInput{}
+	sdkObj.LoadBalancerArn = awssdk.String(lbARN)
+	sdkObj.Port = awssdk.Int64(lsSpec.Port)
+	sdkObj.Protocol = awssdk.String(string(lsSpec.Protocol))
+	defaultActions, err := buildSDKActions(lsSpec.DefaultActions)
+	if err != nil {
+		return nil, err
+	}
+	sdkObj.DefaultActions = defaultActions
+	sdkObj.Certificates, _ = buildSDKCertificates(lsSpec.Certificates)
+	sdkObj.SslPolicy = lsSpec.SSLPolicy
+	if len(lsSpec.ALPNPolicy) != 0 {
+		sdkObj.AlpnPolicy = awssdk.StringSlice(lsSpec.ALPNPolicy)
+	}
+	return sdkObj, nil
+}
+
+func buildSDKModifyListenerInput(lsSpec elbv2model.ListenerSpec, desiredDefaultActions []*elbv2sdk.Action, desiredDefaultCerts []*elbv2sdk.Certificate) *elbv2sdk.ModifyListenerInput {
+	sdkObj := &elbv2sdk.ModifyListenerInput{}
+	sdkObj.Port = awssdk.Int64(lsSpec.Port)
+	sdkObj.Protocol = awssdk.String(string(lsSpec.Protocol))
+	sdkObj.DefaultActions = desiredDefaultActions
+	sdkObj.Certificates = desiredDefaultCerts
+	sdkObj.SslPolicy = lsSpec.SSLPolicy
+	if len(lsSpec.ALPNPolicy) != 0 {
+		sdkObj.AlpnPolicy = awssdk.StringSlice(lsSpec.ALPNPolicy)
+	}
+	return sdkObj
+}
+
+// buildSDKCertificates builds the certificate list for listener.
+// returns the default certificates and extra certificates.
+func buildSDKCertificates(modelCerts []elbv2model.Certificate) ([]*elbv2sdk.Certificate, []*elbv2sdk.Certificate) {
+	if len(modelCerts) == 0 {
+		return nil, nil
+	}
+
+	var defaultSDKCerts []*elbv2sdk.Certificate
+	var extraSDKCerts []*elbv2sdk.Certificate
+	defaultSDKCerts = append(defaultSDKCerts, buildSDKCertificate(modelCerts[0]))
+	for _, cert := range modelCerts[1:] {
+		extraSDKCerts = append(extraSDKCerts, buildSDKCertificate(cert))
+	}
+	return defaultSDKCerts, extraSDKCerts
+}
+
+func buildSDKCertificate(modelCert elbv2model.Certificate) *elbv2sdk.Certificate {
+	return &elbv2sdk.Certificate{
+		CertificateArn: modelCert.CertificateARN,
+	}
+}
+
+func buildResListenerStatus(sdkLS *elbv2sdk.Listener) elbv2model.ListenerStatus {
+	return elbv2model.ListenerStatus{
+		ListenerARN: awssdk.StringValue(sdkLS.ListenerArn),
+	}
+}

--- a/pkg/deploy/elbv2/listener_manager_test.go
+++ b/pkg/deploy/elbv2/listener_manager_test.go
@@ -1,0 +1,72 @@
+package elbv2
+
+import (
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/stretchr/testify/assert"
+	elbv2model "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/elbv2"
+	"testing"
+)
+
+func Test_isSDKListenerSettingsDrifted(t *testing.T) {
+	type args struct {
+		lsSpec elbv2model.ListenerSpec
+		sdkLS  *elbv2sdk.Listener
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "listener hasn't drifted",
+			args: args{
+				lsSpec: elbv2model.ListenerSpec{
+					Port:     80,
+					Protocol: elbv2model.ProtocolHTTPS,
+					Certificates: []elbv2model.Certificate{
+						{
+							CertificateARN: awssdk.String("cert-arn1"),
+						},
+					},
+					DefaultActions: []elbv2model.Action{
+						{
+							Type: elbv2model.ActionTypeFixedResponse,
+							FixedResponseConfig: &elbv2model.FixedResponseActionConfig{
+								StatusCode: "404",
+							},
+						},
+					},
+					SSLPolicy:  awssdk.String("ELBSecurityPolicy-FS-1-2-Res-2019-08"),
+					ALPNPolicy: []string{"HTTP2Preferred"},
+				},
+				sdkLS: &elbv2sdk.Listener{
+					Port:     awssdk.Int64(80),
+					Protocol: awssdk.String("HTTPS"),
+					Certificates: []*elbv2sdk.Certificate{
+						{
+							CertificateArn: awssdk.String("cert-arn1"),
+							IsDefault:      awssdk.Bool(true),
+						},
+					},
+					DefaultActions: []*elbv2sdk.Action{
+						{
+							Type: awssdk.String("fixed-response"),
+							FixedResponseConfig: &elbv2sdk.FixedResponseActionConfig{
+								StatusCode: awssdk.String("404"),
+							},
+						},
+					},
+					SslPolicy:  awssdk.String("ELBSecurityPolicy-FS-1-2-Res-2019-08"),
+					AlpnPolicy: awssdk.StringSlice([]string{"HTTP2Preferred"}),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSDKListenerSettingsDrifted(tt.args.lsSpec, tt.args.sdkLS)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/deploy/elbv2/listener_synthesizer.go
+++ b/pkg/deploy/elbv2/listener_synthesizer.go
@@ -1,0 +1,146 @@
+package elbv2
+
+import (
+	"context"
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+	elbv2model "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/elbv2"
+)
+
+func NewListenerSynthesizer(elbv2Client services.ELBV2, lsManager ListenerManager, logger logr.Logger, stack core.Stack) *listenerSynthesizer {
+	return &listenerSynthesizer{
+		elbv2Client: elbv2Client,
+		lsManager:   lsManager,
+		logger:      logger,
+		stack:       stack,
+	}
+}
+
+type listenerSynthesizer struct {
+	elbv2Client services.ELBV2
+	lsManager   ListenerManager
+	logger      logr.Logger
+
+	stack core.Stack
+}
+
+func (s *listenerSynthesizer) Synthesize(ctx context.Context) error {
+	var resLSs []*elbv2model.Listener
+	s.stack.ListResources(&resLSs)
+	resLSsByLBARN, err := mapResListenerByLoadBalancerARN(resLSs)
+	if err != nil {
+		return err
+	}
+	for lbARN, resLSs := range resLSsByLBARN {
+		if err := s.synthesizeListenersOnLB(ctx, lbARN, resLSs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *listenerSynthesizer) PostSynthesize(ctx context.Context) error {
+	// nothing to do here.
+	return nil
+}
+
+func (s *listenerSynthesizer) synthesizeListenersOnLB(ctx context.Context, lbARN string, resLSs []*elbv2model.Listener) error {
+	sdkLSs, err := s.findSDKListenersOnLB(ctx, lbARN)
+	if err != nil {
+		return err
+	}
+	matchedResAndSDKLSs, unmatchedResLSs, unmatchedSDKLSs := matchResAndSDKListeners(resLSs, sdkLSs)
+	for _, sdkLS := range unmatchedSDKLSs {
+		if err := s.lsManager.Delete(ctx, sdkLS); err != nil {
+			return err
+		}
+	}
+	for _, resLS := range unmatchedResLSs {
+		lsStatus, err := s.lsManager.Create(ctx, resLS)
+		if err != nil {
+			return err
+		}
+		resLS.SetStatus(lsStatus)
+	}
+	for _, resAndSDKLS := range matchedResAndSDKLSs {
+		lsStatus, err := s.lsManager.Update(ctx, resAndSDKLS.resLS, resAndSDKLS.sdkLS)
+		if err != nil {
+			return err
+		}
+		resAndSDKLS.resLS.SetStatus(lsStatus)
+	}
+	return nil
+}
+
+// findSDKListenersOnLB returns the listeners configured on LoadBalancer.
+func (s *listenerSynthesizer) findSDKListenersOnLB(ctx context.Context, lbARN string) ([]*elbv2sdk.Listener, error) {
+	req := &elbv2sdk.DescribeListenersInput{
+		LoadBalancerArn: awssdk.String(lbARN),
+	}
+	return s.elbv2Client.DescribeListenersAsList(ctx, req)
+}
+
+type resAndSDKListenerPair struct {
+	resLS *elbv2model.Listener
+	sdkLS *elbv2sdk.Listener
+}
+
+func matchResAndSDKListeners(resLSs []*elbv2model.Listener, sdkLSs []*elbv2sdk.Listener) ([]resAndSDKListenerPair, []*elbv2model.Listener, []*elbv2sdk.Listener) {
+	var matchedResAndSDKLSs []resAndSDKListenerPair
+	var unmatchedResLSs []*elbv2model.Listener
+	var unmatchedSDKLSs []*elbv2sdk.Listener
+
+	resLSByPort := mapResListenerByPort(resLSs)
+	sdkLSByPort := mapSDKListenerByPort(sdkLSs)
+	resLSPorts := sets.Int64KeySet(resLSByPort)
+	sdkLSPorts := sets.Int64KeySet(sdkLSByPort)
+	for _, port := range resLSPorts.Intersection(sdkLSPorts).List() {
+		resLS := resLSByPort[port]
+		sdkLS := sdkLSByPort[port]
+		matchedResAndSDKLSs = append(matchedResAndSDKLSs, resAndSDKListenerPair{
+			resLS: resLS,
+			sdkLS: sdkLS,
+		})
+	}
+	for _, port := range resLSPorts.Difference(sdkLSPorts).List() {
+		unmatchedResLSs = append(unmatchedResLSs, resLSByPort[port])
+	}
+	for _, port := range sdkLSPorts.Difference(resLSPorts).List() {
+		unmatchedSDKLSs = append(unmatchedSDKLSs, sdkLSByPort[port])
+	}
+	return matchedResAndSDKLSs, unmatchedResLSs, unmatchedSDKLSs
+}
+
+func mapResListenerByPort(resLSs []*elbv2model.Listener) map[int64]*elbv2model.Listener {
+	resLSByPort := make(map[int64]*elbv2model.Listener, len(resLSs))
+	for _, ls := range resLSs {
+		resLSByPort[ls.Spec.Port] = ls
+	}
+	return resLSByPort
+}
+
+func mapSDKListenerByPort(sdkLSs []*elbv2sdk.Listener) map[int64]*elbv2sdk.Listener {
+	sdkLSByPort := make(map[int64]*elbv2sdk.Listener, len(sdkLSs))
+	for _, ls := range sdkLSs {
+		sdkLSByPort[awssdk.Int64Value(ls.Port)] = ls
+	}
+	return sdkLSByPort
+}
+
+func mapResListenerByLoadBalancerARN(resLSs []*elbv2model.Listener) (map[string][]*elbv2model.Listener, error) {
+	resLSsByLBARN := make(map[string][]*elbv2model.Listener, len(resLSs))
+	ctx := context.Background()
+	for _, ls := range resLSs {
+		lbARN, err := ls.Spec.LoadBalancerARN.Resolve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		resLSsByLBARN[lbARN] = append(resLSsByLBARN[lbARN], ls)
+	}
+	return resLSsByLBARN, nil
+}

--- a/pkg/deploy/elbv2/listener_utils.go
+++ b/pkg/deploy/elbv2/listener_utils.go
@@ -1,0 +1,122 @@
+package elbv2
+
+import (
+	"context"
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
+	elbv2model "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/elbv2"
+)
+
+func buildSDKActions(modelActions []elbv2model.Action) ([]*elbv2sdk.Action, error) {
+	var sdkActions []*elbv2sdk.Action
+	if len(modelActions) != 0 {
+		sdkActions = make([]*elbv2sdk.Action, 0, len(modelActions))
+		for index, modelAction := range modelActions {
+			sdkAction, err := buildSDKAction(modelAction)
+			sdkAction.Order = awssdk.Int64(int64(index) + 1)
+			if err != nil {
+				return nil, err
+			}
+			sdkActions = append(sdkActions, sdkAction)
+		}
+	}
+	return sdkActions, nil
+}
+
+func buildSDKAction(modelAction elbv2model.Action) (*elbv2sdk.Action, error) {
+	sdkObj := &elbv2sdk.Action{}
+	sdkObj.Type = awssdk.String(string(modelAction.Type))
+	if modelAction.AuthenticateCognitoConfig != nil {
+		sdkObj.AuthenticateCognitoConfig = buildSDKAuthenticateCognitoActionConfig(*modelAction.AuthenticateCognitoConfig)
+	}
+	if modelAction.AuthenticateOIDCConfig != nil {
+		sdkObj.AuthenticateOidcConfig = buildSDKAuthenticateOidcActionConfig(*modelAction.AuthenticateOIDCConfig)
+	}
+	if modelAction.FixedResponseConfig != nil {
+		sdkObj.FixedResponseConfig = buildSDKFixedResponseActionConfig(*modelAction.FixedResponseConfig)
+	}
+	if modelAction.RedirectConfig != nil {
+		sdkObj.RedirectConfig = buildSDKRedirectActionConfig(*modelAction.RedirectConfig)
+	}
+	if modelAction.ForwardConfig != nil {
+		forwardConfig, err := buildSDKForwardActionConfig(*modelAction.ForwardConfig)
+		if err != nil {
+			return nil, err
+		}
+		sdkObj.ForwardConfig = forwardConfig
+	}
+	return sdkObj, nil
+}
+
+func buildSDKAuthenticateCognitoActionConfig(modelCfg elbv2model.AuthenticateCognitoActionConfig) *elbv2sdk.AuthenticateCognitoActionConfig {
+	return &elbv2sdk.AuthenticateCognitoActionConfig{
+		AuthenticationRequestExtraParams: awssdk.StringMap(modelCfg.AuthenticationRequestExtraParams),
+		OnUnauthenticatedRequest:         (*string)(modelCfg.OnUnauthenticatedRequest),
+		Scope:                            modelCfg.Scope,
+		SessionCookieName:                modelCfg.SessionCookieName,
+		SessionTimeout:                   modelCfg.SessionTimeout,
+		UserPoolArn:                      awssdk.String(modelCfg.UserPoolARN),
+		UserPoolClientId:                 awssdk.String(modelCfg.UserPoolClientID),
+		UserPoolDomain:                   awssdk.String(modelCfg.UserPoolDomain),
+	}
+}
+
+func buildSDKAuthenticateOidcActionConfig(modelCfg elbv2model.AuthenticateOIDCActionConfig) *elbv2sdk.AuthenticateOidcActionConfig {
+	return &elbv2sdk.AuthenticateOidcActionConfig{
+		AuthenticationRequestExtraParams: awssdk.StringMap(modelCfg.AuthenticationRequestExtraParams),
+		OnUnauthenticatedRequest:         (*string)(modelCfg.OnUnauthenticatedRequest),
+		Scope:                            modelCfg.Scope,
+		SessionCookieName:                modelCfg.SessionCookieName,
+		SessionTimeout:                   modelCfg.SessionTimeout,
+		ClientId:                         awssdk.String(modelCfg.ClientID),
+		ClientSecret:                     awssdk.String(modelCfg.ClientSecret),
+		Issuer:                           awssdk.String(modelCfg.Issuer),
+		AuthorizationEndpoint:            awssdk.String(modelCfg.AuthorizationEndpoint),
+		TokenEndpoint:                    awssdk.String(modelCfg.TokenEndpoint),
+		UserInfoEndpoint:                 awssdk.String(modelCfg.UserInfoEndpoint),
+	}
+}
+
+func buildSDKFixedResponseActionConfig(modelCfg elbv2model.FixedResponseActionConfig) *elbv2sdk.FixedResponseActionConfig {
+	return &elbv2sdk.FixedResponseActionConfig{
+		ContentType: modelCfg.ContentType,
+		MessageBody: modelCfg.MessageBody,
+		StatusCode:  awssdk.String(modelCfg.StatusCode),
+	}
+}
+
+func buildSDKRedirectActionConfig(modelCfg elbv2model.RedirectActionConfig) *elbv2sdk.RedirectActionConfig {
+	return &elbv2sdk.RedirectActionConfig{
+		Host:       modelCfg.Host,
+		Path:       modelCfg.Path,
+		Port:       modelCfg.Port,
+		Protocol:   modelCfg.Protocol,
+		Query:      modelCfg.Query,
+		StatusCode: awssdk.String(modelCfg.StatusCode),
+	}
+}
+
+func buildSDKForwardActionConfig(modelCfg elbv2model.ForwardActionConfig) (*elbv2sdk.ForwardActionConfig, error) {
+	ctx := context.Background()
+	sdkObj := &elbv2sdk.ForwardActionConfig{}
+	var tgTuples []*elbv2sdk.TargetGroupTuple
+	for _, tgt := range modelCfg.TargetGroups {
+		tgARN, err := tgt.TargetGroupARN.Resolve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		tgTuples = append(tgTuples, &elbv2sdk.TargetGroupTuple{
+			TargetGroupArn: awssdk.String(tgARN),
+			Weight:         tgt.Weight,
+		})
+	}
+	sdkObj.TargetGroups = tgTuples
+	if modelCfg.TargetGroupStickinessConfig != nil {
+		sdkObj.TargetGroupStickinessConfig = &elbv2sdk.TargetGroupStickinessConfig{
+			DurationSeconds: modelCfg.TargetGroupStickinessConfig.DurationSeconds,
+			Enabled:         modelCfg.TargetGroupStickinessConfig.Enabled,
+		}
+	}
+
+	return sdkObj, nil
+}

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -1,0 +1,71 @@
+package deploy
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/deploy/elbv2"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/deploy/tagging"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+)
+
+// StackDeployer will deploy a resource stack into AWS and K8S.
+type StackDeployer interface {
+	// Deploy a resource stack.
+	Deploy(ctx context.Context, stack core.Stack) error
+}
+
+// NewDefaultStackDeployer constructs new defaultStackDeployer.
+func NewDefaultStackDeployer(elbv2Client services.ELBV2, vpcID string, clusterName string, tagPrefix string, logger logr.Logger) *defaultStackDeployer {
+	taggingProvider := tagging.NewDefaultProvider(tagPrefix, clusterName)
+	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(elbv2Client, logger)
+	return &defaultStackDeployer{
+		elbv2Client:         elbv2Client,
+		taggingProvider:     taggingProvider,
+		elbv2TaggingManager: elbv2TaggingManager,
+		elbv2LBManager:      elbv2.NewDefaultLoadBalancerManager(elbv2Client, taggingProvider, elbv2TaggingManager, logger),
+		elbv2LSManager:      elbv2.NewDefaultListenerManager(elbv2Client, logger),
+		elbv2TGManager:      elbv2.NewDefaultTargetGroupManager(elbv2Client, taggingProvider, elbv2TaggingManager, vpcID, logger),
+		logger:              logger,
+	}
+}
+
+var _ StackDeployer = &defaultStackDeployer{}
+
+// defaultStackDeployer is the default implementation for StackDeployer
+type defaultStackDeployer struct {
+	elbv2Client         services.ELBV2
+	taggingProvider     tagging.Provider
+	elbv2TaggingManager elbv2.TaggingManager
+	elbv2LBManager      elbv2.LoadBalancerManager
+	elbv2LSManager      elbv2.ListenerManager
+	elbv2TGManager      elbv2.TargetGroupManager
+
+	logger logr.Logger
+}
+
+type ResourceSynthesizer interface {
+	Synthesize(ctx context.Context) error
+	PostSynthesize(ctx context.Context) error
+}
+
+// Deploy a resource stack.
+func (d *defaultStackDeployer) Deploy(ctx context.Context, stack core.Stack) error {
+	synthesizers := []ResourceSynthesizer{
+		elbv2.NewTargetGroupSynthesizer(d.elbv2Client, d.taggingProvider, d.elbv2TaggingManager, d.elbv2TGManager, d.logger, stack),
+		elbv2.NewLoadBalancerSynthesizer(d.elbv2Client, d.taggingProvider, d.elbv2TaggingManager, d.elbv2LBManager, d.logger, stack),
+		elbv2.NewListenerSynthesizer(d.elbv2Client, d.elbv2LSManager, d.logger, stack),
+	}
+	for _, synthesizer := range synthesizers {
+		if err := synthesizer.Synthesize(ctx); err != nil {
+			return err
+		}
+	}
+	for i := len(synthesizers) - 1; i >= 0; i-- {
+		if err := synthesizers[i].PostSynthesize(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/equality/elbv2/compare_option_for_actions.go
+++ b/pkg/equality/elbv2/compare_option_for_actions.go
@@ -1,0 +1,54 @@
+package elbv2
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/equality"
+)
+
+func CompareOptionForTargetGroupTuples() cmp.Option {
+	return cmpopts.AcyclicTransformer("normalizeWeights", func(tgt []*elbv2sdk.TargetGroupTuple) []*elbv2sdk.TargetGroupTuple {
+		if len(tgt) != 1 {
+			return tgt
+		}
+		singleTG := tgt[0]
+		return []*elbv2sdk.TargetGroupTuple{
+			{
+				TargetGroupArn: singleTG.TargetGroupArn,
+				Weight:         nil,
+			},
+		}
+	})
+}
+
+func CompareOptionForForwardActionConfig() cmp.Option {
+	return cmp.Options{
+		equality.IgnoreLeftHandUnset(elbv2sdk.ForwardActionConfig{}, "TargetGroupStickinessConfig"),
+		CompareOptionForTargetGroupTuples(),
+	}
+}
+
+// CompareOptionForAction returns the compare option for action.
+func CompareOptionForAction() cmp.Option {
+	return cmp.Options{
+		cmpopts.IgnoreFields(elbv2sdk.Action{}, "Order"),
+		cmpopts.IgnoreFields(elbv2sdk.Action{}, "TargetGroupArn"),
+		CompareOptionForForwardActionConfig(),
+	}
+}
+
+// CompareOptionForActions returns the compare option for action slice.
+func CompareOptionForActions() cmp.Option {
+	return cmp.Options{
+		cmpopts.EquateEmpty(),
+		cmpopts.SortSlices(func(lhs *elbv2sdk.Action, rhs *elbv2sdk.Action) bool {
+			if lhs.Order == nil || rhs.Order == nil {
+				return false
+			}
+			return aws.Int64Value(lhs.Order) < aws.Int64Value(rhs.Order)
+		}),
+		CompareOptionForAction(),
+	}
+}

--- a/pkg/equality/elbv2/compare_option_for_actions_test.go
+++ b/pkg/equality/elbv2/compare_option_for_actions_test.go
@@ -1,0 +1,381 @@
+package elbv2
+
+import (
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCompareOptionForAction(t *testing.T) {
+	type args struct {
+		lhs elbv2sdk.Action
+		rhs elbv2sdk.Action
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "two actions equals exactly",
+			args: args{
+				lhs: elbv2sdk.Action{
+					Type: awssdk.String("forward"),
+					ForwardConfig: &elbv2sdk.ForwardActionConfig{
+						TargetGroups: []*elbv2sdk.TargetGroupTuple{
+							{
+								TargetGroupArn: awssdk.String("tg-a"),
+							},
+						},
+					},
+				},
+				rhs: elbv2sdk.Action{
+					Type: awssdk.String("forward"),
+					ForwardConfig: &elbv2sdk.ForwardActionConfig{
+						TargetGroups: []*elbv2sdk.TargetGroupTuple{
+							{
+								TargetGroupArn: awssdk.String("tg-a"),
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "two actions are not equal if some fields un-equal",
+			args: args{
+				lhs: elbv2sdk.Action{
+					Type: awssdk.String("forward"),
+					ForwardConfig: &elbv2sdk.ForwardActionConfig{
+						TargetGroups: []*elbv2sdk.TargetGroupTuple{
+							{
+								TargetGroupArn: awssdk.String("tg-a"),
+							},
+						},
+					},
+				},
+				rhs: elbv2sdk.Action{
+					Type: awssdk.String("forward"),
+					ForwardConfig: &elbv2sdk.ForwardActionConfig{
+						TargetGroups: []*elbv2sdk.TargetGroupTuple{
+							{
+								TargetGroupArn: awssdk.String("tg-b"),
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "two actions are equal irrelevant of their order existence",
+			args: args{
+				lhs: elbv2sdk.Action{
+					Type: awssdk.String("forward"),
+					ForwardConfig: &elbv2sdk.ForwardActionConfig{
+						TargetGroups: []*elbv2sdk.TargetGroupTuple{
+							{
+								TargetGroupArn: awssdk.String("tg-a"),
+							},
+						},
+					},
+				},
+				rhs: elbv2sdk.Action{
+					Type: awssdk.String("forward"),
+					ForwardConfig: &elbv2sdk.ForwardActionConfig{
+						TargetGroups: []*elbv2sdk.TargetGroupTuple{
+							{
+								TargetGroupArn: awssdk.String("tg-a"),
+							},
+						},
+					},
+					Order: awssdk.Int64(1),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "two actions are equal irrelevant of their order value",
+			args: args{
+				lhs: elbv2sdk.Action{
+					Type: awssdk.String("forward"),
+					ForwardConfig: &elbv2sdk.ForwardActionConfig{
+						TargetGroups: []*elbv2sdk.TargetGroupTuple{
+							{
+								TargetGroupArn: awssdk.String("tg-a"),
+							},
+						},
+					},
+					Order: awssdk.Int64(1),
+				},
+				rhs: elbv2sdk.Action{
+					Type: awssdk.String("forward"),
+					ForwardConfig: &elbv2sdk.ForwardActionConfig{
+						TargetGroups: []*elbv2sdk.TargetGroupTuple{
+							{
+								TargetGroupArn: awssdk.String("tg-a"),
+							},
+						},
+					},
+					Order: awssdk.Int64(2),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "two action are equal irrelevant of their targetGroupARN existence",
+			args: args{
+				lhs: elbv2sdk.Action{
+					Type: awssdk.String("forward"),
+					ForwardConfig: &elbv2sdk.ForwardActionConfig{
+						TargetGroups: []*elbv2sdk.TargetGroupTuple{
+							{
+								TargetGroupArn: awssdk.String("tg-a"),
+							},
+						},
+					},
+				},
+				rhs: elbv2sdk.Action{
+					Type: awssdk.String("forward"),
+					ForwardConfig: &elbv2sdk.ForwardActionConfig{
+						TargetGroups: []*elbv2sdk.TargetGroupTuple{
+							{
+								TargetGroupArn: awssdk.String("tg-a"),
+							},
+						},
+					},
+					TargetGroupArn: awssdk.String("tg-a"),
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cmp.Equal(tt.args.lhs, tt.args.rhs, CompareOptionForAction())
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCompareOptionForActions(t *testing.T) {
+	type args struct {
+		lhs []*elbv2sdk.Action
+		rhs []*elbv2sdk.Action
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "two actions slice equals exactly",
+			args: args{
+				lhs: []*elbv2sdk.Action{
+					{
+						Type: awssdk.String("authenticate-cognito"),
+						AuthenticateCognitoConfig: &elbv2sdk.AuthenticateCognitoActionConfig{
+							UserPoolArn:      awssdk.String("pool-arn-a"),
+							UserPoolClientId: awssdk.String("pool-client-id-a"),
+							UserPoolDomain:   awssdk.String("pool-domain-a"),
+						},
+						Order: awssdk.Int64(1),
+					},
+					{
+						Type: awssdk.String("forward"),
+						ForwardConfig: &elbv2sdk.ForwardActionConfig{
+							TargetGroups: []*elbv2sdk.TargetGroupTuple{
+								{
+									TargetGroupArn: awssdk.String("tg-a"),
+								},
+							},
+						},
+						Order: awssdk.Int64(2),
+					},
+				},
+				rhs: []*elbv2sdk.Action{
+					{
+						Type: awssdk.String("authenticate-cognito"),
+						AuthenticateCognitoConfig: &elbv2sdk.AuthenticateCognitoActionConfig{
+							UserPoolArn:      awssdk.String("pool-arn-a"),
+							UserPoolClientId: awssdk.String("pool-client-id-a"),
+							UserPoolDomain:   awssdk.String("pool-domain-a"),
+						},
+						Order: awssdk.Int64(1),
+					},
+					{
+						Type: awssdk.String("forward"),
+						ForwardConfig: &elbv2sdk.ForwardActionConfig{
+							TargetGroups: []*elbv2sdk.TargetGroupTuple{
+								{
+									TargetGroupArn: awssdk.String("tg-a"),
+								},
+							},
+						},
+						Order: awssdk.Int64(2),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "two actions slice are not equal if there actions are not equal",
+			args: args{
+				lhs: []*elbv2sdk.Action{
+					{
+						Type: awssdk.String("authenticate-cognito"),
+						AuthenticateCognitoConfig: &elbv2sdk.AuthenticateCognitoActionConfig{
+							UserPoolArn:      awssdk.String("pool-arn-a"),
+							UserPoolClientId: awssdk.String("pool-client-id-a"),
+							UserPoolDomain:   awssdk.String("pool-domain-a"),
+						},
+						Order: awssdk.Int64(1),
+					},
+					{
+						Type: awssdk.String("forward"),
+						ForwardConfig: &elbv2sdk.ForwardActionConfig{
+							TargetGroups: []*elbv2sdk.TargetGroupTuple{
+								{
+									TargetGroupArn: awssdk.String("tg-a"),
+								},
+							},
+						},
+						Order: awssdk.Int64(2),
+					},
+				},
+				rhs: []*elbv2sdk.Action{
+					{
+						Type: awssdk.String("authenticate-cognito"),
+						AuthenticateCognitoConfig: &elbv2sdk.AuthenticateCognitoActionConfig{
+							UserPoolArn:      awssdk.String("pool-arn-b"),
+							UserPoolClientId: awssdk.String("pool-client-id-b"),
+							UserPoolDomain:   awssdk.String("pool-domain-b"),
+						},
+						Order: awssdk.Int64(1),
+					},
+					{
+						Type: awssdk.String("forward"),
+						ForwardConfig: &elbv2sdk.ForwardActionConfig{
+							TargetGroups: []*elbv2sdk.TargetGroupTuple{
+								{
+									TargetGroupArn: awssdk.String("tg-a"),
+								},
+							},
+						},
+						Order: awssdk.Int64(2),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "two actions slice equals when they are equal after sorted by order",
+			args: args{
+				lhs: []*elbv2sdk.Action{
+					{
+						Type: awssdk.String("authenticate-cognito"),
+						AuthenticateCognitoConfig: &elbv2sdk.AuthenticateCognitoActionConfig{
+							UserPoolArn:      awssdk.String("pool-arn-a"),
+							UserPoolClientId: awssdk.String("pool-client-id-a"),
+							UserPoolDomain:   awssdk.String("pool-domain-a"),
+						},
+						Order: awssdk.Int64(1),
+					},
+					{
+						Type: awssdk.String("forward"),
+						ForwardConfig: &elbv2sdk.ForwardActionConfig{
+							TargetGroups: []*elbv2sdk.TargetGroupTuple{
+								{
+									TargetGroupArn: awssdk.String("tg-a"),
+								},
+							},
+						},
+						Order: awssdk.Int64(2),
+					},
+				},
+				rhs: []*elbv2sdk.Action{
+					{
+						Type: awssdk.String("forward"),
+						ForwardConfig: &elbv2sdk.ForwardActionConfig{
+							TargetGroups: []*elbv2sdk.TargetGroupTuple{
+								{
+									TargetGroupArn: awssdk.String("tg-a"),
+								},
+							},
+						},
+						Order: awssdk.Int64(4),
+					},
+					{
+						Type: awssdk.String("authenticate-cognito"),
+						AuthenticateCognitoConfig: &elbv2sdk.AuthenticateCognitoActionConfig{
+							UserPoolArn:      awssdk.String("pool-arn-a"),
+							UserPoolClientId: awssdk.String("pool-client-id-a"),
+							UserPoolDomain:   awssdk.String("pool-domain-a"),
+						},
+						Order: awssdk.Int64(3),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "two actions slice are not equals when they are not equal after sorted by order",
+			args: args{
+				lhs: []*elbv2sdk.Action{
+					{
+						Type: awssdk.String("authenticate-cognito"),
+						AuthenticateCognitoConfig: &elbv2sdk.AuthenticateCognitoActionConfig{
+							UserPoolArn:      awssdk.String("pool-arn-a"),
+							UserPoolClientId: awssdk.String("pool-client-id-a"),
+							UserPoolDomain:   awssdk.String("pool-domain-a"),
+						},
+						Order: awssdk.Int64(1),
+					},
+					{
+						Type: awssdk.String("forward"),
+						ForwardConfig: &elbv2sdk.ForwardActionConfig{
+							TargetGroups: []*elbv2sdk.TargetGroupTuple{
+								{
+									TargetGroupArn: awssdk.String("tg-a"),
+								},
+							},
+						},
+						Order: awssdk.Int64(2),
+					},
+				},
+				rhs: []*elbv2sdk.Action{
+					{
+						Type: awssdk.String("forward"),
+						ForwardConfig: &elbv2sdk.ForwardActionConfig{
+							TargetGroups: []*elbv2sdk.TargetGroupTuple{
+								{
+									TargetGroupArn: awssdk.String("tg-a"),
+								},
+							},
+						},
+						Order: awssdk.Int64(3),
+					},
+					{
+						Type: awssdk.String("authenticate-cognito"),
+						AuthenticateCognitoConfig: &elbv2sdk.AuthenticateCognitoActionConfig{
+							UserPoolArn:      awssdk.String("pool-arn-a"),
+							UserPoolClientId: awssdk.String("pool-client-id-a"),
+							UserPoolDomain:   awssdk.String("pool-domain-a"),
+						},
+						Order: awssdk.Int64(4),
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cmp.Equal(tt.args.lhs, tt.args.rhs, CompareOptionForActions())
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/equality/elbv2/compare_option_for_certificates.go
+++ b/pkg/equality/elbv2/compare_option_for_certificates.go
@@ -1,0 +1,22 @@
+package elbv2
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func CompareOptionForCertificate() cmp.Option {
+	return cmpopts.IgnoreFields(elbv2sdk.Certificate{}, "IsDefault")
+}
+
+func CompareOptionForCertificates() cmp.Options {
+	return cmp.Options{
+		cmpopts.EquateEmpty(),
+		cmpopts.SortSlices(func(lhs *elbv2sdk.Certificate, rhs *elbv2sdk.Certificate) bool {
+			return aws.StringValue(lhs.CertificateArn) < aws.StringValue(rhs.CertificateArn)
+		}),
+		CompareOptionForCertificate(),
+	}
+}

--- a/pkg/equality/elbv2/compare_option_for_certificates_test.go
+++ b/pkg/equality/elbv2/compare_option_for_certificates_test.go
@@ -1,0 +1,146 @@
+package elbv2
+
+import (
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCompareOptionForCertificate(t *testing.T) {
+	type args struct {
+		lhs elbv2sdk.Certificate
+		rhs elbv2sdk.Certificate
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "two certificate equals exactly",
+			args: args{
+				lhs: elbv2sdk.Certificate{
+					CertificateArn: awssdk.String("cert-A"),
+				},
+				rhs: elbv2sdk.Certificate{
+					CertificateArn: awssdk.String("cert-A"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "two certificate are not equals if certARN mismatch",
+			args: args{
+				lhs: elbv2sdk.Certificate{
+					CertificateArn: awssdk.String("cert-A"),
+				},
+				rhs: elbv2sdk.Certificate{
+					CertificateArn: awssdk.String("cert-B"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "two certificate equals exactly irrelevant of their isDefault",
+			args: args{
+				lhs: elbv2sdk.Certificate{
+					CertificateArn: awssdk.String("cert-A"),
+				},
+				rhs: elbv2sdk.Certificate{
+					CertificateArn: awssdk.String("cert-A"),
+					IsDefault:      awssdk.Bool(true),
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cmp.Equal(tt.args.lhs, tt.args.rhs, CompareOptionForCertificate())
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCompareOptionForCertificates(t *testing.T) {
+	type args struct {
+		lhs []*elbv2sdk.Certificate
+		rhs []*elbv2sdk.Certificate
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "two certificates slice are equal exactly",
+			args: args{
+				lhs: []*elbv2sdk.Certificate{
+					{
+						CertificateArn: awssdk.String("cert-A"),
+					},
+				},
+				rhs: []*elbv2sdk.Certificate{
+					{
+						CertificateArn: awssdk.String("cert-A"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "two certificates slice are not equal if certARN mismatches",
+			args: args{
+				lhs: []*elbv2sdk.Certificate{
+					{
+						CertificateArn: awssdk.String("cert-A"),
+					},
+				},
+				rhs: []*elbv2sdk.Certificate{
+					{
+						CertificateArn: awssdk.String("cert-B"),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "two certificates slice are equal if they are equal after sorted",
+			args: args{
+				lhs: []*elbv2sdk.Certificate{
+					{
+						CertificateArn: awssdk.String("cert-A"),
+					},
+					{
+						CertificateArn: awssdk.String("cert-B"),
+					},
+				},
+				rhs: []*elbv2sdk.Certificate{
+					{
+						CertificateArn: awssdk.String("cert-B"),
+					},
+					{
+						CertificateArn: awssdk.String("cert-A"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "two certificates slice are equal for nil and empty slice",
+			args: args{
+				lhs: []*elbv2sdk.Certificate{},
+				rhs: nil,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cmp.Equal(tt.args.lhs, tt.args.rhs, CompareOptionForCertificates())
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/equality/ingore_left_hand_unset.go
+++ b/pkg/equality/ingore_left_hand_unset.go
@@ -1,0 +1,32 @@
+package equality
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"reflect"
+)
+
+// IgnoreLeftHandUnset is an option that ignores struct fields that are unset on the left hand side of a comparison.
+// Note:
+//	 1. for map and slices, only nil value is considered to be unset, non-nil but empty is not considered as unset.
+//   2. for struct pointers, nil value is considered to be unset
+func IgnoreLeftHandUnset(typ interface{}, fields ...string) cmp.Option {
+	t := reflect.TypeOf(typ)
+	fieldsSet := sets.NewString(fields...)
+	return cmp.FilterPath(func(path cmp.Path) bool {
+		if len(path) < 2 || path.Index(-2).Type() != t {
+			return false
+		}
+		ps, ok := path.Last().(cmp.StructField)
+		if !ok || !fieldsSet.Has(ps.Name()) {
+			return false
+		}
+
+		v1, _ := ps.Values()
+		switch v1.Kind() {
+		case reflect.Slice, reflect.Map, reflect.Ptr:
+			return v1.IsNil()
+		}
+		return false
+	}, cmp.Ignore())
+}

--- a/pkg/equality/ingore_left_hand_unset_test.go
+++ b/pkg/equality/ingore_left_hand_unset_test.go
@@ -1,0 +1,231 @@
+package equality
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type NestedStruct struct {
+	StrField string
+}
+
+type TestStruct struct {
+	StrField       string
+	SliceField     []string
+	MapField       map[string]string
+	StructField    NestedStruct
+	StructPtrField *NestedStruct
+}
+
+func TestIgnoreLeftHandUnset(t *testing.T) {
+	tests := []struct {
+		name       string
+		argLeft    TestStruct
+		argRight   TestStruct
+		fields     []string
+		wantEquals bool
+	}{
+		{
+			name: "when StrField equals",
+			argLeft: TestStruct{
+				StrField: "a",
+			},
+			argRight: TestStruct{
+				StrField: "a",
+			},
+			fields:     []string{"StrField"},
+			wantEquals: true,
+		},
+		{
+			name: "when StrField differs",
+			argLeft: TestStruct{
+				StrField: "a",
+			},
+			argRight: TestStruct{
+				StrField: "b",
+			},
+			fields:     []string{"StrField"},
+			wantEquals: false,
+		},
+		{
+			name: "when SliceField equals",
+			argLeft: TestStruct{
+				SliceField: []string{"a", "b"},
+			},
+			argRight: TestStruct{
+				SliceField: []string{"a", "b"},
+			},
+			fields:     []string{"SliceField"},
+			wantEquals: true,
+		},
+		{
+			name: "when SliceField differs",
+			argLeft: TestStruct{
+				SliceField: []string{"a", "b"},
+			},
+			argRight: TestStruct{
+				SliceField: []string{"b", "a"},
+			},
+			fields:     []string{"SliceField"},
+			wantEquals: false,
+		},
+		{
+			name: "when left hand arg have nil SliceField",
+			argLeft: TestStruct{
+				SliceField: nil,
+			},
+			argRight: TestStruct{
+				SliceField: []string{"b", "a"},
+			},
+			fields:     []string{"SliceField"},
+			wantEquals: true,
+		},
+		{
+			name: "when left hand arg have non-nil but empty SliceField",
+			argLeft: TestStruct{
+				SliceField: []string{},
+			},
+			argRight: TestStruct{
+				SliceField: []string{"b", "a"},
+			},
+			fields:     []string{"SliceField"},
+			wantEquals: false,
+		},
+		{
+			name: "when MapField equals",
+			argLeft: TestStruct{
+				MapField: map[string]string{"k": "v"},
+			},
+			argRight: TestStruct{
+				MapField: map[string]string{"k": "v"},
+			},
+			fields:     []string{"MapField"},
+			wantEquals: true,
+		},
+		{
+			name: "when MapField differs by value",
+			argLeft: TestStruct{
+				MapField: map[string]string{"k": "v1"},
+			},
+			argRight: TestStruct{
+				MapField: map[string]string{"k": "v2"},
+			},
+			fields:     []string{"MapField"},
+			wantEquals: false,
+		},
+		{
+			name: "when MapField differs by key",
+			argLeft: TestStruct{
+				MapField: map[string]string{"k1": "v"},
+			},
+			argRight: TestStruct{
+				MapField: map[string]string{"k2": "v"},
+			},
+			fields:     []string{"MapField"},
+			wantEquals: false,
+		},
+		{
+			name: "when left hand arg have nil MapField",
+			argLeft: TestStruct{
+				MapField: nil,
+			},
+			argRight: TestStruct{
+				MapField: map[string]string{"k": "v"},
+			},
+			fields:     []string{"MapField"},
+			wantEquals: true,
+		},
+		{
+			name: "when left hand arg have non-nil but empty MapField",
+			argLeft: TestStruct{
+				MapField: map[string]string{},
+			},
+			argRight: TestStruct{
+				MapField: map[string]string{"k": "v"},
+			},
+			fields:     []string{"MapField"},
+			wantEquals: false,
+		},
+		{
+			name: "when StructField equals",
+			argLeft: TestStruct{
+				StructField: NestedStruct{
+					StrField: "a",
+				},
+			},
+			argRight: TestStruct{
+				StructField: NestedStruct{
+					StrField: "a",
+				},
+			},
+			fields:     []string{"StructField"},
+			wantEquals: true,
+		},
+		{
+			name: "when StructField differs",
+			argLeft: TestStruct{
+				StructField: NestedStruct{
+					StrField: "a",
+				},
+			},
+			argRight: TestStruct{
+				StructField: NestedStruct{
+					StrField: "b",
+				},
+			},
+			fields:     []string{"StructField"},
+			wantEquals: false,
+		},
+		{
+			name: "when StructPtrField equals",
+			argLeft: TestStruct{
+				StructPtrField: &NestedStruct{
+					StrField: "a",
+				},
+			},
+			argRight: TestStruct{
+				StructPtrField: &NestedStruct{
+					StrField: "a",
+				},
+			},
+			fields:     []string{"StructPtrField"},
+			wantEquals: true,
+		},
+		{
+			name: "when StructPtrField differs",
+			argLeft: TestStruct{
+				StructPtrField: &NestedStruct{
+					StrField: "a",
+				},
+			},
+			argRight: TestStruct{
+				StructPtrField: &NestedStruct{
+					StrField: "b",
+				},
+			},
+			fields:     []string{"StructPtrField"},
+			wantEquals: false,
+		},
+		{
+			name: "when left hand arg have nil StructPtrField",
+			argLeft: TestStruct{
+				StructPtrField: nil,
+			},
+			argRight: TestStruct{
+				StructPtrField: &NestedStruct{
+					StrField: "b",
+				},
+			},
+			fields:     []string{"StructPtrField"},
+			wantEquals: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := IgnoreLeftHandUnset(TestStruct{}, tt.fields...)
+			gotEquals := cmp.Equal(tt.argLeft, tt.argRight, opts)
+			assert.Equal(t, tt.wantEquals, gotEquals)
+		})
+	}
+}


### PR DESCRIPTION
add ListenerSynthesizer and deployer.

sample usage:
```
	internetFacingScheme := elbv2model.LoadBalancerSchemeInternal
	dualStack := elbv2model.IPAddressTypeIPV4
	stack := core.NewDefaultStack("default/m00nf1sh")
	lb := elbv2model.NewLoadBalancer(stack, "LoadBalancer", elbv2model.LoadBalancerSpec{
		Name:           "my-lb-name",
		Type:           elbv2model.LoadBalancerTypeApplication,
		Scheme:         &internetFacingScheme,
		IPAddressType:  &dualStack,
		SecurityGroups: []core.StringToken{core.LiteralStringToken("sg-0ca25fcb0bc093f68")},
		SubnetMappings: []elbv2model.SubnetMapping{
			{
				SubnetID: "subnet-04b92c6c476990a92",
			},
			{
				SubnetID: "subnet-086207056122ab917",
			},
		},
		Tags: map[string]string{
			"Stage":       "Prod",
			"Environment": "not OK",
		},
		LoadBalancerAttributes: []elbv2model.LoadBalancerAttribute{
			{
				Key:   "access_logs.s3.enabled",
				Value: "false",
			},
		},
	})
	tg1 := elbv2model.NewTargetGroup(stack, "tg-1", elbv2model.TargetGroupSpec{
		Name:       "my-tg",
		TargetType: elbv2model.TargetTypeIP,
		Port:       1,
		Protocol:   elbv2model.ProtocolHTTP,
		HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
			Port:                    nil,
			Protocol:                nil,
			Path:                    nil,
			Matcher:                 nil,
			IntervalSeconds:         nil,
			TimeoutSeconds:          nil,
			HealthyThresholdCount:   nil,
			UnhealthyThresholdCount: nil,
		},
		TargetGroupAttributes: nil,
		Tags: map[string]string{
			"Stage":       "Prod",
			"Environment": "not OK",
		},
	})
	tg2 := elbv2model.NewTargetGroup(stack, "tg-2", elbv2model.TargetGroupSpec{
		Name:       "my-tg-2",
		TargetType: elbv2model.TargetTypeIP,
		Port:       1,
		Protocol:   elbv2model.ProtocolHTTP,
		HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
			Port:                    nil,
			Protocol:                nil,
			Path:                    nil,
			Matcher:                 nil,
			IntervalSeconds:         nil,
			TimeoutSeconds:          nil,
			HealthyThresholdCount:   nil,
			UnhealthyThresholdCount: nil,
		},
		TargetGroupAttributes: nil,
		Tags: map[string]string{
			"Stage":       "Prod",
			"Environment": "OK123",
		},
	})
	_ = elbv2model.NewListener(stack, "80", elbv2model.ListenerSpec{
		LoadBalancerARN: lb.LoadBalancerARN(),
		Port:            110,
		Protocol:        elbv2model.ProtocolHTTP,
		DefaultActions: []elbv2model.Action{
			{
				Type: elbv2model.ActionTypeForward,
				ForwardConfig: &elbv2model.ForwardActionConfig{
					TargetGroups: []elbv2model.TargetGroupTuple{
						{
							TargetGroupARN: tg1.TargetGroupARN(),
						},
					},
				},
			},
		},
	})

	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
	os.Setenv("AWS_PROFILE", "m00nf1sh")
	sess := session.Must(session.NewSession(aws.NewConfig().WithRegion("us-west-2")))

	marshaller := deploy.NewDefaultStackMarshaller()
	elbv2client := services.NewELBV2(sess)
	deployer := deploy.NewDefaultStackDeployer(elbv2client, "vpc-03ee59a894395222b", "m00nf1sh-dev", "ingress.k8s.aws", ctrl.Log)

	ctx := context.Background()
	payload, err := marshaller.Marshal(stack)
	fmt.Println(payload, err)
	fmt.Println(deployer.Deploy(ctx, stack))
	fmt.Println(lb.DNSName().Resolve(ctx))
	fmt.Println(tg1.TargetGroupARN().Resolve(ctx))
	fmt.Println(tg2.TargetGroupARN().Resolve(ctx))
```