### PR TITLE
refactor ingress model builder

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -88,13 +88,13 @@ func (r *GroupReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if err := r.stackDeployer.Deploy(ctx, stack); err != nil {
 		return ctrl.Result{}, err
 	}
+	r.log.Info("successfully deployed model")
 
 	if len(ingGroup.Members) > 0 {
 		lbDNS, err := lb.DNSName().Resolve(ctx)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		r.log.Info("successfully deployed model", "LB", lbDNS)
 		if err := r.updateIngressGroupStatus(ctx, ingGroup, lbDNS); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -16,6 +16,7 @@ const (
 	IngressSuffixLoadBalancerAttributes       = "load-balancer-attributes"
 	IngressSuffixSecurityGroups               = "security-groups"
 	IngressSuffixListenPorts                  = "listen-ports"
+	IngressSuffixInboundCIDRs                 = "inbound-cidrs"
 	IngressSuffixCertificateARN               = "certificate-arn"
 	IngressSuffixSSLPolicy                    = "ssl-policy"
 	IngressSuffixTargetType                   = "target-type"

--- a/pkg/aws/errors/utils.go
+++ b/pkg/aws/errors/utils.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/pkg/errors"
+)
+
+func IsELBV2TargetGroupNotFoundError(err error) bool {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return awsErr.Code() == "TargetGroupNotFound"
+	}
+	return false
+}
+
+func IsEC2SecurityGroupNotFoundError(err error) bool {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return awsErr.Code() == "InvalidGroup.NotFound"
+	}
+	return false
+}

--- a/pkg/deploy/ec2/security_group_manager.go
+++ b/pkg/deploy/ec2/security_group_manager.go
@@ -167,9 +167,9 @@ func buildIPPermissionInfo(permission ec2model.IPPermission) (networking.IPPermi
 		labels := networking.NewIPPermissionLabelsForRawDescription(permission.IPRanges[0].Description)
 		return networking.NewCIDRIPPermission(protocol, permission.FromPort, permission.ToPort, permission.IPRanges[0].CIDRIP, labels), nil
 	}
