### PR TITLE
Enable security hardening options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ ARG TARGETARCH
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on \
+    CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2" \
+    CGO_LDFLAGS="-Wl,-z,relro,-z,now" \
     go build -ldflags="-s -w" -buildmode=pie -a -o /out/controller main.go
 
 FROM amazonlinux:2 as bin-unix

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - controller.yaml
 patchesStrategicMerge:
 - iam_for_sa_patch.yaml
+- security_context_patch.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/controller/security_context_patch.yaml
+++ b/config/controller/security_context_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: controller
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true


### PR DESCRIPTION
Enable D_FORTIFY_SOURCE=2
populate default security context for controller

Ran checksec tool on the controller, here are the results -
```
# checksec.sh/checksec --file=./controller
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	Symbols		FORTIFY	Fortified	Fortifiable	FILE
Partial RELRO   No canary found   NX enabled    PIE enabled     No RPATH   No RUNPATH   No Symbols	  Yes	2		2		./controller
```