### PR TITLE
add support for targetHealthReadinessGate in tgb

### DIFF
--- a/apis/elbv2/v1alpha1/targetgroupbinding_types.go
+++ b/apis/elbv2/v1alpha1/targetgroupbinding_types.go
@@ -26,7 +26,7 @@ type TargetType string
 
 const (
 	TargetTypeInstance TargetType = "instance"
-	TargetTypeIP                  = "ip"
+	TargetTypeIP       TargetType = "ip"
 )
 
 // ServiceReference defines reference to a Kubernetes Service and its ServicePort.

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- controller.yaml
+  - controller.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,50 +16,50 @@ bases:
   - ../crd
   - ../rbac
   - ../controller
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+  # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+  # crd/kustomization.yaml
+  - ../webhook
+  # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+  - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- controller_webhook_patch.yaml
+  # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+  # crd/kustomization.yaml
+  - controller_webhook_patch.yaml
 
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
-# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
-# 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+  # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+  # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+  # 'CERTMANAGER' needs to be enabled to use ca injection
+  - webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1alpha2
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1alpha2
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+  # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+    objref:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1alpha2
+      name: serving-cert # this name should match the one in certificate.yaml
+    fieldref:
+      fieldpath: metadata.namespace
+  - name: CERTIFICATE_NAME
+    objref:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1alpha2
+      name: serving-cert # this name should match the one in certificate.yaml
+  - name: SERVICE_NAMESPACE # namespace of the service
+    objref:
+      kind: Service
+      version: v1
+      name: webhook-service
+    fieldref:
+      fieldpath: metadata.namespace
+  - name: SERVICE_NAME
+    objref:
+      kind: Service
+      version: v1
+      name: webhook-service

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -3,13 +3,13 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-webhook-configuration
+  name: webhook
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: validating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+#apiVersion: admissionregistration.k8s.io/v1beta1
+#kind: ValidatingWebhookConfiguration
+#metadata:
+#  name: webhook
+#  annotations:
+#    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -4,3 +4,6 @@ resources:
 
 configurations:
   - kustomizeconfig.yaml
+
+patchesStrategicMerge:
+  - pod_mutator_patch.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,25 @@
+
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: webhook
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1-pod
+  failurePolicy: Fail
+  name: mpod.elbv2.k8s.aws
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods

