### PR TITLE
Add cmdline flags aws-vpc-id and cluster-name

### DIFF
--- a/pkg/aws/cloud_config.go
+++ b/pkg/aws/cloud_config.go
@@ -8,6 +8,7 @@ import (
 const (
 	flagAWSRegion      = "aws-region"
 	flagAWSAPIThrottle = "aws-api-throttle"
+	flagAWSVpcID       = "aws-vpc-id"
 )
 
 type CloudConfig struct {
@@ -16,9 +17,13 @@ type CloudConfig struct {
 
 	// Throttle settings for aws APIs
 	ThrottleConfig *throttle.ServiceOperationsThrottleConfig
+
+	// VPC ID of the Kubernetes cluster
+	VpcID string
 }
 
 func (cfg *CloudConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&cfg.Region, flagAWSRegion, "", "AWS Region for the kubernetes cluster")
 	fs.Var(cfg.ThrottleConfig, flagAWSAPIThrottle, "throttle settings for AWS APIs, format: serviceID1:operationRegex1=rate:burst,serviceID2:operationRegex2=rate:burst")
+	fs.StringVar(&cfg.VpcID, flagAWSVpcID, "", "AWS VPC ID for the Kubernetes cluster")
 }

--- a/pkg/aws/services/ec2_metadata.go
+++ b/pkg/aws/services/ec2_metadata.go
@@ -1,12 +1,14 @@
 package services
 
 import (
+	"fmt"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 type EC2Metadata interface {
 	Region() (string, error)
+	VpcID() (string, error)
 }
 
 // NewEC2Metadata constructs new EC2Metadata implementation.
@@ -18,4 +20,16 @@ func NewEC2Metadata(session *session.Session) EC2Metadata {
 
 type defaultEC2Metadata struct {
 	*ec2metadata.EC2Metadata
+}
+
+func (c *defaultEC2Metadata) VpcID() (string, error) {
+	mac, err := c.GetMetadata("mac")
+	if err != nil {
+		return "", err
+	}
+	vpcID, err := c.GetMetadata(fmt.Sprintf("network/interfaces/macs/%s/vpc-id", mac))
+	if err != nil {
+		return "", err
+	}
+	return vpcID, nil
 }


### PR DESCRIPTION
Add support for additional cmdline flags aws-vpc-id and k8s-cluster-name. Discover vpc-id from metadata.