### PR TITLE
hard-code ingressClass to alb & adjust memory limit 

### DIFF
--- a/config/controller/controller.yaml
+++ b/config/controller/controller.yaml
@@ -26,10 +26,11 @@ spec:
           image: controller:latest
           args:
             - --cluster-name=your-cluster-name
+            - --ingress-class=alb
           resources:
             limits:
               cpu: 100m
-              memory: 300Mi
+              memory: 2000Mi
             requests:
               cpu: 100m
               memory: 200Mi

--- a/config/samples/install_v2_0_0_rc3.yaml
+++ b/config/samples/install_v2_0_0_rc3.yaml
@@ -498,6 +498,7 @@ spec:
       containers:
         - args:
             - --cluster-name=your-cluster-name
+            - --ingress-class=alb
           image: amazon/aws-alb-ingress-controller:v2.0.0-rc3
           name: controller
           ports:
@@ -507,7 +508,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 300Mi
+              memory: 2000Mi
             requests:
               cpu: 100m
               memory: 200Mi


### PR DESCRIPTION
1. hard-code ingressClass to `alb`. 
    2. If `--ingress-class` is not specified, it will match all Ingresses without IngressClass annotation and IngressClass==`alb`
2. adjust memory limit  to be 2GB.