### PR TITLE
add cert discovery functionality

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -29,8 +29,11 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 	annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
 	authConfigBuilder := ingress.NewDefaultAuthConfigBuilder(annotationParser)
 	enhancedBackendBuilder := ingress.NewDefaultEnhancedBackendBuilder(annotationParser)
-	modelBuilder := ingress.NewDefaultModelBuilder(k8sClient, eventRecorder, cloud.EC2(), cloud.VpcID(), clusterName, annotationParser, subnetsResolver,
-		authConfigBuilder, enhancedBackendBuilder)
+	modelBuilder := ingress.NewDefaultModelBuilder(k8sClient, eventRecorder,
+		cloud.EC2(), cloud.ACM(),
+		annotationParser, subnetsResolver,
+		authConfigBuilder, enhancedBackendBuilder,
+		cloud.VpcID(), clusterName, logger)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, clusterName, "ingress.k8s.aws", logger)
 	groupLoader := ingress.NewDefaultGroupLoader(k8sClient, annotationParser, "alb")

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -18,6 +18,9 @@ type Cloud interface {
 	// ELBV2 provides API to AWS ELBV2
 	ELBV2() services.ELBV2
 
+	// ACM provides API to AWS ACM
+	ACM() services.ACM
+
 	// WAFv2 provides API to AWS WAFv2
 	WAFv2() services.WAFv2
 
@@ -73,6 +76,7 @@ func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, 
 		cfg:         cfg,
 		ec2:         services.NewEC2(sess),
 		elbv2:       services.NewELBV2(sess),
+		acm:         services.NewACM(sess),
 		wafv2:       services.NewWAFv2(sess),
 		wafRegional: services.NewWAFRegional(sess, cfg.Region),
 		shield:      services.NewShield(sess),
@@ -87,6 +91,7 @@ type defaultCloud struct {
 	ec2   services.EC2
 	elbv2 services.ELBV2
 
+	acm         services.ACM
 	wafv2       services.WAFv2
 	wafRegional services.WAFRegional
 	shield      services.Shield
@@ -98,6 +103,10 @@ func (c *defaultCloud) EC2() services.EC2 {
 
 func (c *defaultCloud) ELBV2() services.ELBV2 {
 	return c.elbv2
+}
+
+func (c *defaultCloud) ACM() services.ACM {
+	return c.acm
 }
 
 func (c *defaultCloud) WAFv2() services.WAFv2 {

--- a/pkg/ingress/cert_discovery.go
+++ b/pkg/ingress/cert_discovery.go
@@ -1,0 +1,169 @@
+package ingress
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/cache"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	certARNsCacheKey = "certARNs"
+	// the certARNs in AWS account will be cached for 1 minute.
+	defaultCertARNsCacheTTL = 1 * time.Minute
+	// the domain names for imported certificates will be cached for 5 minute.
+	defaultImportedCertDomainsCacheTTL = 5 * time.Minute
+	// the domain names for private certificates won't change, cache for a longer time.
+	defaultPrivateCertDomainsCacheTTL = 10 * time.Hour
+)
+
+// CertDiscovery is responsible for auto-discover TLS certificates for tls hosts.
+type CertDiscovery interface {
+	// Discover will try to find valid certificateARNs for each tlsHost.
+	Discover(ctx context.Context, tlsHosts []string) ([]string, error)
+}
+
+// NewACMCertDiscovery constructs new acmCertDiscovery
+func NewACMCertDiscovery(acmClient services.ACM, logger logr.Logger) *acmCertDiscovery {
+	return &acmCertDiscovery{
+		acmClient: acmClient,
+		logger:    logger,
+
+		loadDomainsByCertARNMutex:   sync.Mutex{},
+		certARNsCache:               cache.NewExpiring(),
+		certARNsCacheTTL:            defaultCertARNsCacheTTL,
+		certDomainsCache:            cache.NewExpiring(),
+		importedCertDomainsCacheTTL: defaultImportedCertDomainsCacheTTL,
+		privateCertDomainsCacheTTL:  defaultPrivateCertDomainsCacheTTL,
+	}
+}
+
+var _ CertDiscovery = &acmCertDiscovery{}
+
+// CertDiscovery implementation for ACM certificates.
+type acmCertDiscovery struct {
+	acmClient services.ACM
+	logger    logr.Logger
+
+	// mutex to serialize the call to loadDomainsForAllCertificates
+	loadDomainsByCertARNMutex   sync.Mutex
+	certARNsCache               *cache.Expiring
+	certARNsCacheTTL            time.Duration
+	certDomainsCache            *cache.Expiring
+	importedCertDomainsCacheTTL time.Duration
+	privateCertDomainsCacheTTL  time.Duration
+}
+
+func (d *acmCertDiscovery) Discover(ctx context.Context, tlsHosts []string) ([]string, error) {
+	domainsByCertARN, err := d.loadDomainsForAllCertificates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	certARNs := sets.NewString()
+	for _, host := range tlsHosts {
+		var certARNsForHost []string
+		for certARN, domains := range domainsByCertARN {
+			for domain := range domains {
+				if d.domainMatchesHost(domain, host) {
+					certARNsForHost = append(certARNsForHost, certARN)
+					break
+				}
+			}
+		}
+
+		if len(certARNsForHost) > 1 {
+			return nil, errors.Errorf("multiple certificate found for host: %s, certARNs: %v", host, certARNsForHost)
+		}
+		if len(certARNsForHost) == 0 {
+			return nil, errors.Errorf("none certificate found for host: %s", host)
+		}
+		certARNs.Insert(certARNsForHost...)
+	}
+	return certARNs.List(), nil
+}
+
+func (d *acmCertDiscovery) loadDomainsForAllCertificates(ctx context.Context) (map[string]sets.String, error) {
+	d.loadDomainsByCertARNMutex.Lock()
+	defer d.loadDomainsByCertARNMutex.Unlock()
+
+	certARNs, err := d.loadAllCertificateARNs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	domainsByCertARN := make(map[string]sets.String, len(certARNs))
+	for _, certARN := range certARNs {
+		certDomains, err := d.loadDomainsForCertificate(ctx, certARN)
+		if err != nil {
+			return nil, err
+		}
+		domainsByCertARN[certARN] = certDomains
+	}
+	return domainsByCertARN, nil
+}
+
+func (d *acmCertDiscovery) loadAllCertificateARNs(ctx context.Context) ([]string, error) {
+	if rawCacheItem, ok := d.certARNsCache.Get(certARNsCacheKey); ok {
+		return rawCacheItem.([]string), nil
+	}
+	req := &acm.ListCertificatesInput{
+		CertificateStatuses: aws.StringSlice([]string{acm.CertificateStatusIssued}),
+	}
+	certSummaries, err := d.acmClient.ListCertificatesAsList(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var certARNs []string
+	for _, certSummary := range certSummaries {
+		certARN := aws.StringValue(certSummary.CertificateArn)
+		certARNs = append(certARNs, certARN)
+	}
+	d.certARNsCache.Set(certARNsCacheKey, certARNs, d.certARNsCacheTTL)
+	return certARNs, nil
+}
+
+func (d *acmCertDiscovery) loadDomainsForCertificate(ctx context.Context, certARN string) (sets.String, error) {
+	if rawCacheItem, ok := d.certDomainsCache.Get(certARN); ok {
+		return rawCacheItem.(sets.String), nil
+	}
+	req := &acm.DescribeCertificateInput{
+		CertificateArn: aws.String(certARN),
+	}
+	resp, err := d.acmClient.DescribeCertificateWithContext(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	certDetail := resp.Certificate
+	domains := sets.NewString(aws.StringValueSlice(certDetail.SubjectAlternativeNames)...)
+	switch aws.StringValue(certDetail.Type) {
+	case acm.CertificateTypeImported:
+		d.certDomainsCache.Set(certARN, domains, d.importedCertDomainsCacheTTL)
+	case acm.CertificateTypeAmazonIssued, acm.CertificateTypePrivate:
+		d.certDomainsCache.Set(certARN, domains, d.privateCertDomainsCacheTTL)
+	}
+	return domains, nil
+}
+
+func (d *acmCertDiscovery) domainMatchesHost(domainName string, tlsHost string) bool {
+	if strings.HasPrefix(domainName, "*.") {
+		ds := strings.Split(domainName, ".")
+		hs := strings.Split(tlsHost, ".")
+
+		if len(ds) != len(hs) {
+			return false
+		}
+
+		return cmp.Equal(ds[1:], hs[1:], cmpopts.EquateEmpty())
+	}
+
+	return domainName == tlsHost
+}

--- a/pkg/ingress/cert_discovery_test.go
+++ b/pkg/ingress/cert_discovery_test.go
@@ -1,0 +1,66 @@
+package ingress
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_acmCertDiscovery_domainMatchesHost(t *testing.T) {
+	type args struct {
+		domainName string
+		tlsHost    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "exact domain matches",
+			args: args{
+				domainName: "example.com",
+				tlsHost:    "example.com",
+			},
+			want: true,
+		},
+		{
+			name: "exact domain didn't matches",
+			args: args{
+				domainName: "example.com",
+				tlsHost:    "www.example.com",
+			},
+			want: false,
+		},
+		{
+			name: "wildcard domain matches",
+			args: args{
+				domainName: "*.example.com",
+				tlsHost:    "www.example.com",
+			},
+			want: true,
+		},
+		{
+			name: "wildcard domain didn't matches - case 1",
+			args: args{
+				domainName: "*.example.com",
+				tlsHost:    "example.com",
+			},
+			want: false,
+		},
+		{
+			name: "wildcard domain didn't matches - case 2",
+			args: args{
+				domainName: "*.example.com",
+				tlsHost:    "www.app.example.com",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &acmCertDiscovery{}
+			got := d.domainMatchesHost(tt.args.domainName, tt.args.tlsHost)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
add cert discovery functionality.

The TLS certs will be decided on per Ingress basis.(each Ingress decides whether to infer certs based on whether TLS certs have been configured via annotation).
The TLS certs for All Ingresses with same listen port will be merged  together.