### PR TITLE
Change the format for NLB targetgroup naming

### DIFF
--- a/pkg/service/nlb/builder.go
+++ b/pkg/service/nlb/builder.go
@@ -402,9 +402,10 @@ func (t *defaultModelBuildTask) buildListeners(ctx context.Context, ec2Subnets [
 			listenerProtocol = elbv2model.ProtocolTLS
 		}
 		tgName := t.targetGroupName(t.service, t.key, port.TargetPort, string(tgProtocol), hc)
+		tgResId := t.buildTargetGroupResourceID(t.key, port.TargetPort)
 		targetGroup, exists := targetGroupMap[port.TargetPort.String()]
 		if !exists {
-			targetGroup = elbv2model.NewTargetGroup(t.stack, tgName, elbv2model.TargetGroupSpec{
+			targetGroup = elbv2model.NewTargetGroup(t.stack, tgResId, elbv2model.TargetGroupSpec{
 				Name:                  tgName,
 				TargetType:            elbv2model.TargetTypeIP,
 				Port:                  int64(port.TargetPort.IntValue()),
@@ -413,27 +414,7 @@ func (t *defaultModelBuildTask) buildListeners(ctx context.Context, ec2Subnets [
 				TargetGroupAttributes: tgAttrs,
 			})
 			targetGroupMap[port.TargetPort.String()] = targetGroup
-
-			var targetType elbv2api.TargetType = elbv2api.TargetTypeIP
-			tgbNetworking := t.buildTargetGroupBindingNetworking(ctx, port.TargetPort, *hc.Port, port.Protocol, ec2Subnets)
-
-			_ = elbv2model.NewTargetGroupBindingResource(t.stack, tgName, elbv2model.TargetGroupBindingResourceSpec{
-				Template: elbv2model.TargetGroupBindingTemplate{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: t.service.Namespace,
-						Name:      tgName,
-					},
-					Spec: elbv2model.TargetGroupBindingSpec{
-						TargetGroupARN: targetGroup.TargetGroupARN(),
-						TargetType:     &targetType,
-						ServiceRef: elbv2api.ServiceReference{
-							Name: t.service.Name,
-							Port: intstr.FromInt(int(port.Port)),
-						},
-						Networking: tgbNetworking,
-					},
-				},
-			})
+			_ = t.buildTargetGropuBinding(ctx, targetGroup, port, hc, ec2Subnets)
 		}
 
 		var sslPolicy *string = nil
@@ -470,6 +451,30 @@ func (t *defaultModelBuildTask) buildListeners(ctx context.Context, ec2Subnets [
 		})
 	}
 	return nil
+}
+
+func (t *defaultModelBuildTask) buildTargetGropuBinding(ctx context.Context, targetGroup *elbv2model.TargetGroup,
+	port corev1.ServicePort, hc *elbv2model.TargetGroupHealthCheckConfig, ec2Subnets []*ec2.Subnet) *elbv2model.TargetGroupBindingResource {
+	var targetType elbv2api.TargetType = elbv2api.TargetTypeIP
+	tgbNetworking := t.buildTargetGroupBindingNetworking(ctx, port.TargetPort, *hc.Port, port.Protocol, ec2Subnets)
+
+	return elbv2model.NewTargetGroupBindingResource(t.stack, targetGroup.ID(), elbv2model.TargetGroupBindingResourceSpec{
+		Template: elbv2model.TargetGroupBindingTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: t.service.Namespace,
+				Name:      targetGroup.Spec.Name,
+			},
+			Spec: elbv2model.TargetGroupBindingSpec{
+				TargetGroupARN: targetGroup.TargetGroupARN(),
+				TargetType:     &targetType,
+				ServiceRef: elbv2api.ServiceReference{
+					Name: t.service.Name,
+					Port: intstr.FromInt(int(port.Port)),
+				},
+				Networking: tgbNetworking,
+			},
+		},
+	})
 }
 
 func (t *defaultModelBuildTask) buildTargetGroupBindingNetworking(_ context.Context, tgPort intstr.IntOrString, hcPort intstr.IntOrString,
@@ -535,4 +540,8 @@ func (t *defaultModelBuildTask) targetGroupName(svc *corev1.Service, id types.Na
 	_, _ = uuidHash.Write([]byte(healthCheckInterval))
 	uuid := hex.EncodeToString(uuidHash.Sum(nil))
 	return fmt.Sprintf("k8s-%.8s-%.8s-%.10s", id.Namespace, id.Name, uuid)
+}
+
+func (t *defaultModelBuildTask) buildTargetGroupResourceID(svcKey types.NamespacedName, port intstr.IntOrString) string {
+	return fmt.Sprintf("%s/%s:%s", svcKey.Namespace, svcKey.Name, port.String())
 }

--- a/pkg/service/nlb/builder.go
+++ b/pkg/service/nlb/builder.go
@@ -534,5 +534,5 @@ func (t *defaultModelBuildTask) targetGroupName(svc *corev1.Service, id types.Na
 	_, _ = uuidHash.Write([]byte(healthCheckProtocol))
 	_, _ = uuidHash.Write([]byte(healthCheckInterval))
 	uuid := hex.EncodeToString(uuidHash.Sum(nil))
-	return fmt.Sprintf("k8s-%.8s-%.8s-%.10s", id.Name, id.Namespace, uuid)
+	return fmt.Sprintf("k8s-%.8s-%.8s-%.10s", id.Namespace, id.Name, uuid)
 }

--- a/pkg/service/nlb/builder_test.go
+++ b/pkg/service/nlb/builder_test.go
@@ -71,7 +71,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                         "targetGroups":[
                            {
                               "targetGroupARN":{
-                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-nlb-ip-s-default-7ed4a09b6c/status/targetGroupARN"
+                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-7ed4a09b6c/status/targetGroupARN"
                               }
                            }
                         ]
@@ -115,9 +115,9 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "AWS::ElasticLoadBalancingV2::TargetGroup":{
-         "k8s-nlb-ip-s-default-7ed4a09b6c":{
+         "k8s-default-nlb-ip-s-7ed4a09b6c":{
             "spec":{
-               "name":"k8s-nlb-ip-s-default-7ed4a09b6c",
+               "name":"k8s-default-nlb-ip-s-7ed4a09b6c",
                "targetType":"ip",
                "port":80,
                "protocol":"TCP",
@@ -139,17 +139,17 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
-         "k8s-nlb-ip-s-default-7ed4a09b6c":{
+         "k8s-default-nlb-ip-s-7ed4a09b6c":{
             "spec":{
                "template":{
                   "metadata":{
-                     "name":"k8s-nlb-ip-s-default-7ed4a09b6c",
+                     "name":"k8s-default-nlb-ip-s-7ed4a09b6c",
                      "namespace":"default",
                      "creationTimestamp":null
                   },
                   "spec":{
                      "targetGroupARN":{
-                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-nlb-ip-s-default-7ed4a09b6c/status/targetGroupARN"
+                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-7ed4a09b6c/status/targetGroupARN"
                      },
                      "targetType":"ip",
                      "serviceRef":{
@@ -244,7 +244,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                         "targetGroups":[
                            {
                               "targetGroupARN":{
-                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-nlb-ip-s-default-03582c76a7/status/targetGroupARN"
+                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-03582c76a7/status/targetGroupARN"
                               }
                            }
                         ]
@@ -267,7 +267,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                         "targetGroups":[
                            {
                               "targetGroupARN":{
-                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-nlb-ip-s-default-03582c76a7/status/targetGroupARN"
+                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-03582c76a7/status/targetGroupARN"
                               }
                            }
                         ]
@@ -314,9 +314,9 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "AWS::ElasticLoadBalancingV2::TargetGroup":{
-         "k8s-nlb-ip-s-default-03582c76a7":{
+         "k8s-default-nlb-ip-s-03582c76a7":{
             "spec":{
-               "name":"k8s-nlb-ip-s-default-03582c76a7",
+               "name":"k8s-default-nlb-ip-s-03582c76a7",
                "targetType":"ip",
                "port":80,
                "protocol":"TCP",
@@ -339,17 +339,17 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
-         "k8s-nlb-ip-s-default-03582c76a7":{
+         "k8s-default-nlb-ip-s-03582c76a7":{
             "spec":{
                "template":{
                   "metadata":{
-                     "name":"k8s-nlb-ip-s-default-03582c76a7",
+                     "name":"k8s-default-nlb-ip-s-03582c76a7",
                      "namespace":"default",
                      "creationTimestamp":null
                   },
                   "spec":{
                      "targetGroupARN":{
-                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-nlb-ip-s-default-03582c76a7/status/targetGroupARN"
+                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-03582c76a7/status/targetGroupARN"
                      },
                      "targetType":"ip",
                      "serviceRef":{
@@ -459,7 +459,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                         "targetGroups":[
                            {
                               "targetGroupARN":{
-                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-nlb-ip-s-default-03582c76a7/status/targetGroupARN"
+                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-03582c76a7/status/targetGroupARN"
                               }
                            }
                         ]
@@ -482,7 +482,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                         "targetGroups":[
                            {
                               "targetGroupARN":{
-                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-nlb-ip-s-default-f4577ac8db/status/targetGroupARN"
+                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-f4577ac8db/status/targetGroupARN"
                               }
                            }
                         ]
@@ -540,9 +540,9 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "AWS::ElasticLoadBalancingV2::TargetGroup":{
-         "k8s-nlb-ip-s-default-03582c76a7":{
+         "k8s-default-nlb-ip-s-03582c76a7":{
             "spec":{
-               "name":"k8s-nlb-ip-s-default-03582c76a7",
+               "name":"k8s-default-nlb-ip-s-03582c76a7",
                "targetType":"ip",
                "port":80,
                "protocol":"TCP",
@@ -563,9 +563,9 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                ]
             }
          },
-         "k8s-nlb-ip-s-default-f4577ac8db":{
+         "k8s-default-nlb-ip-s-f4577ac8db":{
             "spec":{
-               "name":"k8s-nlb-ip-s-default-f4577ac8db",
+               "name":"k8s-default-nlb-ip-s-f4577ac8db",
                "targetType":"ip",
                "port":8883,
                "protocol":"TCP",
@@ -588,17 +588,17 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
-         "k8s-nlb-ip-s-default-03582c76a7":{
+         "k8s-default-nlb-ip-s-03582c76a7":{
             "spec":{
                "template":{
                   "metadata":{
-                     "name":"k8s-nlb-ip-s-default-03582c76a7",
+                     "name":"k8s-default-nlb-ip-s-03582c76a7",
                      "namespace":"default",
                      "creationTimestamp":null
                   },
                   "spec":{
                      "targetGroupARN":{
-                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-nlb-ip-s-default-03582c76a7/status/targetGroupARN"
+                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-03582c76a7/status/targetGroupARN"
                      },
                      "targetType":"ip",
                      "serviceRef":{
@@ -638,17 +638,17 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                }
             }
          },
-         "k8s-nlb-ip-s-default-f4577ac8db":{
+         "k8s-default-nlb-ip-s-f4577ac8db":{
             "spec":{
                "template":{
                   "metadata":{
-                     "name":"k8s-nlb-ip-s-default-f4577ac8db",
+                     "name":"k8s-default-nlb-ip-s-f4577ac8db",
                      "namespace":"default",
                      "creationTimestamp":null
                   },
                   "spec":{
                      "targetGroupARN":{
-                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-nlb-ip-s-default-f4577ac8db/status/targetGroupARN"
+                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-f4577ac8db/status/targetGroupARN"
                      },
                      "targetType":"ip",
                      "serviceRef":{

--- a/pkg/service/nlb/builder_test.go
+++ b/pkg/service/nlb/builder_test.go
@@ -71,7 +71,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                         "targetGroups":[
                            {
                               "targetGroupARN":{
-                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-7ed4a09b6c/status/targetGroupARN"
+                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
                               }
                            }
                         ]
@@ -115,7 +115,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "AWS::ElasticLoadBalancingV2::TargetGroup":{
-         "k8s-default-nlb-ip-s-7ed4a09b6c":{
+         "default/nlb-ip-svc-tls:80":{
             "spec":{
                "name":"k8s-default-nlb-ip-s-7ed4a09b6c",
                "targetType":"ip",
@@ -139,7 +139,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
-         "k8s-default-nlb-ip-s-7ed4a09b6c":{
+         "default/nlb-ip-svc-tls:80":{
             "spec":{
                "template":{
                   "metadata":{
@@ -149,7 +149,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                   },
                   "spec":{
                      "targetGroupARN":{
-                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-7ed4a09b6c/status/targetGroupARN"
+                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
                      },
                      "targetType":"ip",
                      "serviceRef":{
@@ -244,7 +244,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                         "targetGroups":[
                            {
                               "targetGroupARN":{
-                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-03582c76a7/status/targetGroupARN"
+                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc:80/status/targetGroupARN"
                               }
                            }
                         ]
@@ -267,7 +267,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                         "targetGroups":[
                            {
                               "targetGroupARN":{
-                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-03582c76a7/status/targetGroupARN"
+                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc:80/status/targetGroupARN"
                               }
                            }
                         ]
@@ -314,7 +314,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "AWS::ElasticLoadBalancingV2::TargetGroup":{
-         "k8s-default-nlb-ip-s-03582c76a7":{
+         "default/nlb-ip-svc:80":{
             "spec":{
                "name":"k8s-default-nlb-ip-s-03582c76a7",
                "targetType":"ip",
@@ -339,7 +339,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
-         "k8s-default-nlb-ip-s-03582c76a7":{
+         "default/nlb-ip-svc:80":{
             "spec":{
                "template":{
                   "metadata":{
@@ -349,7 +349,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                   },
                   "spec":{
                      "targetGroupARN":{
-                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-03582c76a7/status/targetGroupARN"
+                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc:80/status/targetGroupARN"
                      },
                      "targetType":"ip",
                      "serviceRef":{
@@ -459,7 +459,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                         "targetGroups":[
                            {
                               "targetGroupARN":{
-                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-03582c76a7/status/targetGroupARN"
+                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
                               }
                            }
                         ]
@@ -482,7 +482,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                         "targetGroups":[
                            {
                               "targetGroupARN":{
-                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-f4577ac8db/status/targetGroupARN"
+                                 "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:8883/status/targetGroupARN"
                               }
                            }
                         ]
@@ -540,7 +540,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "AWS::ElasticLoadBalancingV2::TargetGroup":{
-         "k8s-default-nlb-ip-s-03582c76a7":{
+         "default/nlb-ip-svc-tls:80":{
             "spec":{
                "name":"k8s-default-nlb-ip-s-03582c76a7",
                "targetType":"ip",
@@ -563,7 +563,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                ]
             }
          },
-         "k8s-default-nlb-ip-s-f4577ac8db":{
+         "default/nlb-ip-svc-tls:8883":{
             "spec":{
                "name":"k8s-default-nlb-ip-s-f4577ac8db",
                "targetType":"ip",
@@ -588,7 +588,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          }
       },
       "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
-         "k8s-default-nlb-ip-s-03582c76a7":{
+         "default/nlb-ip-svc-tls:80":{
             "spec":{
                "template":{
                   "metadata":{
@@ -598,7 +598,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                   },
                   "spec":{
                      "targetGroupARN":{
-                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-03582c76a7/status/targetGroupARN"
+                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
                      },
                      "targetType":"ip",
                      "serviceRef":{
@@ -638,7 +638,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                }
             }
          },
-         "k8s-default-nlb-ip-s-f4577ac8db":{
+         "default/nlb-ip-svc-tls:8883":{
             "spec":{
                "template":{
                   "metadata":{
@@ -648,7 +648,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                   },
                   "spec":{
                      "targetGroupARN":{
-                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/k8s-default-nlb-ip-s-f4577ac8db/status/targetGroupARN"
+                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:8883/status/targetGroupARN"
                      },
                      "targetType":"ip",
                      "serviceRef":{


### PR DESCRIPTION
Use the format k8s-<namespace>-<name>-<uuid> to be consistent with the ingress target groups.