### PR TITLE
Add model/deployer/builder for LoadBalancer Addons(WAF/Shield)

### DIFF
--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -7,7 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/aws-alb-ingress-controller/controllers/service/eventhandlers"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/annotations"
-	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/deploy"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/k8s"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
@@ -28,9 +28,9 @@ const (
 	controllerName          = "service"
 )
 
-func NewServiceReconciler(k8sClient client.Client, ec2Client services.EC2, elbv2Client services.ELBV2,
+func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client,
 	sgManager networking.SecurityGroupManager, sgReconciler networking.SecurityGroupReconciler,
-	vpcID string, clusterName string, resolver networking.SubnetsResolver, logger logr.Logger) *ServiceReconciler {
+	clusterName string, resolver networking.SubnetsResolver, logger logr.Logger) *ServiceReconciler {
 	return &ServiceReconciler{
 		k8sClient:        k8sClient,
 		logger:           logger,
@@ -38,7 +38,7 @@ func NewServiceReconciler(k8sClient client.Client, ec2Client services.EC2, elbv2
 		finalizerManager: k8s.NewDefaultFinalizerManager(k8sClient, logger),
 		subnetsResolver:  resolver,
 		stackMarshaller:  deploy.NewDefaultStackMarshaller(),
-		stackDeployer:    deploy.NewDefaultStackDeployer(k8sClient, ec2Client, elbv2Client, sgManager, sgReconciler, vpcID, clusterName, DefaultTagPrefix, logger),
+		stackDeployer:    deploy.NewDefaultStackDeployer(cloud, k8sClient, sgManager, sgReconciler, clusterName, DefaultTagPrefix, logger),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -113,17 +113,15 @@ func main() {
 		podENIResolver, nodeENIResolver, sgManager, sgReconciler, cloud.VpcID(), k8sClusterName, ctrl.Log)
 
 	subnetResolver := networking.NewSubnetsResolver(cloud.EC2(), cloud.VpcID(), k8sClusterName, ctrl.Log.WithName("subnets-resolver"))
-	ingGroupReconciler := ingress.NewGroupReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("ingress"), cloud.EC2(), cloud.ELBV2(),
-		sgManager, sgReconciler, cloud.VpcID(), k8sClusterName, subnetResolver, ctrl.Log)
+	ingGroupReconciler := ingress.NewGroupReconciler(cloud, mgr.GetClient(), mgr.GetEventRecorderFor("ingress"),
+		sgManager, sgReconciler, k8sClusterName, subnetResolver, ctrl.Log)
 	tgbReconciler := elbv2controller.NewTargetGroupBindingReconciler(mgr.GetClient(), mgr.GetFieldIndexer(), finalizerManager, tgbResManager,
 		ctrl.Log.WithName("controllers").WithName("TargetGroupBinding"))
 	svcReconciler := service.NewServiceReconciler(
+		cloud,
 		mgr.GetClient(),
-		cloud.EC2(),
-		cloud.ELBV2(),
 		sgManager,
 		sgReconciler,
-		cloud.VpcID(),
 		k8sClusterName,
 		subnetResolver,
 		ctrl.Log.WithName("controllers").WithName("Service"))

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -14,6 +14,10 @@ const (
 	IngressSuffixScheme                       = "scheme"
 	IngressSuffixSubnets                      = "subnets"
 	IngressSuffixLoadBalancerAttributes       = "load-balancer-attributes"
+	IngressSuffixWAFv2ACLARN                  = "wafv2-acl-arn"
+	IngressSuffixWAFACLID                     = "waf-acl-id"
+	IngressSuffixWebACLID                     = "web-acl-id" // deprecated, use "waf-acl-id" instead.
+	IngressSuffixShieldAdvancedProtection     = "shield-advanced-protection"
 	IngressSuffixSecurityGroups               = "security-groups"
 	IngressSuffixListenPorts                  = "listen-ports"
 	IngressSuffixInboundCIDRs                 = "inbound-cidrs"

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -18,6 +18,15 @@ type Cloud interface {
 	// ELBV2 provides API to AWS ELBV2
 	ELBV2() services.ELBV2
 
+	// WAFv2 provides API to AWS WAFv2
+	WAFv2() services.WAFv2
+
+	// WAFRegional provides API to AWS WAFRegional
+	WAFRegional() services.WAFRegional
+
+	// Shield provides API to AWS Shield
+	Shield() services.Shield
+
 	// Region for the kubernetes cluster
 	Region() string
 
@@ -61,9 +70,12 @@ func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, 
 	awsCfg := aws.NewConfig().WithRegion(cfg.Region).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint)
 	sess = sess.Copy(awsCfg)
 	return &defaultCloud{
-		cfg:   cfg,
-		ec2:   services.NewEC2(sess),
-		elbv2: services.NewELBV2(sess),
+		cfg:         cfg,
+		ec2:         services.NewEC2(sess),
+		elbv2:       services.NewELBV2(sess),
+		wafv2:       services.NewWAFv2(sess),
+		wafRegional: services.NewWAFRegional(sess),
+		shield:      services.NewShield(sess),
 	}, nil
 }
 
@@ -74,6 +86,10 @@ type defaultCloud struct {
 
 	ec2   services.EC2
 	elbv2 services.ELBV2
+
+	wafv2       services.WAFv2
+	wafRegional services.WAFRegional
+	shield      services.Shield
 }
 
 func (c *defaultCloud) EC2() services.EC2 {
@@ -82,6 +98,18 @@ func (c *defaultCloud) EC2() services.EC2 {
 
 func (c *defaultCloud) ELBV2() services.ELBV2 {
 	return c.elbv2
+}
+
+func (c *defaultCloud) WAFv2() services.WAFv2 {
+	return c.wafv2
+}
+
+func (c *defaultCloud) WAFRegional() services.WAFRegional {
+	return c.wafRegional
+}
+
+func (c *defaultCloud) Shield() services.Shield {
+	return c.shield
 }
 
 func (c *defaultCloud) Region() string {

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -74,7 +74,7 @@ func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, 
 		ec2:         services.NewEC2(sess),
 		elbv2:       services.NewELBV2(sess),
 		wafv2:       services.NewWAFv2(sess),
-		wafRegional: services.NewWAFRegional(sess),
+		wafRegional: services.NewWAFRegional(sess, cfg.Region),
 		shield:      services.NewShield(sess),
 	}, nil
 }

--- a/pkg/aws/services/shield.go
+++ b/pkg/aws/services/shield.go
@@ -1,0 +1,25 @@
+package services
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/shield"
+	"github.com/aws/aws-sdk-go/service/shield/shieldiface"
+)
+
+type Shield interface {
+	shieldiface.ShieldAPI
+}
+
+// NewShield constructs new Shield implementation.
+func NewShield(session *session.Session) Shield {
+	return &defaultShield{
+		// shield is only available as a global API in us-east-1.
+		ShieldAPI: shield.New(session, aws.NewConfig().WithRegion("us-east-1")),
+	}
+}
+
+// default implementation for Shield.
+type defaultShield struct {
+	shieldiface.ShieldAPI
+}

--- a/pkg/aws/services/shield.go
+++ b/pkg/aws/services/shield.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/shield"
@@ -9,6 +10,8 @@ import (
 
 type Shield interface {
 	shieldiface.ShieldAPI
+
+	Available() (bool, error)
 }
 
 // NewShield constructs new Shield implementation.
@@ -22,4 +25,13 @@ func NewShield(session *session.Session) Shield {
 // default implementation for Shield.
 type defaultShield struct {
 	shieldiface.ShieldAPI
+}
+
+func (c *defaultShield) Available() (bool, error) {
+	req := &shield.GetSubscriptionStateInput{}
+	resp, err := c.GetSubscriptionStateWithContext(context.Background(), req)
+	if err != nil {
+		return false, err
+	}
+	return *resp.SubscriptionState == "ACTIVE", nil
 }

--- a/pkg/aws/services/wafregional.go
+++ b/pkg/aws/services/wafregional.go
@@ -1,0 +1,23 @@
+package services
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/aws/aws-sdk-go/service/wafregional/wafregionaliface"
+)
+
+type WAFRegional interface {
+	wafregionaliface.WAFRegionalAPI
+}
+
+// NewWAFRegional constructs new WAFRegional implementation.
+func NewWAFRegional(session *session.Session) WAFRegional {
+	return &defaultWAFRegional{
+		WAFRegionalAPI: wafregional.New(session),
+	}
+}
+
+// default implementation for WAFRegional.
+type defaultWAFRegional struct {
+	wafregionaliface.WAFRegionalAPI
+}

--- a/pkg/aws/services/wafregional.go
+++ b/pkg/aws/services/wafregional.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/wafregional"
 	"github.com/aws/aws-sdk-go/service/wafregional/wafregionaliface"
@@ -8,16 +10,26 @@ import (
 
 type WAFRegional interface {
 	wafregionaliface.WAFRegionalAPI
+
+	Available() bool
 }
 
 // NewWAFRegional constructs new WAFRegional implementation.
-func NewWAFRegional(session *session.Session) WAFRegional {
+func NewWAFRegional(session *session.Session, region string) WAFRegional {
 	return &defaultWAFRegional{
-		WAFRegionalAPI: wafregional.New(session),
+		WAFRegionalAPI: wafregional.New(session, aws.NewConfig().WithRegion(region)),
+		region:         region,
 	}
 }
 
 // default implementation for WAFRegional.
 type defaultWAFRegional struct {
 	wafregionaliface.WAFRegionalAPI
+	region string
+}
+
+func (c *defaultWAFRegional) Available() bool {
+	resolver := endpoints.DefaultResolver()
+	_, err := resolver.EndpointFor(wafregional.EndpointsID, c.region, endpoints.StrictMatchingOption)
+	return err == nil
 }

--- a/pkg/aws/services/wafv2.go
+++ b/pkg/aws/services/wafv2.go
@@ -1,0 +1,23 @@
+package services
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/wafv2"
+	"github.com/aws/aws-sdk-go/service/wafv2/wafv2iface"
+)
+
+type WAFv2 interface {
+	wafv2iface.WAFV2API
+}
+
+// NewWAFv2 constructs new WAFv2 implementation.
+func NewWAFv2(session *session.Session) WAFv2 {
+	return &defaultWAFv2{
+		WAFV2API: wafv2.New(session),
+	}
+}
+
+// default implementation for WAFv2.
+type defaultWAFv2 struct {
+	wafv2iface.WAFV2API
+}

--- a/pkg/deploy/shield/protection_manager.go
+++ b/pkg/deploy/shield/protection_manager.go
@@ -1,0 +1,123 @@
+package shield
+
+import (
+	"context"
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	shieldsdk "github.com/aws/aws-sdk-go/service/shield"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/cache"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws/services"
+	"time"
+)
+
+const defaultProtectionInfoByResourceARNCacheTTL = 10 * time.Minute
+
+type ProtectionManager interface {
+	// CreateProtection creates shield protection for resource. returns protectionID.
+	CreateProtection(ctx context.Context, resourceARN string, protectionName string) (string, error)
+
+	// DeleteProtection deletes shield protection for resource.
+	DeleteProtection(ctx context.Context, resourceARN string, protectionID string) error
+
+	// GetProtection returns shield protection information for resource.
+	// returns nil if no protection exists.
+	GetProtection(ctx context.Context, resourceARN string) (*ProtectionInfo, error)
+}
+
+func NewDefaultProtectionManager(shieldClient services.Shield, logger logr.Logger) *defaultProtectionManager {
+	return &defaultProtectionManager{
+		shieldClient:                        shieldClient,
+		logger:                              logger,
+		protectionInfoByResourceARNCache:    cache.NewExpiring(),
+		protectionInfoByResourceARNCacheTTL: defaultProtectionInfoByResourceARNCacheTTL,
+	}
+}
+
+var _ ProtectionManager = &defaultProtectionManager{}
+
+type defaultProtectionManager struct {
+	shieldClient services.Shield
+	logger       logr.Logger
+
+	protectionInfoByResourceARNCache    *cache.Expiring
+	protectionInfoByResourceARNCacheTTL time.Duration
+}
+
+type ProtectionInfo struct {
+	Name string
+	ID   string
+}
+
+func (m *defaultProtectionManager) CreateProtection(ctx context.Context, resourceARN string, protectionName string) (string, error) {
+	req := &shieldsdk.CreateProtectionInput{
+		ResourceArn: awssdk.String(resourceARN),
+		Name:        awssdk.String(protectionName),
+	}
+	m.logger.Info("enabling shield protection",
+		"resourceARN", resourceARN,
+		"protectionName", protectionName)
+	resp, err := m.shieldClient.CreateProtectionWithContext(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	protectionID := awssdk.StringValue(resp.ProtectionId)
+	m.logger.Info("enabled shield protection",
+		"resourceARN", resourceARN,
+		"protectionName", protectionName,
+		"protectionID", protectionID)
+	protectionInfo := &ProtectionInfo{
+		Name: protectionName,
+		ID:   protectionID,
+	}
+	m.protectionInfoByResourceARNCache.Set(resourceARN, protectionInfo, m.protectionInfoByResourceARNCacheTTL)
+	return protectionID, nil
+}
+
+func (m *defaultProtectionManager) DeleteProtection(ctx context.Context, resourceARN string, protectionID string) error {
+	req := &shieldsdk.DeleteProtectionInput{
+		ProtectionId: awssdk.String(protectionID),
+	}
+	m.logger.Info("disabling shield protection",
+		"resourceARN", resourceARN,
+		"protectionID", protectionID)
+	_, err := m.shieldClient.DeleteProtectionWithContext(ctx, req)
+	if err != nil {
+		return err
+	}
+	m.logger.Info("disabled shield protection",
+		"resourceARN", resourceARN)
+
+	var protectionInfo *ProtectionInfo
+	m.protectionInfoByResourceARNCache.Set(resourceARN, protectionInfo, m.protectionInfoByResourceARNCacheTTL)
+	return nil
+}
+
+func (m *defaultProtectionManager) GetProtection(ctx context.Context, resourceARN string) (*ProtectionInfo, error) {
+	rawCacheItem, exists := m.protectionInfoByResourceARNCache.Get(resourceARN)
+	if exists {
+		return rawCacheItem.(*ProtectionInfo), nil
+	}
+
+	req := &shieldsdk.DescribeProtectionInput{
+		ResourceArn: awssdk.String(resourceARN),
+	}
+	resp, err := m.shieldClient.DescribeProtectionWithContext(ctx, req)
+	var protectionInfo *ProtectionInfo
+	if err != nil {
+		aerr, ok := err.(awserr.Error)
+		if ok && aerr.Code() == shieldsdk.ErrCodeResourceNotFoundException {
+			protectionInfo = nil
+		} else {
+			return nil, err
+		}
+	}
+	if resp.Protection != nil {
+		protectionInfo = &ProtectionInfo{
+			Name: awssdk.StringValue(resp.Protection.Name),
+			ID:   awssdk.StringValue(resp.Protection.Id),
+		}
+	}
+	m.protectionInfoByResourceARNCache.Set(resourceARN, protectionInfo, m.protectionInfoByResourceARNCacheTTL)
+	return protectionInfo, nil
+}

--- a/pkg/deploy/shield/protection_synthesizer.go
+++ b/pkg/deploy/shield/protection_synthesizer.go
@@ -1,0 +1,106 @@
+package shield
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+	elbv2model "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/elbv2"
+	shieldmodel "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/shield"
+)
+
+const (
+	protectionNameManaged       = "managed by aws-load-balancer-controller"
+	protectionNameManagedLegacy = "managed by aws-alb-ingress-controller"
+)
+
+// NewProtectionSynthesizer constructs new protectionSynthesizer
+func NewProtectionSynthesizer(protectionManager ProtectionManager, logger logr.Logger, stack core.Stack) *protectionSynthesizer {
+	return &protectionSynthesizer{
+		protectionManager: protectionManager,
+		logger:            logger,
+		stack:             stack,
+	}
+}
+
+type protectionSynthesizer struct {
+	protectionManager ProtectionManager
+	logger            logr.Logger
+	stack             core.Stack
+}
+
+func (s *protectionSynthesizer) Synthesize(ctx context.Context) error {
+	var resProtections []*shieldmodel.Protection
+	s.stack.ListResources(&resProtections)
+	resProtectionsByResARN, err := mapResProtectionByResourceARN(resProtections)
+	if err != nil {
+		return err
+	}
+
+	var resLBs []*elbv2model.LoadBalancer
+	s.stack.ListResources(&resLBs)
+	for _, resLB := range resLBs {
+		lbARN, err := resLB.LoadBalancerARN().Resolve(ctx)
+		if err != nil {
+			return err
+		}
+		resProtections := resProtectionsByResARN[lbARN]
+		if err := s.synthesizeProtectionsOnLB(ctx, lbARN, resProtections); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *protectionSynthesizer) PostSynthesize(ctx context.Context) error {
+	// nothing to do here.
+	return nil
+}
+
+func (s *protectionSynthesizer) synthesizeProtectionsOnLB(ctx context.Context, lbARN string, resProtections []*shieldmodel.Protection) error {
+	if len(resProtections) > 1 {
+		return errors.Errorf("[should never happen] multiple shield protection desired on LoadBalancer: %v", lbARN)
+	}
+
+	enableProtection := false
+	if len(resProtections) == 1 {
+		enableProtection = true
+	}
+
+	protectionInfo, err := s.protectionManager.GetProtection(ctx, lbARN)
+	if err != nil {
+		return err
+	}
+	switch {
+	case !enableProtection && protectionInfo != nil:
+		managedProtectionNames := sets.NewString(protectionNameManaged, protectionNameManagedLegacy)
+		if managedProtectionNames.Has(protectionInfo.Name) {
+			if err := s.protectionManager.DeleteProtection(ctx, lbARN, protectionInfo.ID); err != nil {
+				return errors.Wrap(err, "failed to delete shield protection on LoadBalancer")
+			}
+		} else {
+			s.logger.Info("ignoring unmanaged shield protection",
+				"protectionName", protectionInfo.Name,
+				"protectionID", protectionInfo.ID)
+		}
+	case enableProtection && protectionInfo == nil:
+		if _, err := s.protectionManager.CreateProtection(ctx, lbARN, protectionNameManaged); err != nil {
+			return errors.Wrap(err, "failed to create shield protection on LoadBalancer")
+		}
+	}
+	return nil
+}
+
+func mapResProtectionByResourceARN(resProtections []*shieldmodel.Protection) (map[string][]*shieldmodel.Protection, error) {
+	resProtectionsByResARN := make(map[string][]*shieldmodel.Protection, len(resProtections))
+	ctx := context.Background()
+	for _, resProtection := range resProtections {
+		resARN, err := resProtection.Spec.ResourceARN.Resolve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		resProtectionsByResARN[resARN] = append(resProtectionsByResARN[resARN], resProtection)
+	}
+	return resProtectionsByResARN, nil
+}

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -3,10 +3,14 @@ package deploy
 import (
 	"context"
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/deploy/ec2"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/deploy/elbv2"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/deploy/shield"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/deploy/tagging"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/deploy/wafregional"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/deploy/wafv2"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
 	"sigs.k8s.io/aws-alb-ingress-controller/pkg/networking"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,27 +23,30 @@ type StackDeployer interface {
 }
 
 // NewDefaultStackDeployer constructs new defaultStackDeployer.
-func NewDefaultStackDeployer(k8sClient client.Client, ec2Client services.EC2, elbv2Client services.ELBV2,
+func NewDefaultStackDeployer(cloud aws.Cloud, k8sClient client.Client,
 	networkingSGManager networking.SecurityGroupManager, networkingSGReconciler networking.SecurityGroupReconciler,
-	vpcID string, clusterName string, tagPrefix string, logger logr.Logger) *defaultStackDeployer {
+	clusterName string, tagPrefix string, logger logr.Logger) *defaultStackDeployer {
 	taggingProvider := tagging.NewDefaultProvider(tagPrefix, clusterName)
-	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(elbv2Client, logger)
+	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), logger)
 
 	return &defaultStackDeployer{
-		k8sClient:           k8sClient,
-		ec2Client:           ec2Client,
-		elbv2Client:         elbv2Client,
-		taggingProvider:     taggingProvider,
-		networkingSGManager: networkingSGManager,
-		ec2SGManager:        ec2.NewDefaultSecurityGroupManager(ec2Client, taggingProvider, networkingSGReconciler, vpcID, logger),
-		elbv2TaggingManager: elbv2TaggingManager,
-		elbv2LBManager:      elbv2.NewDefaultLoadBalancerManager(elbv2Client, taggingProvider, elbv2TaggingManager, logger),
-		elbv2LSManager:      elbv2.NewDefaultListenerManager(elbv2Client, logger),
-		elbv2LRManager:      elbv2.NewDefaultListenerRuleManager(elbv2Client, logger),
-		elbv2TGManager:      elbv2.NewDefaultTargetGroupManager(elbv2Client, taggingProvider, elbv2TaggingManager, vpcID, logger),
-		elbv2TGBManager:     elbv2.NewDefaultTargetGroupBindingManager(k8sClient, taggingProvider, logger),
-		vpcID:               vpcID,
-		logger:              logger,
+		k8sClient:                           k8sClient,
+		ec2Client:                           cloud.EC2(),
+		elbv2Client:                         cloud.ELBV2(),
+		taggingProvider:                     taggingProvider,
+		networkingSGManager:                 networkingSGManager,
+		ec2SGManager:                        ec2.NewDefaultSecurityGroupManager(cloud.EC2(), taggingProvider, networkingSGReconciler, cloud.VpcID(), logger),
+		elbv2TaggingManager:                 elbv2TaggingManager,
+		elbv2LBManager:                      elbv2.NewDefaultLoadBalancerManager(cloud.ELBV2(), taggingProvider, elbv2TaggingManager, logger),
+		elbv2LSManager:                      elbv2.NewDefaultListenerManager(cloud.ELBV2(), logger),
+		elbv2LRManager:                      elbv2.NewDefaultListenerRuleManager(cloud.ELBV2(), logger),
+		elbv2TGManager:                      elbv2.NewDefaultTargetGroupManager(cloud.ELBV2(), taggingProvider, elbv2TaggingManager, cloud.VpcID(), logger),
+		elbv2TGBManager:                     elbv2.NewDefaultTargetGroupBindingManager(k8sClient, taggingProvider, logger),
+		wafv2WebACLAssociationManager:       wafv2.NewDefaultWebACLAssociationManager(cloud.WAFv2(), logger),
+		wafRegionalWebACLAssociationManager: wafregional.NewDefaultWebACLAssociationManager(cloud.WAFRegional(), logger),
+		shieldProtectionManager:             shield.NewDefaultProtectionManager(cloud.Shield(), logger),
+		vpcID:                               cloud.VpcID(),
+		logger:                              logger,
 	}
 }
 
@@ -47,19 +54,22 @@ var _ StackDeployer = &defaultStackDeployer{}
 
 // defaultStackDeployer is the default implementation for StackDeployer
 type defaultStackDeployer struct {
-	k8sClient           client.Client
-	ec2Client           services.EC2
-	elbv2Client         services.ELBV2
-	taggingProvider     tagging.Provider
-	networkingSGManager networking.SecurityGroupManager
-	ec2SGManager        ec2.SecurityGroupManager
-	elbv2TaggingManager elbv2.TaggingManager
-	elbv2LBManager      elbv2.LoadBalancerManager
-	elbv2LSManager      elbv2.ListenerManager
-	elbv2LRManager      elbv2.ListenerRuleManager
-	elbv2TGManager      elbv2.TargetGroupManager
-	elbv2TGBManager     elbv2.TargetGroupBindingManager
-	vpcID               string
+	k8sClient                           client.Client
+	ec2Client                           services.EC2
+	elbv2Client                         services.ELBV2
+	taggingProvider                     tagging.Provider
+	networkingSGManager                 networking.SecurityGroupManager
+	ec2SGManager                        ec2.SecurityGroupManager
+	elbv2TaggingManager                 elbv2.TaggingManager
+	elbv2LBManager                      elbv2.LoadBalancerManager
+	elbv2LSManager                      elbv2.ListenerManager
+	elbv2LRManager                      elbv2.ListenerRuleManager
+	elbv2TGManager                      elbv2.TargetGroupManager
+	elbv2TGBManager                     elbv2.TargetGroupBindingManager
+	wafv2WebACLAssociationManager       wafv2.WebACLAssociationManager
+	wafRegionalWebACLAssociationManager wafregional.WebACLAssociationManager
+	shieldProtectionManager             shield.ProtectionManager
+	vpcID                               string
 
 	logger logr.Logger
 }
@@ -78,6 +88,9 @@ func (d *defaultStackDeployer) Deploy(ctx context.Context, stack core.Stack) err
 		elbv2.NewLoadBalancerSynthesizer(d.elbv2Client, d.taggingProvider, d.elbv2TaggingManager, d.elbv2LBManager, d.logger, stack),
 		elbv2.NewListenerSynthesizer(d.elbv2Client, d.elbv2LSManager, d.logger, stack),
 		elbv2.NewListenerRuleSynthesizer(d.elbv2Client, d.elbv2LRManager, d.logger, stack),
+		wafv2.NewWebACLAssociationSynthesizer(d.wafv2WebACLAssociationManager, d.logger, stack),
+		wafregional.NewWebACLAssociationSynthesizer(d.wafRegionalWebACLAssociationManager, d.logger, stack),
+		shield.NewProtectionSynthesizer(d.shieldProtectionManager, d.logger, stack),
 	}
 	for _, synthesizer := range synthesizers {
 		if err := synthesizer.Synthesize(ctx); err != nil {

--- a/pkg/deploy/wafregional/web_acl_association_manager.go
+++ b/pkg/deploy/wafregional/web_acl_association_manager.go
@@ -1,0 +1,105 @@
+package wafregional
+
+import (
+	"context"
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	wafregionalsdk "github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/cache"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws/services"
+	"time"
+)
+
+const defaultWebACLIDByResourceARNCacheTTL = 10 * time.Minute
+
+// WebACLAssociationManager is responsible for manage WAFRegion webACL associations.
+type WebACLAssociationManager interface {
+	// AssociateWebACL associate webACL to resources.
+	AssociateWebACL(ctx context.Context, resourceARN string, webACLID string) error
+
+	// DisassociateWebACL disassociate webACL from resources.
+	DisassociateWebACL(ctx context.Context, resourceARN string) error
+
+	// GetAssociatedWebACL returns the associated webACL for resource, returns empty if no webACL is associated.
+	GetAssociatedWebACL(ctx context.Context, resourceARN string) (string, error)
+}
+
+// NewDefaultWebACLAssociationManager constructs new defaultWebACLAssociationManager.
+func NewDefaultWebACLAssociationManager(wafRegionalClient services.WAFRegional, logger logr.Logger) *defaultWebACLAssociationManager {
+	return &defaultWebACLAssociationManager{
+		wafRegionalClient:             wafRegionalClient,
+		logger:                        logger,
+		webACLIDByResourceARNCache:    cache.NewExpiring(),
+		webACLIDByResourceARNCacheTTL: defaultWebACLIDByResourceARNCacheTTL,
+	}
+}
+
+var _ WebACLAssociationManager = &defaultWebACLAssociationManager{}
+
+// default implementation for WebACLAssociationManager.
+type defaultWebACLAssociationManager struct {
+	wafRegionalClient services.WAFRegional
+	logger            logr.Logger
+
+	// cache that stores webACLARN indexed by resourceARN
+	// The cache value is string, while "" represents no webACL.
+	webACLIDByResourceARNCache *cache.Expiring
+	// ttl for webACLARNByResourceARNCache
+	webACLIDByResourceARNCacheTTL time.Duration
+}
+
+func (m *defaultWebACLAssociationManager) AssociateWebACL(ctx context.Context, resourceARN string, webACLID string) error {
+	req := &wafregionalsdk.AssociateWebACLInput{
+		ResourceArn: awssdk.String(resourceARN),
+		WebACLId:    awssdk.String(webACLID),
+	}
+	m.logger.Info("associating WAFRegional webACL",
+		"resourceARN", resourceARN,
+		"webACLID", webACLID)
+	if _, err := m.wafRegionalClient.AssociateWebACLWithContext(ctx, req); err != nil {
+		return err
+	}
+	m.logger.Info("associated WAFRegional webACL",
+		"resourceARN", resourceARN,
+		"webACLID", webACLID)
+	m.webACLIDByResourceARNCache.Set(resourceARN, webACLID, m.webACLIDByResourceARNCacheTTL)
+	return nil
+}
+
+func (m *defaultWebACLAssociationManager) DisassociateWebACL(ctx context.Context, resourceARN string) error {
+	req := &wafregionalsdk.DisassociateWebACLInput{
+		ResourceArn: awssdk.String(resourceARN),
+	}
+	m.logger.Info("disassociating WAFRegional webACL",
+		"resourceARN", resourceARN)
+	if _, err := m.wafRegionalClient.DisassociateWebACLWithContext(ctx, req); err != nil {
+		return err
+	}
+	m.logger.Info("disassociated WAFRegional webACL",
+		"resourceARN", resourceARN)
+	m.webACLIDByResourceARNCache.Set(resourceARN, "", m.webACLIDByResourceARNCacheTTL)
+	return nil
+}
+
+func (m *defaultWebACLAssociationManager) GetAssociatedWebACL(ctx context.Context, resourceARN string) (string, error) {
+	rawCacheItem, exists := m.webACLIDByResourceARNCache.Get(resourceARN)
+	if exists {
+		return rawCacheItem.(string), nil
+	}
+
+	req := &wafregionalsdk.GetWebACLForResourceInput{
+		ResourceArn: awssdk.String(resourceARN),
+	}
+
+	resp, err := m.wafRegionalClient.GetWebACLForResourceWithContext(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	var webACLID string
+	if resp.WebACLSummary != nil {
+		webACLID = awssdk.StringValue(resp.WebACLSummary.WebACLId)
+	}
+
+	m.webACLIDByResourceARNCache.Set(resourceARN, webACLID, m.webACLIDByResourceARNCacheTTL)
+	return webACLID, nil
+}

--- a/pkg/deploy/wafregional/web_acl_association_synthesizer.go
+++ b/pkg/deploy/wafregional/web_acl_association_synthesizer.go
@@ -1,0 +1,96 @@
+package wafregional
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+	elbv2model "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/elbv2"
+	wafregionalmodel "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/wafregional"
+)
+
+// NewWebACLAssociationSynthesizer constructs new webACLAssociationSynthesizer.
+func NewWebACLAssociationSynthesizer(associationManager WebACLAssociationManager, logger logr.Logger, stack core.Stack) *webACLAssociationSynthesizer {
+	return &webACLAssociationSynthesizer{
+		associationManager: associationManager,
+		logger:             logger,
+		stack:              stack,
+	}
+}
+
+type webACLAssociationSynthesizer struct {
+	associationManager WebACLAssociationManager
+	logger             logr.Logger
+	stack              core.Stack
+}
+
+func (s *webACLAssociationSynthesizer) Synthesize(ctx context.Context) error {
+	var resAssociations []*wafregionalmodel.WebACLAssociation
+	s.stack.ListResources(&resAssociations)
+	resAssociationsByResARN, err := mapResWebACLAssociationByResourceARN(resAssociations)
+	if err != nil {
+		return err
+	}
+
+	var resLBs []*elbv2model.LoadBalancer
+	s.stack.ListResources(&resLBs)
+	for _, resLB := range resLBs {
+		lbARN, err := resLB.LoadBalancerARN().Resolve(ctx)
+		if err != nil {
+			return err
+		}
+		resAssociations := resAssociationsByResARN[lbARN]
+		if err := s.synthesizeWebACLAssociationsOnLB(ctx, lbARN, resAssociations); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *webACLAssociationSynthesizer) PostSynthesize(ctx context.Context) error {
+	// nothing to do here.
+	return nil
+}
+
+func (s *webACLAssociationSynthesizer) synthesizeWebACLAssociationsOnLB(ctx context.Context, lbARN string, resAssociations []*wafregionalmodel.WebACLAssociation) error {
+	if len(resAssociations) > 1 {
+		return errors.Errorf("[should never happen] multiple WAFRegional webACL desired on LoadBalancer: %v", lbARN)
+	}
+
+	var desiredWebACLID string
+	if len(resAssociations) == 1 {
+		desiredWebACLID = resAssociations[0].Spec.WebACLID
+	}
+	currentWebACLID, err := s.associationManager.GetAssociatedWebACL(ctx, lbARN)
+	if err != nil {
+		return err
+	}
+	switch {
+	case desiredWebACLID == "" && currentWebACLID != "":
+		if err := s.associationManager.DisassociateWebACL(ctx, lbARN); err != nil {
+			return errors.Wrap(err, "failed to delete WAFv2 WAFRegional association on LoadBalancer")
+		}
+	case desiredWebACLID != "" && currentWebACLID == "":
+		if err := s.associationManager.AssociateWebACL(ctx, lbARN, desiredWebACLID); err != nil {
+			return errors.Wrap(err, "failed to create WAFv2 WAFRegional association on LoadBalancer")
+		}
+	case desiredWebACLID != "" && currentWebACLID != "" && desiredWebACLID != currentWebACLID:
+		if err := s.associationManager.AssociateWebACL(ctx, lbARN, desiredWebACLID); err != nil {
+			return errors.Wrap(err, "failed to update WAFv2 WAFRegional association on LoadBalancer")
+		}
+	}
+	return nil
+}
+
+func mapResWebACLAssociationByResourceARN(resAssociations []*wafregionalmodel.WebACLAssociation) (map[string][]*wafregionalmodel.WebACLAssociation, error) {
+	resAssociationsByResARN := make(map[string][]*wafregionalmodel.WebACLAssociation, len(resAssociations))
+	ctx := context.Background()
+	for _, resAssociation := range resAssociations {
+		resARN, err := resAssociation.Spec.ResourceARN.Resolve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		resAssociationsByResARN[resARN] = append(resAssociationsByResARN[resARN], resAssociation)
+	}
+	return resAssociationsByResARN, nil
+}

--- a/pkg/deploy/wafv2/web_acl_association_manager.go
+++ b/pkg/deploy/wafv2/web_acl_association_manager.go
@@ -1,0 +1,105 @@
+package wafv2
+
+import (
+	"context"
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	wafv2sdk "github.com/aws/aws-sdk-go/service/wafv2"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/cache"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/aws/services"
+	"time"
+)
+
+const defaultWebACLARNByResourceARNCacheTTL = 10 * time.Minute
+
+// WebACLAssociationManager is responsible for manage WAFv2 webACL associations.
+type WebACLAssociationManager interface {
+	// AssociateWebACL associate webACL to resources.
+	AssociateWebACL(ctx context.Context, resourceARN string, webACLARN string) error
+
+	// DisassociateWebACL disassociate webACL from resources.
+	DisassociateWebACL(ctx context.Context, resourceARN string) error
+
+	// GetAssociatedWebACL returns the associated webACL for resource, returns empty if no webACL is associated.
+	GetAssociatedWebACL(ctx context.Context, resourceARN string) (string, error)
+}
+
+// NewDefaultWebACLAssociationManager constructs new defaultWebACLAssociationManager.
+func NewDefaultWebACLAssociationManager(wafv2Client services.WAFv2, logger logr.Logger) *defaultWebACLAssociationManager {
+	return &defaultWebACLAssociationManager{
+		wafv2Client:                    wafv2Client,
+		logger:                         logger,
+		webACLARNByResourceARNCache:    cache.NewExpiring(),
+		webACLARNByResourceARNCacheTTL: defaultWebACLARNByResourceARNCacheTTL,
+	}
+}
+
+var _ WebACLAssociationManager = &defaultWebACLAssociationManager{}
+
+// default implementation for WebACLAssociationManager.
+type defaultWebACLAssociationManager struct {
+	wafv2Client services.WAFv2
+	logger      logr.Logger
+
+	// cache that stores webACLARN indexed by resourceARN
+	// The cache value is string, while "" represents no webACL.
+	webACLARNByResourceARNCache *cache.Expiring
+	// ttl for webACLARNByResourceARNCache
+	webACLARNByResourceARNCacheTTL time.Duration
+}
+
+func (m *defaultWebACLAssociationManager) AssociateWebACL(ctx context.Context, resourceARN string, webACLARN string) error {
+	req := &wafv2sdk.AssociateWebACLInput{
+		ResourceArn: awssdk.String(resourceARN),
+		WebACLArn:   awssdk.String(webACLARN),
+	}
+	m.logger.Info("associating WAFv2 webACL",
+		"resourceARN", resourceARN,
+		"webACLARN", webACLARN)
+	if _, err := m.wafv2Client.AssociateWebACLWithContext(ctx, req); err != nil {
+		return err
+	}
+	m.logger.Info("associated WAFv2 webACL",
+		"resourceARN", resourceARN,
+		"webACLARN", webACLARN)
+	m.webACLARNByResourceARNCache.Set(resourceARN, webACLARN, m.webACLARNByResourceARNCacheTTL)
+	return nil
+}
+
+func (m *defaultWebACLAssociationManager) DisassociateWebACL(ctx context.Context, resourceARN string) error {
+	req := &wafv2sdk.DisassociateWebACLInput{
+		ResourceArn: awssdk.String(resourceARN),
+	}
+	m.logger.Info("disassociating WAFv2 webACL",
+		"resourceARN", resourceARN)
+	if _, err := m.wafv2Client.DisassociateWebACLWithContext(ctx, req); err != nil {
+		return err
+	}
+	m.logger.Info("disassociated WAFv2 webACL",
+		"resourceARN", resourceARN)
+	m.webACLARNByResourceARNCache.Set(resourceARN, "", m.webACLARNByResourceARNCacheTTL)
+	return nil
+}
+
+func (m *defaultWebACLAssociationManager) GetAssociatedWebACL(ctx context.Context, resourceARN string) (string, error) {
+	rawCacheItem, exists := m.webACLARNByResourceARNCache.Get(resourceARN)
+	if exists {
+		return rawCacheItem.(string), nil
+	}
+
+	req := &wafv2sdk.GetWebACLForResourceInput{
+		ResourceArn: awssdk.String(resourceARN),
+	}
+
+	resp, err := m.wafv2Client.GetWebACLForResourceWithContext(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	var webACLARN string
+	if resp.WebACL != nil {
+		webACLARN = awssdk.StringValue(resp.WebACL.ARN)
+	}
+
+	m.webACLARNByResourceARNCache.Set(resourceARN, webACLARN, m.webACLARNByResourceARNCacheTTL)
+	return webACLARN, nil
+}

--- a/pkg/deploy/wafv2/web_acl_association_synthesizer.go
+++ b/pkg/deploy/wafv2/web_acl_association_synthesizer.go
@@ -1,0 +1,96 @@
+package wafv2
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+	elbv2model "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/elbv2"
+	wafv2model "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/wafv2"
+)
+
+// NewWebACLAssociationSynthesizer constructs new webACLAssociationSynthesizer.
+func NewWebACLAssociationSynthesizer(associationManager WebACLAssociationManager, logger logr.Logger, stack core.Stack) *webACLAssociationSynthesizer {
+	return &webACLAssociationSynthesizer{
+		associationManager: associationManager,
+		logger:             logger,
+		stack:              stack,
+	}
+}
+
+type webACLAssociationSynthesizer struct {
+	associationManager WebACLAssociationManager
+	logger             logr.Logger
+	stack              core.Stack
+}
+
+func (s *webACLAssociationSynthesizer) Synthesize(ctx context.Context) error {
+	var resAssociations []*wafv2model.WebACLAssociation
+	s.stack.ListResources(&resAssociations)
+	resAssociationsByResARN, err := mapResWebACLAssociationByResourceARN(resAssociations)
+	if err != nil {
+		return err
+	}
+
+	var resLBs []*elbv2model.LoadBalancer
+	s.stack.ListResources(&resLBs)
+	for _, resLB := range resLBs {
+		lbARN, err := resLB.LoadBalancerARN().Resolve(ctx)
+		if err != nil {
+			return err
+		}
+		resAssociations := resAssociationsByResARN[lbARN]
+		if err := s.synthesizeWebACLAssociationsOnLB(ctx, lbARN, resAssociations); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *webACLAssociationSynthesizer) PostSynthesize(ctx context.Context) error {
+	// nothing to do here.
+	return nil
+}
+
+func (s *webACLAssociationSynthesizer) synthesizeWebACLAssociationsOnLB(ctx context.Context, lbARN string, resAssociations []*wafv2model.WebACLAssociation) error {
+	if len(resAssociations) > 1 {
+		return errors.Errorf("[should never happen] multiple WAFv2 webACL desired on LoadBalancer: %v", lbARN)
+	}
+
+	var desiredWebACLARN string
+	if len(resAssociations) == 1 {
+		desiredWebACLARN = resAssociations[0].Spec.WebACLARN
+	}
+	currentWebACLARN, err := s.associationManager.GetAssociatedWebACL(ctx, lbARN)
+	if err != nil {
+		return err
+	}
+	switch {
+	case desiredWebACLARN == "" && currentWebACLARN != "":
+		if err := s.associationManager.DisassociateWebACL(ctx, lbARN); err != nil {
+			return errors.Wrap(err, "failed to delete WAFv2 webACL association on LoadBalancer")
+		}
+	case desiredWebACLARN != "" && currentWebACLARN == "":
+		if err := s.associationManager.AssociateWebACL(ctx, lbARN, desiredWebACLARN); err != nil {
+			return errors.Wrap(err, "failed to create WAFv2 webACL association on LoadBalancer")
+		}
+	case desiredWebACLARN != "" && currentWebACLARN != "" && desiredWebACLARN != currentWebACLARN:
+		if err := s.associationManager.AssociateWebACL(ctx, lbARN, desiredWebACLARN); err != nil {
+			return errors.Wrap(err, "failed to update WAFv2 webACL association on LoadBalancer")
+		}
+	}
+	return nil
+}
+
+func mapResWebACLAssociationByResourceARN(resAssociations []*wafv2model.WebACLAssociation) (map[string][]*wafv2model.WebACLAssociation, error) {
+	resAssociationsByResARN := make(map[string][]*wafv2model.WebACLAssociation, len(resAssociations))
+	ctx := context.Background()
+	for _, resAssociation := range resAssociations {
+		resARN, err := resAssociation.Spec.ResourceARN.Resolve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		resAssociationsByResARN[resARN] = append(resAssociationsByResARN[resARN], resAssociation)
+	}
+	return resAssociationsByResARN, nil
+}

--- a/pkg/ingress/model_build_load_balancer_addons.go
+++ b/pkg/ingress/model_build_load_balancer_addons.go
@@ -1,0 +1,104 @@
+package ingress
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/annotations"
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+	shieldmodel "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/shield"
+	wafregionalmodel "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/wafregional"
+	wafv2model "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/wafv2"
+)
+
+func (t *defaultModelBuildTask) buildLoadBalancerAddOns(ctx context.Context, lbARN core.StringToken) error {
+	if _, err := t.buildWAFv2WebACLAssociation(ctx, lbARN); err != nil {
+		return err
+	}
+	if _, err := t.buildWAFRegionalWebACLAssociation(ctx, lbARN); err != nil {
+		return err
+	}
+	if _, err := t.buildShieldProtection(ctx, lbARN); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *defaultModelBuildTask) buildWAFv2WebACLAssociation(_ context.Context, lbARN core.StringToken) (*wafv2model.WebACLAssociation, error) {
+	explicitWebACLARNs := sets.NewString()
+	for _, ing := range t.ingGroup.Members {
+		rawWebACLARN := ""
+		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWAFv2ACLARN, &rawWebACLARN, ing.Annotations); exists {
+			explicitWebACLARNs.Insert(rawWebACLARN)
+		}
+	}
+	if len(explicitWebACLARNs) == 0 {
+		return nil, nil
+	}
+	if len(explicitWebACLARNs) > 1 {
+		return nil, errors.Errorf("conflicting WAFv2 WebACL ARNs: %v", explicitWebACLARNs.List())
+	}
+	webACLARN, _ := explicitWebACLARNs.PopAny()
+	if webACLARN != "" {
+		association := wafv2model.NewWebACLAssociation(t.stack, resourceIDLoadBalancer, wafv2model.WebACLAssociationSpec{
+			WebACLARN:   webACLARN,
+			ResourceARN: lbARN,
+		})
+		return association, nil
+	}
+	return nil, nil
+}
+
+func (t *defaultModelBuildTask) buildWAFRegionalWebACLAssociation(_ context.Context, lbARN core.StringToken) (*wafregionalmodel.WebACLAssociation, error) {
+	explicitWebACLIDs := sets.NewString()
+	for _, ing := range t.ingGroup.Members {
+		rawWebACLARN := ""
+		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWAFACLID, &rawWebACLARN, ing.Annotations); exists {
+			explicitWebACLIDs.Insert(rawWebACLARN)
+		} else if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWebACLID, &rawWebACLARN, ing.Annotations); exists {
+			explicitWebACLIDs.Insert(rawWebACLARN)
+		}
+	}
+	if len(explicitWebACLIDs) == 0 {
+		return nil, nil
+	}
+	if len(explicitWebACLIDs) > 1 {
+		return nil, errors.Errorf("conflicting WAFRegional WebACL IDs: %v", explicitWebACLIDs.List())
+	}
+	webACLID, _ := explicitWebACLIDs.PopAny()
+	if webACLID != "" {
+		association := wafregionalmodel.NewWebACLAssociation(t.stack, resourceIDLoadBalancer, wafregionalmodel.WebACLAssociationSpec{
+			WebACLID:    webACLID,
+			ResourceARN: lbARN,
+		})
+		return association, nil
+	}
+	return nil, nil
+}
+
+func (t *defaultModelBuildTask) buildShieldProtection(_ context.Context, lbARN core.StringToken) (*shieldmodel.Protection, error) {
+	explicitEnableProtections := make(map[bool]struct{})
+	for _, ing := range t.ingGroup.Members {
+		rawEnableProtection := false
+		exists, err := t.annotationParser.ParseBoolAnnotation(annotations.IngressSuffixShieldAdvancedProtection, &rawEnableProtection, ing.Annotations)
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			explicitEnableProtections[rawEnableProtection] = struct{}{}
+		}
+	}
+	if len(explicitEnableProtections) == 0 {
+		return nil, nil
+	}
+	if len(explicitEnableProtections) > 1 {
+		return nil, errors.New("conflicting enable shield advanced protection")
+	}
+	if _, enableProtection := explicitEnableProtections[true]; enableProtection {
+		protection := shieldmodel.NewProtection(t.stack, resourceIDLoadBalancer, shieldmodel.ProtectionSpec{
+			ResourceARN: lbARN,
+		})
+		return protection, nil
+	}
+	return nil, nil
+}

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -175,6 +175,10 @@ func (t *defaultModelBuildTask) run(ctx context.Context) error {
 			return err
 		}
 	}
+
+	if err := t.buildLoadBalancerAddOns(ctx, lb.LoadBalancerARN()); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/model/shield/protection.go
+++ b/pkg/model/shield/protection.go
@@ -1,0 +1,33 @@
+package shield
+
+import "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+
+type Protection struct {
+	core.ResourceMeta `json:"-"`
+
+	// desired state of Protection
+	Spec ProtectionSpec `json:"spec"`
+}
+
+// NewProtection constructs new Protection resource.
+func NewProtection(stack core.Stack, id string, spec ProtectionSpec) *Protection {
+	p := &Protection{
+		ResourceMeta: core.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::LoadBalancer", id),
+		Spec:         spec,
+	}
+	stack.AddResource(p)
+	p.registerDependencies(stack)
+	return p
+}
+
+// register dependencies for Protection.
+func (p *Protection) registerDependencies(stack core.Stack) {
+	for _, dep := range p.Spec.ResourceARN.Dependencies() {
+		stack.AddDependency(dep, p)
+	}
+}
+
+// ProtectionSpec defines the desired state of Protection.
+type ProtectionSpec struct {
+	ResourceARN core.StringToken `json:"resourceARN"`
+}

--- a/pkg/model/wafregional/web_acl_association.go
+++ b/pkg/model/wafregional/web_acl_association.go
@@ -1,0 +1,35 @@
+package wafregional
+
+import "sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+
+// WebACLAssociation represents a waf-region web-acl association.
+type WebACLAssociation struct {
+	core.ResourceMeta `json:"-"`
+
+	// desired state of WebACLAssociation
+	Spec WebACLAssociationSpec `json:"spec"`
+}
+
+// NewWebACLAssociation constructs new WebACLAssociation resource.
+func NewWebACLAssociation(stack core.Stack, id string, spec WebACLAssociationSpec) *WebACLAssociation {
+	a := &WebACLAssociation{
+		ResourceMeta: core.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::LoadBalancer", id),
+		Spec:         spec,
+	}
+	stack.AddResource(a)
+	a.registerDependencies(stack)
+	return a
+}
+
+// register dependencies for WebACLAssociation.
+func (a *WebACLAssociation) registerDependencies(stack core.Stack) {
+	for _, dep := range a.Spec.ResourceARN.Dependencies() {
+		stack.AddDependency(dep, a)
+	}
+}
+
+// WebACLAssociationSpec defines the desired state of LoadBalancer
+type WebACLAssociationSpec struct {
+	WebACLID    string           `json:"webACLID"`
+	ResourceARN core.StringToken `json:"resourceARN"`
+}

--- a/pkg/model/wafv2/web_acl_association.go
+++ b/pkg/model/wafv2/web_acl_association.go
@@ -1,0 +1,37 @@
+package wafv2
+
+import (
+	"sigs.k8s.io/aws-alb-ingress-controller/pkg/model/core"
+)
+
+// WebACLAssociation represents a waf v2 web-acl association.
+type WebACLAssociation struct {
+	core.ResourceMeta `json:"-"`
+
+	// desired state of WebACLAssociation
+	Spec WebACLAssociationSpec `json:"spec"`
+}
+
+// NewWebACLAssociation constructs new WebACLAssociation resource.
+func NewWebACLAssociation(stack core.Stack, id string, spec WebACLAssociationSpec) *WebACLAssociation {
+	a := &WebACLAssociation{
+		ResourceMeta: core.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::LoadBalancer", id),
+		Spec:         spec,
+	}
+	stack.AddResource(a)
+	a.registerDependencies(stack)
+	return a
+}
+
+// register dependencies for WebACLAssociation.
+func (a *WebACLAssociation) registerDependencies(stack core.Stack) {
+	for _, dep := range a.Spec.ResourceARN.Dependencies() {
+		stack.AddDependency(dep, a)
+	}
+}
+
+// WebACLAssociationSpec defines the desired state of LoadBalancer
+type WebACLAssociationSpec struct {
+	WebACLARN   string           `json:"webACLARN"`
+	ResourceARN core.StringToken `json:"resourceARN"`
+}


### PR DESCRIPTION
Add model/deployer/builder for LoadBalancer Addons(WAF/Shield)
Three addons are supported:
1. wafRegion webACLAssociation
2. wafv2 webACLAssociation
3. shield protection