### PR TITLE
add support for pod mutator webhook

### DIFF
--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -1,0 +1,16 @@
+package inject
+
+import "github.com/spf13/pflag"
+
+const (
+	flagEnableReadinessInject = "enable-readiness-gate-inject"
+)
+
+type Config struct {
+	EnablePodReadinessGateInject bool
+}
+
+func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&cfg.EnablePodReadinessGateInject, flagEnableReadinessInject, false,
+		`If enabled, readiness gate config will get injected to the pod spec for the matching endpoint pods`)
+}

--- a/pkg/inject/pod_readiness_gate.go
+++ b/pkg/inject/pod_readiness_gate.go
@@ -1,0 +1,96 @@
+package inject
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	elbv2api "sigs.k8s.io/aws-alb-ingress-controller/apis/elbv2/v1alpha1"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+const (
+	v1ReadiessGatePrefix = "target-health.alb.ingress.k8s.aws"
+	readinessGatePrefix  = "elbv2.k8s.aws"
+)
+
+// NewPodReadinessGate constructs new PodReadinessGate
+func NewPodReadinessGate(k8sClient client.Client, logger logr.Logger) *PodReadinessGate {
+	return &PodReadinessGate{
+		k8sClient: k8sClient,
+		logger:    logger,
+	}
+}
+
+// PodReadinessGate is a pod mutator that adds readiness gates to pods matching the target group bindings
+type PodReadinessGate struct {
+	k8sClient client.Client
+	logger    logr.Logger
+}
+
+// matchLabels returns true if the service selector matches the pod labels
+func (m *PodReadinessGate) matchLabels(selector map[string]string, labels map[string]string) bool {
+	if len(selector) == 0 {
+		return false
+	}
+	for key, selectorVal := range selector {
+		if labelsVal, ok := labels[key]; !ok || labelsVal != selectorVal {
+			return false
+		}
+	}
+	return true
+}
+
+// removeReadinessGates removes existing v1/v2 readiness gates. v1 readiness gates are removed for maintaining
+// backwards compatibility
+func (m *PodReadinessGate) removeReadinessGates(_ context.Context, pod *corev1.Pod) {
+	var modifiedReadinessGates []corev1.PodReadinessGate
+	for _, item := range pod.Spec.ReadinessGates {
+		if !strings.HasPrefix(string(item.ConditionType), v1ReadiessGatePrefix) &&
+			!strings.HasPrefix(string(item.ConditionType), readinessGatePrefix) {
+			modifiedReadinessGates = append(modifiedReadinessGates, item)
+		}
+	}
+	pod.Spec.ReadinessGates = modifiedReadinessGates
+}
+
+// Mutate adds the readiness gates to the pod if there are target group bindings on the same namespace as the pod
+// and referring to existing services matching the pod labels
+func (m *PodReadinessGate) Mutate(ctx context.Context, pod *corev1.Pod) error {
+	m.removeReadinessGates(ctx, pod)
+
+	// see https://github.com/kubernetes/kubernetes/issues/88282 and https://github.com/kubernetes/kubernetes/issues/76680
+	req := webhook.ContextGetAdmissionRequest(ctx)
+	tgbList := &elbv2api.TargetGroupBindingList{}
+	if err := m.k8sClient.List(ctx, tgbList, client.InNamespace(req.Namespace)); err != nil {
+		m.logger.V(1).Info("unable to list TargetGroupBindings", "namespace", req.Namespace)
+		return client.IgnoreNotFound(err)
+	}
+
+	var newReadinessGates []corev1.PodReadinessGate
+	for _, tg := range tgbList.Items {
+		svcRef := tg.Spec.ServiceRef
+		svc := &corev1.Service{}
+		if err := m.k8sClient.Get(ctx, types.NamespacedName{Name: svcRef.Name, Namespace: req.Namespace}, svc); err != nil {
+			// If the service is not found, ignore
+			if client.IgnoreNotFound(err) == nil {
+				m.logger.Info("Unable to lookup service", "name", svcRef, "namespace", req.Namespace)
+				continue
+			}
+			return err
+		}
+		if m.matchLabels(svc.Spec.Selector, pod.Labels) {
+			readinessGate := corev1.PodReadinessGate{
+				ConditionType: corev1.PodConditionType(fmt.Sprintf("%s/%s", readinessGatePrefix, tg.Name)),
+			}
+			newReadinessGates = append(newReadinessGates, readinessGate)
+			m.logger.V(1).Info("Adding readiness gate", "readinessGate", readinessGate.String())
+		}
+	}
+	m.logger.V(1).Info("Appending readiness gates to", "pod", pod.Name, "gates", newReadinessGates)
+	pod.Spec.ReadinessGates = append(pod.Spec.ReadinessGates, newReadinessGates...)
+	return nil
+}

