### PR TITLE
fix securityGroup rules reconcile

### DIFF
--- a/pkg/deploy/ec2/security_group_manager.go
+++ b/pkg/deploy/ec2/security_group_manager.go
@@ -195,7 +195,7 @@ func buildIPPermissionInfo(permission ec2model.IPPermission) (networking.IPPermi
 	}
 	if len(permission.IPv6Range) == 1 {
 		labels := networking.NewIPPermissionLabelsForRawDescription(permission.IPv6Range[0].Description)
-		return networking.NewCIDRIPPermission(protocol, permission.FromPort, permission.ToPort, permission.IPv6Range[0].CIDRIPv6, labels), nil
+		return networking.NewCIDRv6IPPermission(protocol, permission.FromPort, permission.ToPort, permission.IPv6Range[0].CIDRIPv6, labels), nil
 	}
 	if len(permission.UserIDGroupPairs) == 1 {
 		labels := networking.NewIPPermissionLabelsForRawDescription(permission.UserIDGroupPairs[0].Description)

--- a/pkg/networking/security_group_reconciler_test.go
+++ b/pkg/networking/security_group_reconciler_test.go
@@ -1,0 +1,47 @@
+package networking
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_defaultSecurityGroupReconciler_shouldRetryWithoutCache(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "should retry without cache when got duplicated permission error",
+			args: args{
+				err: awserr.New("InvalidPermission.Duplicate", "", nil),
+			},
+			want: true,
+		},
+		{
+			name: "should retry without cache when got not found permission error",
+			args: args{
+				err: awserr.New("InvalidPermission.NotFound", "", nil),
+			},
+			want: true,
+		},
+		{
+			name: "shouldn't retry when got some other error",
+			args: args{
+				err: awserr.New("SomeOtherError", "", nil),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &defaultSecurityGroupReconciler{}
+			got := r.shouldRetryWithoutCache(tt.args.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/targetgroupbinding/networking_manager.go
+++ b/pkg/targetgroupbinding/networking_manager.go
@@ -427,7 +427,7 @@ func (m *defaultNetworkingManager) resolveEndpointSGForENI(ctx context.Context, 
 		return sgIDs[0], nil
 	}
 
-	sgInfoByID, err := m.sgManager.FetchSGInfosByID(ctx, sgIDs...)
+	sgInfoByID, err := m.sgManager.FetchSGInfosByID(ctx, sgIDs)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
1. retry without cache when we facing Duplicated or NotFound permission error.
   * we cache permissions for SecurityGroup for 5 minutes if there is no changes made by controller.
   * if there are permission added to SecurityGroup out-of-band, the controller's cached information will be out-dated, and reconcile might fail if it tries to add Duplicated permission or remove NotFound permissions.
   * we add a retry if such error occurs by force reload securityGroup permissions from AWS without cache.
   * Fixes #1438 

2. fix a bug in for CIDRv6 handling during securityGroup deployer. (IPv4 Permission was used for IPv6 CIDR)

