### PR TITLE
dependency handling during resource deletion and fix a bug in TGB

### DIFF
--- a/controllers/elbv2/eventhandlers/endpoints.go
+++ b/controllers/elbv2/eventhandlers/endpoints.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1alpha1"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/targetgroupbinding"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -64,7 +63,6 @@ func (h *enqueueRequestsForEndpointsEvent) enqueueImpactedTargetGroupBindings(qu
 		h.logger.Error(err, "failed to fetch targetGroupBindings")
 		return
 	}
-	h.logger.Info("found", "count", len(tgbList.Items), "name", k8s.NamespacedName(ep))
 
 	for _, tgb := range tgbList.Items {
 		queue.Add(reconcile.Request{

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -181,13 +181,14 @@ func (m *defaultResourceManager) updateTargetHealthPodConditionForPod(ctx contex
 	if !k8s.IsPodHasReadinessGate(pod, targetHealthCondType) {
 		return false, nil
 	}
+	existingTargetHealthCond := k8s.GetPodCondition(pod, targetHealthCondType)
+	if existingTargetHealthCond != nil && existingTargetHealthCond.Status == corev1.ConditionTrue {
+		return false, nil
+	}
+
 	targetHealthCondStatus := corev1.ConditionFalse
 	if target.IsHealthy() {
 		targetHealthCondStatus = corev1.ConditionTrue
-	}
-	existingTargetHealthCond := k8s.GetPodCondition(pod, targetHealthCondType)
-	if existingTargetHealthCond != nil && existingTargetHealthCond.Status == targetHealthCondStatus {
-		return false, nil
 	}
 	var reason, message string
 	if target.TargetHealth != nil {


### PR DESCRIPTION
1. handle dependency during resource deletion by wait & poll.
    * due to AWS API's eventual consistency model, we need to wait during delete resources. (e.g. when LB is deleted, the SG might still in-use by the LB's ENI)
    * we need to wait TargetGroupBinding's deletion since it have finalizer. we use a frequent interval since it's in-memory lookuup.
2. Fix a bug in TGB's readinessGate handling.