--- a/config/webhook/pod_mutator_patch.yaml
+++ b/config/webhook/pod_mutator_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook
+webhooks:
+  - name: mpod.elbv2.k8s.aws
+    namespaceSelector:
+      matchExpressions:
+        - key: elbv2.k8s.aws/pod-readiness-gate-inject
+          operator: In
+          values:
+            - enabled

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/controllers/service"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/throttle"
-	podinjector "sigs.k8s.io/aws-load-balancer-controller/pkg/inject"
+	inject "sigs.k8s.io/aws-load-balancer-controller/pkg/inject"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/targetgroupbinding"
@@ -64,7 +64,7 @@ func main() {
 	var enableLeaderElection bool
 	var k8sClusterName string
 	awsCloudConfig := aws.CloudConfig{ThrottleConfig: throttle.NewDefaultServiceOperationsThrottleConfig()}
-	injectConfig := podinjector.Config{}
+	injectConfig := inject.Config{}
 	fs := pflag.NewFlagSet("", pflag.ExitOnError)
 	fs.StringVar(&metricsAddr, flagMetricsAddr, ":8080", "The address the metric endpoint binds to.")
 	fs.BoolVar(&enableLeaderElection, flagEnableLeaderElection, false,
@@ -138,8 +138,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	readinesGateInjector := podinjector.NewPodReadinessGate(injectConfig, mgr.GetClient(), ctrl.Log.WithName("readiness-gate-injector"))
-	corewebhook.NewPodMutator(readinesGateInjector) //.SetupWithManager(mgr)
+	podReadinessGateInjector := inject.NewPodReadinessGate(injectConfig, mgr.GetClient(), ctrl.Log.WithName("pod-readiness-gate-injector"))
+	corewebhook.NewPodMutator(podReadinessGateInjector).SetupWithManager(mgr)
 	// +kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -3,7 +3,7 @@ package inject
 import "github.com/spf13/pflag"
 
 const (
-	flagEnableReadinessInject = "enable-readiness-gate-inject"
+	flagEnablePodReadinessGateInject = "enable-pod-readiness-gate-inject"
 )
 
 type Config struct {
@@ -11,6 +11,6 @@ type Config struct {
 }
 
 func (cfg *Config) BindFlags(fs *pflag.FlagSet) {
-	fs.BoolVar(&cfg.EnablePodReadinessGateInject, flagEnableReadinessInject, false,
-		`If enabled, readiness gate config will get injected to the pod spec for the matching endpoint pods`)
+	fs.BoolVar(&cfg.EnablePodReadinessGateInject, flagEnablePodReadinessGateInject, true,
+		`If enabled, targetHealth readiness gate will get injected to the pod spec for the matching endpoint pods`)
 }

--- a/pkg/k8s/pod_utils.go
+++ b/pkg/k8s/pod_utils.go
@@ -32,6 +32,16 @@ func GetPodCondition(pod *corev1.Pod, conditionType corev1.PodConditionType) *co
 	return nil
 }
 
+// UpdatePodCondition will update Pod to contain specified condition.
+func UpdatePodCondition(pod *corev1.Pod, condition corev1.PodCondition) {
+	existingCond := GetPodCondition(pod, condition.Type)
+	if existingCond != nil {
+		*existingCond = condition
+		return
+	}
+	pod.Status.Conditions = append(pod.Status.Conditions, condition)
+}
+
 // LookupContainerPort returns the numerical containerPort for specific port on Pod.
 func LookupContainerPort(pod *corev1.Pod, port intstr.IntOrString) (int64, error) {
 	switch port.Type {

--- a/pkg/targetgroupbinding/utils.go
+++ b/pkg/targetgroupbinding/utils.go
@@ -1,14 +1,29 @@
 package targetgroupbinding
 
 import (
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1alpha1"
 )
 
-// Index Key for "ServiceReference" index.
-const IndexKeyServiceRefName = "spec.serviceRef.name"
-const IndexKeyTargetType = "spec.targetType"
+const (
+	// Prefix for TargetHealth pod condition type.
+	TargetHealthPodConditionTypePrefix = "target-health.elbv2.k8s.aws"
+	// Legacy Prefix for TargetHealth pod condition type(used by AWS ALB Ingress Controller)
+	TargetHealthPodConditionTypePrefixLegacy = "target-health.alb.ingress.k8s.aws"
+
+	// Index Key for "ServiceReference" index.
+	IndexKeyServiceRefName = "spec.serviceRef.name"
+	// Index Key for "TargetType" index
+	IndexKeyTargetType = "spec.targetType"
+)
+
+// BuildTargetHealthPodConditionType constructs the condition type for TargetHealth pod condition.
+func BuildTargetHealthPodConditionType(tgb *elbv2api.TargetGroupBinding) corev1.PodConditionType {
+	return corev1.PodConditionType(fmt.Sprintf("%s/%s", TargetHealthPodConditionTypePrefix, tgb.Name))
+}
 
 // Index Func for "ServiceReference" index.
 func IndexFuncServiceRefName(obj runtime.Object) []string {

--- a/webhooks/core/pod_mutator.go
+++ b/webhooks/core/pod_mutator.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	podinjector "sigs.k8s.io/aws-load-balancer-controller/pkg/inject"
+	inject "sigs.k8s.io/aws-load-balancer-controller/pkg/inject"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/webhook"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -15,33 +15,36 @@ const (
 )
 
 // NewPodMutator returns a mutator for Pod.
-func NewPodMutator(readiness *podinjector.PodReadinessGate) *podMutator {
+func NewPodMutator(podReadinessGateInjector *inject.PodReadinessGate) *podMutator {
 	return &podMutator{
-		readiness: readiness,
+		podReadinessGateInjector: podReadinessGateInjector,
 	}
 }
 
 var _ webhook.Mutator = &podMutator{}
 
 type podMutator struct {
-	readiness *podinjector.PodReadinessGate
+	podReadinessGateInjector *inject.PodReadinessGate
 }
 
-func (m *podMutator) Prototype(req admission.Request) (runtime.Object, error) {
+func (m *podMutator) Prototype(_ admission.Request) (runtime.Object, error) {
 	return &corev1.Pod{}, nil
 }
 
 func (m *podMutator) MutateCreate(ctx context.Context, obj runtime.Object) (runtime.Object, error) {
 	pod := obj.(*corev1.Pod)
-	err := m.readiness.Mutate(ctx, pod)
-	return pod, err
+	if err := m.podReadinessGateInjector.Mutate(ctx, pod); err != nil {
+		return pod, err
+	}
+	return pod, nil
 }
 
 func (m *podMutator) MutateUpdate(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
 	return obj, nil
 }
 
-// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1alpha1,name=mpod.elbv2.k8s.aws
+// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=mpod.elbv2.k8s.aws
+
 func (m *podMutator) SetupWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(apiPathMutatePod, webhook.MutatingWebhookForMutator(m))
 }


### PR DESCRIPTION
1. add support for targetHealthReadinessGate in TargetGroupBindings. 
     1. During TargetGroupBinding's reconcile, pods that have matching target will be updating it's targetHealth readinessGate condition.
     2. If there are any pod with targetHealth readinessGate but haven't been healthy or there are new targets, a requeue will be scheduled after 10 second.
2. small changes to targetHealthReadinessGate webhook.
     1. only TargetGroupBinding with `TargetType: ip` will be considered.
     2. manually specified readinessGate with 'target-health.elbv2.k8s.aws/some-tg-not-exists', will be perserved. (it's a user error and will be surfaced to user)
     3. the readinessGate will be formatted as `target-health.elbv2.k8s.aws/tg-name` instead of `elbv2.k8s.aws/tg-name`
3. enabled webhook.
     1. the webhook will be named `aws-load-balancer-webhook` instead of `aws-load-balancer-mutating-webhook-configuration`
     2. only namespaces with label `elbv2.k8s.aws/pod-readiness-gate-inject: enable` will have pod-readiness-gate-inject webhook called.
     3. renamed the controller flag  to be `--enable-pod-readiness-gate-inject`