### PR TITLE
add two equality:FilterField and equality:IgnoreStringSliceOrder

### DIFF
--- a/pkg/equality/filter_field.go
+++ b/pkg/equality/filter_field.go
@@ -1,0 +1,21 @@
+package equality
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"reflect"
+)
+
+// FilterField return a new option that only apply specified option to specific struct field.
+func FilterField(typ interface{}, field string, opt cmp.Option) cmp.Option {
+	t := reflect.TypeOf(typ)
+	return cmp.FilterPath(func(path cmp.Path) bool {
+		if len(path) < 2 || path.Index(-2).Type() != t {
+			return false
+		}
+		ps, ok := path.Last().(cmp.StructField)
+		if !ok || field != ps.Name() {
+			return false
+		}
+		return true
+	}, opt)
+}

--- a/pkg/equality/filter_field_test.go
+++ b/pkg/equality/filter_field_test.go
@@ -1,0 +1,129 @@
+package equality
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFilterField(t *testing.T) {
+	type testStruct struct {
+		SliceField0 []string
+		SliceField1 []string
+	}
+	type args struct {
+		field string
+		opt   cmp.Option
+	}
+	tests := []struct {
+		name       string
+		args       args
+		argLeft    testStruct
+		argRight   testStruct
+		wantEquals bool
+	}{
+		{
+			name: "both sliceField equals",
+			args: args{
+				field: "SliceField0",
+				opt:   IgnoreStringSliceOrder(),
+			},
+			argLeft: testStruct{
+				SliceField0: []string{"A", "B", "C"},
+				SliceField1: []string{"1", "2", "3"},
+			},
+			argRight: testStruct{
+				SliceField0: []string{"A", "B", "C"},
+				SliceField1: []string{"1", "2", "3"},
+			},
+			wantEquals: true,
+		},
+		{
+			name: "SliceField0 compares without order - equals",
+			args: args{
+				field: "SliceField0",
+				opt:   IgnoreStringSliceOrder(),
+			},
+			argLeft: testStruct{
+				SliceField0: []string{"A", "B", "C"},
+				SliceField1: []string{"1", "2", "3"},
+			},
+			argRight: testStruct{
+				SliceField0: []string{"C", "B", "A"},
+				SliceField1: []string{"1", "2", "3"},
+			},
+			wantEquals: true,
+		},
+		{
+			name: "SliceField0 compares without order - not equals",
+			args: args{
+				field: "SliceField0",
+				opt:   IgnoreStringSliceOrder(),
+			},
+			argLeft: testStruct{
+				SliceField0: []string{"A", "B", "C"},
+				SliceField1: []string{"1", "2", "3"},
+			},
+			argRight: testStruct{
+				SliceField0: []string{"A", "B", "D"},
+				SliceField1: []string{"1", "2", "3"},
+			},
+			wantEquals: false,
+		},
+		{
+			name: "SliceField0 compares without order - slice1 not equals",
+			args: args{
+				field: "SliceField0",
+				opt:   IgnoreStringSliceOrder(),
+			},
+			argLeft: testStruct{
+				SliceField0: []string{"A", "B", "C"},
+				SliceField1: []string{"1", "2", "3"},
+			},
+			argRight: testStruct{
+				SliceField0: []string{"A", "B", "C"},
+				SliceField1: []string{"3", "2", "1"},
+			},
+			wantEquals: false,
+		},
+		{
+			name: "SliceField1 compares without order - equals",
+			args: args{
+				field: "SliceField1",
+				opt:   IgnoreStringSliceOrder(),
+			},
+			argLeft: testStruct{
+				SliceField0: []string{"A", "B", "C"},
+				SliceField1: []string{"1", "2", "3"},
+			},
+			argRight: testStruct{
+				SliceField0: []string{"A", "B", "C"},
+				SliceField1: []string{"3", "2", "1"},
+			},
+			wantEquals: true,
+		},
+		{
+			name: "SliceField1 compares without order - not equals",
+			args: args{
+				field: "SliceField1",
+				opt:   IgnoreStringSliceOrder(),
+			},
+			argLeft: testStruct{
+				SliceField0: []string{"A", "B", "C"},
+				SliceField1: []string{"1", "2", "3"},
+			},
+			argRight: testStruct{
+				SliceField0: []string{"A", "B", "C"},
+				SliceField1: []string{"1", "2", "4"},
+			},
+			wantEquals: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := FilterField(testStruct{}, tt.args.field, tt.args.opt)
+			gotEquals := cmp.Equal(tt.argLeft, tt.argRight, opts)
+			assert.Equal(t, tt.wantEquals, gotEquals)
+		})
+	}
+}

--- a/pkg/equality/ignore_string_slice_order.go
+++ b/pkg/equality/ignore_string_slice_order.go
@@ -1,0 +1,13 @@
+package equality
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// IgnoreStringSliceOrder is option that compare string slices without order.
+func IgnoreStringSliceOrder() cmp.Option {
+	return cmpopts.SortSlices(func(lhs string, rhs string) bool {
+		return lhs < rhs
+	})
+}

--- a/pkg/equality/ignore_string_slice_order_test.go
+++ b/pkg/equality/ignore_string_slice_order_test.go
@@ -1,0 +1,58 @@
+package equality
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIgnoreStringSliceOrder(t *testing.T) {
+	type testStruct struct {
+		SliceField []string
+	}
+
+	tests := []struct {
+		name       string
+		argLeft    testStruct
+		argRight   testStruct
+		wantEquals bool
+	}{
+		{
+			name: "two string slice equals",
+			argLeft: testStruct{
+				SliceField: []string{"A", "B", "C"},
+			},
+			argRight: testStruct{
+				SliceField: []string{"A", "B", "C"},
+			},
+			wantEquals: true,
+		},
+		{
+			name: "two string slice equals without order",
+			argLeft: testStruct{
+				SliceField: []string{"A", "B", "C"},
+			},
+			argRight: testStruct{
+				SliceField: []string{"C", "B", "A"},
+			},
+			wantEquals: true,
+		},
+		{
+			name: "two string slice not equals",
+			argLeft: testStruct{
+				SliceField: []string{"A", "B", "C"},
+			},
+			argRight: testStruct{
+				SliceField: []string{"A", "B", "D"},
+			},
+			wantEquals: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := IgnoreStringSliceOrder()
+			gotEquals := cmp.Equal(tt.argLeft, tt.argRight, opts)
+			assert.Equal(t, tt.wantEquals, gotEquals)
+		})
+	}
+}


### PR DESCRIPTION
add two equality function:
1. `equality:FilterField` applies specific cmp option to certain struct field only.
2. `equality:IgnoreStringSliceOrder` ignores order for comparing `[]string`
