### PR TITLE
add support for specifying eip allocations

### DIFF
--- a/controllers/service/eventhandlers/service_events.go
+++ b/controllers/service/eventhandlers/service_events.go
@@ -59,7 +59,7 @@ func (h *enqueueRequestsForServiceEvent) Generic(e event.GenericEvent, queue wor
 func (h *enqueueRequestsForServiceEvent) isServiceSupported(service *corev1.Service) bool {
 	lbType := ""
 	// TODO: Use constant instead of hardcoded annotation value
-	if h.annotationParser.ParseStringAnnotation("aws-load-balancer-type", &lbType, service.Annotations); lbType == "nlb-ip" {
+	if h.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixLoadBalancerType, &lbType, service.Annotations); lbType == "nlb-ip" {
 		return true
 	}
 	return false

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -59,4 +59,5 @@ const (
 	SvcLBSuffixHCProtocol                    = "aws-load-balancer-healthcheck-protocol"
 	SvcLBSuffixHCPort                        = "aws-load-balancer-healthcheck-port"
 	SvcLBSuffixHCPath                        = "aws-load-balancer-healthcheck-path"
+	SvcLBSuffixEIPAllocations                = "aws-load-balancer-eip-allocations"
 )


### PR DESCRIPTION
Add support for specifying EIP allocations via the annotation service.beta.kubernetes.io/aws-load-balancer-eip-allocations.
Tests
1. Verified using the following spec NLB got provisioned with the correct EIP allocation 
```yaml
kind: Service
apiVersion: v1
metadata:
  name: nlb-ip-svc
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
    service.beta.kubernetes.io/aws-load-balancer-eip-allocations: "eipalloc-xxx, eipalloc-yyy"
spec:
```
2. Invalid allocation id results in error

