### PR TITLE
restrict addons to alb only

### DIFF
--- a/pkg/deploy/shield/protection_synthesizer.go
+++ b/pkg/deploy/shield/protection_synthesizer.go
@@ -41,6 +41,10 @@ func (s *protectionSynthesizer) Synthesize(ctx context.Context) error {
 	var resLBs []*elbv2model.LoadBalancer
 	s.stack.ListResources(&resLBs)
 	for _, resLB := range resLBs {
+		// shield protection can only be associated with ALB for now.
+		if resLB.Spec.Type != elbv2model.LoadBalancerTypeApplication {
+			continue
+		}
 		lbARN, err := resLB.LoadBalancerARN().Resolve(ctx)
 		if err != nil {
 			return err

--- a/pkg/deploy/wafregional/web_acl_association_synthesizer.go
+++ b/pkg/deploy/wafregional/web_acl_association_synthesizer.go
@@ -35,6 +35,10 @@ func (s *webACLAssociationSynthesizer) Synthesize(ctx context.Context) error {
 	var resLBs []*elbv2model.LoadBalancer
 	s.stack.ListResources(&resLBs)
 	for _, resLB := range resLBs {
+		// wafRegional WebACL can only be associated with ALB for now.
+		if resLB.Spec.Type != elbv2model.LoadBalancerTypeApplication {
+			continue
+		}
 		lbARN, err := resLB.LoadBalancerARN().Resolve(ctx)
 		if err != nil {
 			return err

--- a/pkg/deploy/wafv2/web_acl_association_synthesizer.go
+++ b/pkg/deploy/wafv2/web_acl_association_synthesizer.go
@@ -35,6 +35,10 @@ func (s *webACLAssociationSynthesizer) Synthesize(ctx context.Context) error {
 	var resLBs []*elbv2model.LoadBalancer
 	s.stack.ListResources(&resLBs)
 	for _, resLB := range resLBs {
+		// wafv2 WebACL can only be associated with ALB for now.
+		if resLB.Spec.Type != elbv2model.LoadBalancerTypeApplication {
+			continue
+		}
 		lbARN, err := resLB.LoadBalancerARN().Resolve(ctx)
 		if err != nil {
 			return err


### PR DESCRIPTION
restrict addons(WAFRegional/WAFv2/Shield) to alb only.
These features is only available to ALB.