### PR TITLE
add networking config to NLB targetgroupbinding

### DIFF
--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -146,12 +146,16 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Cont
 		explicitSubnetNameOrIDsList = append(explicitSubnetNameOrIDsList, rawSubnetNameOrIDs)
 	}
 	if len(explicitSubnetNameOrIDsList) == 0 {
-		chosenSubnetIDs, err := t.subnetsResolver.DiscoverSubnets(ctx, scheme)
+		chosenSubnets, err := t.subnetsResolver.DiscoverSubnets(ctx, scheme)
 		if err != nil {
 			return nil, err
 		}
+		var chosenSubnetIDs []string
+		for _, subnet := range chosenSubnets {
+			chosenSubnetIDs = append(chosenSubnetIDs, awssdk.StringValue(subnet.SubnetId))
+		}
 		if len(chosenSubnetIDs) <= 2 {
-			return nil, errors.Errorf("cannot found at least two subnet from different Availability Zones, discovered subnetIDs: %v", chosenSubnetIDs)
+			return nil, errors.Errorf("cannot find at least two subnets from different Availability Zones, discovered subnetIDs: %v", chosenSubnetIDs)
 		}
 		return buildLoadBalancerSubnetMappingsWithSubnetIDs(chosenSubnetIDs), nil
 	}

--- a/pkg/service/nlb/mock_subnet_resolver.go
+++ b/pkg/service/nlb/mock_subnet_resolver.go
@@ -2,20 +2,34 @@ package nlb
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/networking"
 )
 
 type mockSubnetsReoslver struct {
 	subnets []string
+	cirds   []string
 }
 
 var _ networking.SubnetsResolver = &mockSubnetsReoslver{}
 
-func (m *mockSubnetsReoslver) DiscoverSubnets(ctx context.Context, scheme elbv2.LoadBalancerScheme) ([]string, error) {
-	return m.subnets, nil
+func (m *mockSubnetsReoslver) DiscoverSubnets(ctx context.Context, scheme elbv2.LoadBalancerScheme) ([]*ec2.Subnet, error) {
+	subnets := make([]*ec2.Subnet, 0, len(m.subnets))
+	for idx, sn := range m.subnets {
+		ec2Subnet := &ec2.Subnet{
+			SubnetId:  aws.String(sn),
+			CidrBlock: aws.String(m.cirds[idx]),
+		}
+		subnets = append(subnets, ec2Subnet)
+	}
+	return subnets, nil
 }
 
-func NewMockSubnetsResolver(subnets []string) networking.SubnetsResolver {
-	return &mockSubnetsReoslver{subnets: subnets}
+func NewMockSubnetsResolver(subnets []string, cidrs []string) networking.SubnetsResolver {
+	return &mockSubnetsReoslver{
+		subnets: subnets,
+		cirds:   cidrs,
+	}
 }


### PR DESCRIPTION
Modify networking.DiscoverSubnets() to return []*ec2.Subnet
Add Subnet/Port to TargetGropuBinding for NLB
   Port is added so networking_manager is able to add the sg rules, will be removed later
Verified SG rules get added for the subnets