--- a/pkg/inject/pod_readiness_gate_test.go
+++ b/pkg/inject/pod_readiness_gate_test.go
@@ -1,0 +1,357 @@
+package inject
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/aws-alb-ingress-controller/apis/elbv2/v1alpha1"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/webhook"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"testing"
+)
+
+func Test_PodReadinessGate_Mutate(t *testing.T) {
+	testNS1 := "name-space-1"
+	testNS2 := "name-space-2"
+	svc1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS1,
+			Name:      "service-1",
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": "app-1",
+				"svc": "svc1",
+			},
+		},
+	}
+	svc2 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS1,
+			Name:      "service-noselector",
+		},
+	}
+	svc3 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS2,
+			Name:      "service-1",
+		},
+	}
+	tgb1 := &v1alpha1.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tgb-1-abcd234",
+			Namespace: testNS1,
+		},
+		Spec: v1alpha1.TargetGroupBindingSpec{
+			ServiceRef: v1alpha1.ServiceReference{
+				Name: "service-1",
+			},
+		},
+	}
+	tgb2 := &v1alpha1.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tgb-2-affddee234",
+			Namespace: testNS1,
+		},
+		Spec: v1alpha1.TargetGroupBindingSpec{
+			ServiceRef: v1alpha1.ServiceReference{
+				Name: "service-1",
+			},
+		},
+	}
+	tgb3 := &v1alpha1.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tgb-2-abcd234",
+			Namespace: testNS1,
+		},
+		Spec: v1alpha1.TargetGroupBindingSpec{
+			ServiceRef: v1alpha1.ServiceReference{
+				Name: "service-nonexistent",
+			},
+		},
+	}
+	tgb4 := &v1alpha1.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tgb-2-affdd-noselector",
+			Namespace: testNS1,
+		},
+		Spec: v1alpha1.TargetGroupBindingSpec{
+			ServiceRef: v1alpha1.ServiceReference{
+				Name: "service-noselector",
+			},
+		},
+	}
+	tests := []struct {
+		name      string
+		namespace string
+		services  []*corev1.Service
+		tgbList   []*v1alpha1.TargetGroupBinding
+		pod       *corev1.Pod
+		want      []corev1.PodReadinessGate
+		wantError bool
+	}{
+		{
+			name:      "matching tgb",
+			namespace: testNS1,
+			services:  []*corev1.Service{svc1},
+			tgbList:   []*v1alpha1.TargetGroupBinding{tgb1},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":    "app-1",
+						"svc":    "svc1",
+						"stable": "none",
+					},
+				},
+			},
+			want: []corev1.PodReadinessGate{
+				{
+					ConditionType: "elbv2.k8s.aws/tgb-1-abcd234",
+				},
+			},
+		},
+		{
+			name:      "multiple tgb",
+			namespace: testNS1,
+			services:  []*corev1.Service{svc1},
+			tgbList:   []*v1alpha1.TargetGroupBinding{tgb1, tgb2},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":    "app-1",
+						"svc":    "svc1",
+						"stable": "none",
+					},
+				},
+			},
+			want: []corev1.PodReadinessGate{
+				{
+					ConditionType: "elbv2.k8s.aws/tgb-1-abcd234",
+				},
+				{
+					ConditionType: "elbv2.k8s.aws/tgb-2-affddee234",
+				},
+			},
+		},
+		{
+			name:      "nonexistent service",
+			namespace: testNS1,
+			services:  []*corev1.Service{svc1, svc2, svc3},
+			tgbList:   []*v1alpha1.TargetGroupBinding{tgb3},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "app-nomatch",
+					},
+				},
+			},
+			want: []corev1.PodReadinessGate(nil),
+		},
+		{
+			name:      "service without selector",
+			namespace: testNS1,
+			services:  []*corev1.Service{svc1, svc2, svc3},
+			tgbList:   []*v1alpha1.TargetGroupBinding{tgb4},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "app-nomatch",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{
+							ConditionType: "leave-unmodified",
+						},
+					},
+				},
+			},
+			want: []corev1.PodReadinessGate{
+				{
+					ConditionType: "leave-unmodified",
+				},
+			},
+		},
+		{
+			name:      "pod label doesn't match",
+			namespace: testNS1,
+			services:  []*corev1.Service{svc1, svc2, svc3},
+			tgbList:   []*v1alpha1.TargetGroupBinding{tgb1, tgb2, tgb3, tgb4},
+			pod:       &corev1.Pod{},
+			want:      []corev1.PodReadinessGate(nil),
+		},
+		{
+			name:      "remove related old readiness gates",
+			namespace: testNS1,
+			services:  []*corev1.Service{svc1, svc2, svc3},
+			tgbList:   []*v1alpha1.TargetGroupBinding{tgb1, tgb2, tgb3, tgb4},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "app-1",
+						"svc": "svc1",
+						"new": "label",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{
+							ConditionType: "target-health.alb.ingress.k8s.aws/old_gate",
+						},
+						{
+							ConditionType: "leave-intact",
+						},
+						{
+							ConditionType: "elbv2.k8s.aws/tgb-0851b1f4d6-something-else",
+						},
+						{
+							ConditionType: "elbv2.k8s.aws/tgb-1-abcd234",
+						},
+					},
+				},
+			},
+			want: []corev1.PodReadinessGate{
+				{
+					ConditionType: "leave-intact",
+				},
+				{
+					ConditionType: "elbv2.k8s.aws/tgb-1-abcd234",
+				},
+				{
+					ConditionType: "elbv2.k8s.aws/tgb-2-affddee234",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			v1alpha1.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			for _, svc := range tt.services {
+				assert.NoError(t, k8sClient.Create(ctx, svc.DeepCopy()))
+			}
+			for _, tgb := range tt.tgbList {
+				assert.NoError(t, k8sClient.Create(ctx, tgb.DeepCopy()))
+			}
+			ctx = webhook.ContextWithAdmissionRequest(ctx, admission.Request{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{Namespace: tt.namespace},
+			})
+			readinessGateInjector := NewPodReadinessGate(k8sClient, &log.NullLogger{})
+			err := readinessGateInjector.Mutate(ctx, tt.pod)
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, tt.pod.Spec.ReadinessGates)
+			}
+		})
+	}
+}
+
+func Test_PodReadinessGate_removeReadinessGates(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want *corev1.Pod
+	}{
+		{
+			name: "no readiness gates",
+			pod:  &corev1.Pod{},
+			want: &corev1.Pod{},
+		},
+		{
+			name: "unrelated readiness gates",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{
+							ConditionType: "unrelated",
+						},
+						{
+							ConditionType: "test-gate",
+						},
+					},
+				},
+			},
+			want: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{
+							ConditionType: "unrelated",
+						},
+						{
+							ConditionType: "test-gate",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "mix and match",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{
+							ConditionType: "unrelated",
+						},
+						{
+							ConditionType: "target-health.alb.ingress.k8s.aws/old_gate",
+						},
+						{
+							ConditionType: "elbv2.k8s.aws/tgb-0851b1f4d6",
+						},
+						{
+							ConditionType: "survive",
+						},
+					},
+				},
+			},
+			want: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{
+							ConditionType: "unrelated",
+						},
+						{
+							ConditionType: "survive",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "empty out",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{
+							ConditionType: "target-health.alb.ingress.k8s.aws/old_gate",
+						},
+						{
+							ConditionType: "elbv2.k8s.aws/tgb-0851b1f4d6",
+						},
+					},
+				},
+			},
+			want: &corev1.Pod{
+				Spec: corev1.PodSpec{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			readinessGateInjector := &PodReadinessGate{}
+			readinessGateInjector.removeReadinessGates(context.Background(), tt.pod)
+			assert.Equal(t, tt.want, tt.pod)
+		})
+	}
+}