-	if len(permission.IPV6Range) == 1 {
-		labels := networking.NewIPPermissionLabelsForRawDescription(permission.IPV6Range[0].Description)
-		return networking.NewCIDRIPPermission(protocol, permission.FromPort, permission.ToPort, permission.IPV6Range[0].CIDRIPv6, labels), nil
+	if len(permission.IPv6Range) == 1 {
+		labels := networking.NewIPPermissionLabelsForRawDescription(permission.IPv6Range[0].Description)
+		return networking.NewCIDRIPPermission(protocol, permission.FromPort, permission.ToPort, permission.IPv6Range[0].CIDRIPv6, labels), nil
 	}
 	if len(permission.UserIDGroupPairs) == 1 {
 		labels := networking.NewIPPermissionLabelsForRawDescription(permission.UserIDGroupPairs[0].Description)

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -2,12 +2,17 @@ package ingress
 
 import (
 	"context"
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
+	networking "k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/annotations"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/k8s"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/elbv2"
-	"sigs.k8s.io/aws-alb-ingress-controller/pkg/networking"
+	networkingpkg "sigs.k8s.io/aws-alb-ingress-controller/pkg/networking"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,7 +28,7 @@ type ModelBuilder interface {
 
 // NewDefaultModelBuilder constructs new defaultModelBuilder.
 func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventRecorder, ec2Client services.EC2, vpcID string, clusterName string,
-	annotationParser annotations.Parser, subnetsResolver networking.SubnetsResolver,
+	annotationParser annotations.Parser, subnetsResolver networkingpkg.SubnetsResolver,
 	authConfigBuilder AuthConfigBuilder, enhancedBackendBuilder EnhancedBackendBuilder) *defaultModelBuilder {
 	return &defaultModelBuilder{
 		k8sClient:              k8sClient,
@@ -35,18 +40,6 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 		subnetsResolver:        subnetsResolver,
 		authConfigBuilder:      authConfigBuilder,
 		enhancedBackendBuilder: enhancedBackendBuilder,
-
-		defaultIPAddressType:                      elbv2model.IPAddressTypeIPV4,
-		defaultScheme:                             elbv2model.LoadBalancerSchemeInternal,
-		defaultSSLPolicy:                          "ELBSecurityPolicy-2016-08",
-		defaultTargetType:                         elbv2model.TargetTypeInstance,
-		defaultBackendProtocol:                    elbv2model.ProtocolHTTP,
-		defaultHealthCheckPath:                    "/",
-		defaultHealthCheckIntervalSeconds:         15,
-		defaultHealthCheckTimeoutSeconds:          5,
-		defaultHealthCheckHealthyThresholdCount:   2,
-		defaultHealthCheckUnhealthyThresholdCount: 2,
-		defaultHealthCheckMatcherHTTPCode:         "200",
 	}
 }
 
@@ -62,9 +55,63 @@ type defaultModelBuilder struct {
 	clusterName string
 
 	annotationParser       annotations.Parser
-	subnetsResolver        networking.SubnetsResolver
+	subnetsResolver        networkingpkg.SubnetsResolver
 	authConfigBuilder      AuthConfigBuilder
 	enhancedBackendBuilder EnhancedBackendBuilder
+}
+
+// build mode stack for a IngressGroup.
+func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group) (core.Stack, *elbv2model.LoadBalancer, error) {
+	stack := core.NewDefaultStack(ingGroup.ID.String())
+	task := &defaultModelBuildTask{
+		k8sClient:              b.k8sClient,
+		eventRecorder:          b.eventRecorder,
+		ec2Client:              b.ec2Client,
+		vpcID:                  b.vpcID,
+		clusterName:            b.clusterName,
+		annotationParser:       b.annotationParser,
+		subnetsResolver:        b.subnetsResolver,
+		authConfigBuilder:      b.authConfigBuilder,
+		enhancedBackendBuilder: b.enhancedBackendBuilder,
+
+		ingGroup: ingGroup,
+		stack:    stack,
+
+		defaultIPAddressType:                      elbv2model.IPAddressTypeIPV4,
+		defaultScheme:                             elbv2model.LoadBalancerSchemeInternal,
+		defaultSSLPolicy:                          "ELBSecurityPolicy-2016-08",
+		defaultTargetType:                         elbv2model.TargetTypeInstance,
+		defaultBackendProtocol:                    elbv2model.ProtocolHTTP,
+		defaultHealthCheckPath:                    "/",
+		defaultHealthCheckIntervalSeconds:         15,
+		defaultHealthCheckTimeoutSeconds:          5,
+		defaultHealthCheckHealthyThresholdCount:   2,
+		defaultHealthCheckUnhealthyThresholdCount: 2,
+		defaultHealthCheckMatcherHTTPCode:         "200",
+
+		loadBalancer: nil,
+		tgByResID:    make(map[string]*elbv2model.TargetGroup),
+	}
+	if err := task.run(ctx); err != nil {
+		return nil, nil, err
+	}
+	return task.stack, task.loadBalancer, nil
+}
+
+// the default model build task
+type defaultModelBuildTask struct {
+	k8sClient              client.Client
+	eventRecorder          record.EventRecorder
+	ec2Client              services.EC2
+	vpcID                  string
+	clusterName            string
+	annotationParser       annotations.Parser
+	subnetsResolver        networkingpkg.SubnetsResolver
+	authConfigBuilder      AuthConfigBuilder
+	enhancedBackendBuilder EnhancedBackendBuilder
+
+	ingGroup Group
+	stack    core.Stack
 
 	defaultIPAddressType                      elbv2model.IPAddressType
 	defaultScheme                             elbv2model.LoadBalancerScheme
@@ -77,17 +124,119 @@ type defaultModelBuilder struct {
 	defaultHealthCheckHealthyThresholdCount   int64
 	defaultHealthCheckUnhealthyThresholdCount int64
 	defaultHealthCheckMatcherHTTPCode         string
+
+	loadBalancer *elbv2model.LoadBalancer
+	tgByResID    map[string]*elbv2model.TargetGroup
 }
 
-// build mode stack for a IngressGroup.
-func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group) (core.Stack, *elbv2model.LoadBalancer, error) {
-	stack := core.NewDefaultStack(ingGroup.ID.String())
-	lb, err := b.buildLoadBalancer(ctx, stack, ingGroup)
+func (t *defaultModelBuildTask) run(ctx context.Context) error {
+	if len(t.ingGroup.Members) == 0 {
+		return nil
+	}
+
+	ingListByPort := make(map[int64][]*networking.Ingress)
+	listenPortConfigsByPort := make(map[int64]map[types.NamespacedName]listenPortConfig)
+	for _, ing := range t.ingGroup.Members {
+		listenPortConfigByPortForIngress, err := t.computeIngressListenPortConfigByPort(ctx, ing)
+		if err != nil {
+			return err
+		}
+		ingKey := k8s.NamespacedName(ing)
+		for port, cfg := range listenPortConfigByPortForIngress {
+			ingListByPort[port] = append(ingListByPort[port], ing)
+			if _, exists := listenPortConfigsByPort[port]; !exists {
+				listenPortConfigsByPort[port] = make(map[types.NamespacedName]listenPortConfig)
+			}
+			listenPortConfigsByPort[port][ingKey] = cfg
+		}
+	}
+	listenPortConfigByPort := make(map[int64]listenPortConfig)
+	for port, cfgs := range listenPortConfigsByPort {
+		mergedCfg, err := t.mergeListenPortConfigs(ctx, cfgs)
+		if err != nil {
+			return errors.Wrapf(err, "failed to merge listPort config for port: %v", port)
+		}
+		listenPortConfigByPort[port] = mergedCfg
+	}
+
+	lb, err := t.buildLoadBalancer(ctx, listenPortConfigByPort)
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
-	if err := b.buildListenerAndListenerRules(ctx, stack, ingGroup, lb.LoadBalancerARN()); err != nil {
-		return nil, nil, err
+	for port, cfg := range listenPortConfigByPort {
+		ingList := ingListByPort[port]
+		ls, err := t.buildListener(ctx, lb.LoadBalancerARN(), port, cfg, ingList)
+		if err != nil {
+			return err
+		}
+		if err := t.buildListenerRules(ctx, ls.ListenerARN(), port, cfg.protocol, ingList); err != nil {
+			return err
+		}
 	}
-	return stack, lb, nil
+	return nil
+}
+
+func (t *defaultModelBuildTask) mergeListenPortConfigs(_ context.Context, listenPortConfigByIngress map[types.NamespacedName]listenPortConfig) (listenPortConfig, error) {
+	var mergedProtocol *elbv2model.Protocol
+	var mergedProtocolProvider types.NamespacedName
+	var mergedInboundCIDRv4s []string
+	var mergedInboundCIDRv6s []string
+	var mergedInboundCIDRsProvider types.NamespacedName
+	var mergedSSLPolicy *string
+	var mergedSSLPolicyProvider types.NamespacedName
+	var mergedTLSCerts []string
+
+	for ingKey, cfg := range listenPortConfigByIngress {
+		if mergedProtocol == nil {
+			protocol := cfg.protocol
+			mergedProtocol = &protocol
+			mergedProtocolProvider = ingKey
+		} else if (*mergedProtocol) != cfg.protocol {
+			return listenPortConfig{}, errors.Errorf("conflicting protocol, %v: %v | %v: %v",
+				mergedProtocolProvider, *mergedProtocol, ingKey, cfg.protocol)
+		}
+
+		definedCIDRsInCfg := len(cfg.inboundCIDRv4s) != 0 || len(cfg.inboundCIDRv6s) != 0
+		if definedCIDRsInCfg {
+			definedCIDRsInMergedCfg := len(mergedInboundCIDRv4s) != 0 || len(mergedInboundCIDRv6s) != 0
+			if !definedCIDRsInMergedCfg {
+				mergedInboundCIDRv4s = cfg.inboundCIDRv4s
+				mergedInboundCIDRv6s = cfg.inboundCIDRv6s
+			} else {
+				return listenPortConfig{}, errors.Errorf("conflicting sslPolicy, %v: %v, %v | %v: %v, %v",
+					mergedInboundCIDRsProvider, mergedInboundCIDRv4s, mergedInboundCIDRv6s, ingKey, cfg.inboundCIDRv4s, cfg.inboundCIDRv6s)
+			}
+		}
+
+		if cfg.sslPolicy != nil {
+			if mergedSSLPolicy == nil {
+				mergedSSLPolicy = cfg.sslPolicy
+				mergedSSLPolicyProvider = ingKey
+			} else if awssdk.StringValue(mergedSSLPolicy) != awssdk.StringValue(cfg.sslPolicy) {
+				return listenPortConfig{}, errors.Errorf("conflicting sslPolicy, %v: %v | %v: %v",
+					mergedSSLPolicyProvider, awssdk.StringValue(mergedSSLPolicy), ingKey, awssdk.StringValue(cfg.sslPolicy))
+			}
+		}
+		mergedTLSCerts = append(mergedTLSCerts, cfg.tlsCerts...)
+	}
+
+	if mergedProtocol == nil {
+		return listenPortConfig{}, errors.New("should never happen")
+	}
+
+	if len(mergedInboundCIDRv4s) == 0 && len(mergedInboundCIDRv6s) == 0 {
+		mergedInboundCIDRv4s = append(mergedInboundCIDRv4s, "0.0.0.0/0")
+		mergedInboundCIDRv6s = append(mergedInboundCIDRv6s, "::/0")
+	}
+	if *mergedProtocol == elbv2model.ProtocolHTTPS && mergedSSLPolicy == nil {
+		mergedSSLPolicy = awssdk.String(t.defaultSSLPolicy)
+	}
+
+	return listenPortConfig{
+		protocol:       *mergedProtocol,
+		inboundCIDRv4s: mergedInboundCIDRv4s,
+		inboundCIDRv6s: mergedInboundCIDRv6s,
+		sslPolicy:      mergedSSLPolicy,
+		tlsCerts:       mergedTLSCerts,
+	}, nil
 }

--- a/pkg/model/ec2/security_group_ingress.go
+++ b/pkg/model/ec2/security_group_ingress.go
@@ -6,7 +6,7 @@ type IPRange struct {
 	Description string `json:"description,omitempty"`
 }
 
-type IPV6Range struct {
+type IPv6Range struct {
 	CIDRIPv6 string `json:"cidrIPv6"`
 	// +optional
 	Description string `json:"description,omitempty"`
@@ -27,7 +27,7 @@ type IPPermission struct {
 	// +optional
 	IPRanges []IPRange `json:"ipRanges,omitempty"`
 	// +optional
-	IPV6Range []IPV6Range `json:"ipv6Ranges,omitempty"`
+	IPv6Range []IPv6Range `json:"ipv6Ranges,omitempty"`
 	// +optional
 	UserIDGroupPairs []UserIDGroupPair `json:"userIDGroupPairs,omitempty"`
 }

--- a/pkg/service/nlb/builder.go
+++ b/pkg/service/nlb/builder.go
@@ -86,7 +86,7 @@ func (b *nlbBuilder) buildModel(ctx context.Context, stack core.Stack) (*elbv2mo
 	return nlb, nil
 }
 
-func(b *nlbBuilder) buildLoadBalancer(ctx context.Context, stack core.Stack) (*elbv2model.LoadBalancer, error) {
+func (b *nlbBuilder) buildLoadBalancer(ctx context.Context, stack core.Stack) (*elbv2model.LoadBalancer, error) {
 	spec, err := b.loadBalancerSpec(ctx)
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func (b *nlbBuilder) loadBalancerSpec(ctx context.Context) (elbv2model.LoadBalan
 	return spec, nil
 }
 
-func(b *nlbBuilder) buildLoadBalancerScheme(ctx context.Context) (elbv2model.LoadBalancerScheme, error) {
+func (b *nlbBuilder) buildLoadBalancerScheme(ctx context.Context) (elbv2model.LoadBalancerScheme, error) {
 	scheme := elbv2model.LoadBalancerSchemeInternetFacing
 	internal := false
 	if _, err := b.annotationParser.ParseBoolAnnotation(annotations.SvcLBSuffixInternal, &internal, b.service.Annotations); err != nil {
@@ -135,7 +135,7 @@ func(b *nlbBuilder) buildLoadBalancerScheme(ctx context.Context) (elbv2model.Loa
 	return scheme, nil
 }
 
-func(b * nlbBuilder) buildLoadBalancerTags(ctx context.Context) (map[string]string, error) {
+func (b *nlbBuilder) buildLoadBalancerTags(ctx context.Context) (map[string]string, error) {
 	tags := make(map[string]string)
 	_, err := b.annotationParser.ParseStringMapAnnotation(annotations.SvcLBSuffixAdditionalTags, &tags, b.service.Annotations)
 	if err != nil {

--- a/pkg/targetgroupbinding/networking_manager.go
+++ b/pkg/targetgroupbinding/networking_manager.go
@@ -123,8 +123,7 @@ func (m *defaultNetworkingManager) reconcileForEndpointSGs(ctx context.Context, 
 	for sgID, ipPermissions := range ingressIPPermissionsBySG {
 		if err := m.sgReconciler.ReconcileIngress(ctx, sgID, ipPermissions,
 			networking.WithPermissionSelector(permissionSelector),
-			networking.WithAuthorizeOnly(!computedEndpointSGsForAllTGBs))
-			err != nil {
+			networking.WithAuthorizeOnly(!computedEndpointSGsForAllTGBs)); err != nil {
 			return err
 		}
 	}

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	elbv2api "sigs.k8s.io/aws-alb-ingress-controller/apis/elbv2/v1alpha1"
+	awserrors "sigs.k8s.io/aws-alb-ingress-controller/pkg/aws/errors"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/backend"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/k8s"
@@ -61,14 +62,14 @@ func (m *defaultResourceManager) Reconcile(ctx context.Context, tgb *elbv2api.Ta
 func (m *defaultResourceManager) Cleanup(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {
 	targets, err := m.targetsManager.ListTargets(ctx, tgb.Spec.TargetGroupARN)
 	if err != nil {
-		if IsTargetGroupNotFoundError(err) {
+		if awserrors.IsELBV2TargetGroupNotFoundError(err) {
 			return nil
 		}
 		return err
 	}
 	err = m.deregisterTargets(ctx, tgb.Spec.TargetGroupARN, targets)
 	if err != nil {
-		if IsTargetGroupNotFoundError(err) {
+		if awserrors.IsELBV2TargetGroupNotFoundError(err) {
 			return nil
 		}
 		return err

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -61,9 +61,19 @@ func (m *defaultResourceManager) Reconcile(ctx context.Context, tgb *elbv2api.Ta
 func (m *defaultResourceManager) Cleanup(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {
 	targets, err := m.targetsManager.ListTargets(ctx, tgb.Spec.TargetGroupARN)
 	if err != nil {
+		if IsTargetGroupNotFoundError(err) {
+			return nil
+		}
 		return err
 	}
-	return m.deregisterTargets(ctx, tgb.Spec.TargetGroupARN, targets)
+	err = m.deregisterTargets(ctx, tgb.Spec.TargetGroupARN, targets)
+	if err != nil {
+		if IsTargetGroupNotFoundError(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {

--- a/pkg/targetgroupbinding/utils.go
+++ b/pkg/targetgroupbinding/utils.go
@@ -1,6 +1,8 @@
 package targetgroupbinding
 
 import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	elbv2api "sigs.k8s.io/aws-alb-ingress-controller/apis/elbv2/v1alpha1"
@@ -23,6 +25,14 @@ func IndexFuncTargetType(obj runtime.Object) []string {
 		targetType = string(*tgb.Spec.TargetType)
 	}
 	return []string{targetType}
+}
+
+func IsTargetGroupNotFoundError(err error) bool {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return awsErr.Code() == "TargetGroupNotFound"
+	}
+	return false
 }
 
 func buildServiceReferenceKey(tgb *elbv2api.TargetGroupBinding, svcRef elbv2api.ServiceReference) types.NamespacedName {

--- a/pkg/targetgroupbinding/utils.go
+++ b/pkg/targetgroupbinding/utils.go
@@ -1,8 +1,6 @@
 package targetgroupbinding
 
 import (
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	elbv2api "sigs.k8s.io/aws-alb-ingress-controller/apis/elbv2/v1alpha1"
@@ -25,14 +23,6 @@ func IndexFuncTargetType(obj runtime.Object) []string {
 		targetType = string(*tgb.Spec.TargetType)
 	}
 	return []string{targetType}
-}
-
-func IsTargetGroupNotFoundError(err error) bool {
-	var awsErr awserr.Error
-	if errors.As(err, &awsErr) {
-		return awsErr.Code() == "TargetGroupNotFound"
-	}
-	return false
 }
 
 func buildServiceReferenceKey(tgb *elbv2api.TargetGroupBinding, svcRef elbv2api.ServiceReference) types.NamespacedName {


### PR DESCRIPTION
1. refactor ingress model builder to share states via modelBuildTask
2. added support for  managed securityGroup
3. handle targetGroupNotFound error
4. gc unnecessay securityGroup rules.

sample model built
```json
{
   "id":"test-ns/ingress-2048",
   "resources":{
      "AWS::EC2::SecurityGroup":{
         "ManagedLBSecurityGroup":{
            "spec":{
               "groupName":"k8s-test-ns-ingress-2-6123993a38",
               "description":"[k8s] Managed SecurityGroup for LoadBalancer",
               "ingress":[
                  {
                     "ipProtocol":"tcp",
                     "fromPort":80,
                     "toPort":80,
                     "ipRanges":[
                        {
                           "cidrIP":"0.0.0.0/0"
                        }
                     ]
                  }
               ]
            }
         }
      },
      "AWS::ElasticLoadBalancingV2::Listener":{
         "80":{
            "spec":{
               "loadBalancerARN":{
                  "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
               },
               "port":80,
               "protocol":"HTTP",
               "defaultActions":[
                  {
                     "type":"fixed-response",
                     "fixedResponseConfig":{
                        "contentType":"text/plain",
                        "statusCode":"404"
                     }
                  }
               ]
            }
         }
      },
      "AWS::ElasticLoadBalancingV2::ListenerRule":{
         "1":{
            "spec":{
               "listenerARN":{
                  "$ref":"#/resources/AWS::ElasticLoadBalancingV2::Listener/80/status/listenerARN"
               },
               "priority":1,
               "actions":[
                  {
                     "type":"forward",
                     "forwardConfig":{
                        "targetGroups":[
                           {
                              "targetGroupARN":{
                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/test-ns/ingress-2048-service-2048:80/status/targetGroupARN"
                              }
                           }
                        ]
                     }
                  }
               ],
               "conditions":[
                  {
                     "field":"path-pattern",
                     "hostHeaderConfig":null,
                     "httpHeaderConfig":null,
                     "httpRequestMethodConfig":null,
                     "pathPatternConfig":{
                        "values":[
                           "/*"
                        ]
                     },
                     "queryStringConfig":null,
                     "sourceIPConfig":null
                  }
               ]
            }
         }
      },
      "AWS::ElasticLoadBalancingV2::LoadBalancer":{
         "LoadBalancer":{
            "spec":{
               "name":"k8s-test-ns-ingress-2-5212e686cf",
               "type":"application",
               "scheme":"internet-facing",
               "ipAddressType":"ipv4",
               "subnetMapping":[
                  {
                     "subnetID":"subnet-00c4874ef08c60d29"
                  },
                  {
                     "subnetID":"subnet-08e78dfc8baf594ef"
                  },
                  {
                     "subnetID":"subnet-04f7d088446bd6335"
                  }
               ],
               "securityGroups":[
                  {
                     "$ref":"#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
                  }
               ]
            }
         }
      },
      "AWS::ElasticLoadBalancingV2::TargetGroup":{
         "test-ns/ingress-2048-service-2048:80":{
            "spec":{
               "name":"k8s-test-ns-service--3dd403d9de",
               "targetType":"instance",
               "port":1,
               "protocol":"HTTP",
               "healthCheckConfig":{
                  "port":"traffic-port",
                  "protocol":"HTTP",
                  "path":"/",
                  "matcher":{
                     "httpCode":"200"
                  },
                  "intervalSeconds":15,
                  "timeoutSeconds":5,
                  "healthyThresholdCount":2,
                  "unhealthyThresholdCount":2
               }
            }
         }
      },
      "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
         "test-ns/ingress-2048-service-2048:80":{
            "spec":{
               "targetGroupARN":{
                  "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/test-ns/ingress-2048-service-2048:80/status/targetGroupARN"
               },
               "template":{
                  "metadata":{
                     "name":"k8s-test-ns-service--3dd403d9de",
                     "namespace":"test-ns",
                     "creationTimestamp":null
                  },
                  "spec":{
                     "targetGroupARN":"",
                     "targetType":"instance",
                     "serviceRef":{
                        "name":"service-2048",
                        "port":80
                     }
                  }
               }
            }
         }
      }
   }
}
```