--- a/webhooks/core/pod_mutator.go
+++ b/webhooks/core/pod_mutator.go
@@ -1,0 +1,47 @@
+package core
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	podinjector "sigs.k8s.io/aws-alb-ingress-controller/pkg/inject"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/webhook"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	apiPathMutatePod = "/mutate-v1-pod"
+)
+
+// NewPodMutator returns a mutator for Pod.
+func NewPodMutator(readiness *podinjector.PodReadinessGate) *podMutator {
+	return &podMutator{
+		readiness: readiness,
+	}
+}
+
+var _ webhook.Mutator = &podMutator{}
+
+type podMutator struct {
+	readiness *podinjector.PodReadinessGate
+}
+
+func (m *podMutator) Prototype(req admission.Request) (runtime.Object, error) {
+	return &corev1.Pod{}, nil
+}
+
+func (m *podMutator) MutateCreate(ctx context.Context, obj runtime.Object) (runtime.Object, error) {
+	pod := obj.(*corev1.Pod)
+	err := m.readiness.Mutate(ctx, pod)
+	return pod, err
+}
+
+func (m *podMutator) MutateUpdate(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
+	return obj, nil
+}
+
+// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1alpha1,name=mpod.elbv2.k8s.aws
+func (m *podMutator) SetupWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register(apiPathMutatePod, webhook.MutatingWebhookForMutator(m))
+}


### PR DESCRIPTION
Add pod mutator webhook to inject readiness gate to the pod spec.
Mutator will remove any v1 readiness gates with prefixes target-health.alb.ingress.k8s.aws, so that existing pod sepc will be compatible with the v2 release. Any existing v2 readiness gates are also cleaned up to keep the readiness gates in sync with the targetgroup bindings configured.

Targetgroupbindings referring nonexistent services are ignored.