### PR TITLE
fix the iam permissions

### DIFF
--- a/docs/guide/upgrade/migrate_v1_v2.md
+++ b/docs/guide/upgrade/migrate_v1_v2.md
@@ -8,7 +8,6 @@ This document contains the information necessary to migrate from an existing ins
     If you have AWSALBIngressController(<1.1.3) installed, you need to upgrade to version>=v1.1.3(e.g. v1.1.9) first.
     
     
-
 ## Backwards compatibility
 The AWSLoadBalancerController(v2.0.0) is backwards-compatible with AWSALBIngressController(>=v1.1.3).
 
@@ -29,7 +28,7 @@ foo@bar:~$ kubectl describe deployment  -n kube-system  alb-ingress-controller |
         Existing Ingress resources do not need to be deleted.
 
 3. Install new AWSLoadBalancerController
-
-    Install AWSLoadBalancerController(v2.0.0) by following the [installation instructions](../controller/installation.md)
+    1. Install AWSLoadBalancerController(v2.0.0) by following the [installation instructions](../controller/installation.md)
+    2. Grant [additional IAM policy](../../install/iam_policy_v1_to_v2_additional.json) needed for migration to the controller.
 
 4. Verify all Ingresses works as expected.

--- a/docs/install/iam_policy.json
+++ b/docs/install/iam_policy.json
@@ -70,13 +70,13 @@
             "Action": [
                 "ec2:CreateTags"
             ],
-            "Resource": "*",
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
             "Condition": {
                 "StringEquals": {
                     "ec2:CreateAction": "CreateSecurityGroup"
                 },
                 "Null": {
-                    "aws:RequestTag/ingress.k8s.aws/cluster": "false"
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
                 }
             }
         },
@@ -86,11 +86,11 @@
                 "ec2:CreateTags",
                 "ec2:DeleteTags"
             ],
-            "Resource": "*",
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
             "Condition": {
                 "Null": {
-                    "aws:RequestTag/ingress.k8s.aws/cluster": "true",
-                    "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
                 }
             }
         },
@@ -104,22 +104,20 @@
             "Resource": "*",
             "Condition": {
                 "Null": {
-                    "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
                 }
             }
         },
         {
             "Effect": "Allow",
             "Action": [
-                "elasticloadbalancing:CreateLoadBalancer"
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
             ],
             "Resource": "*",
             "Condition": {
-                "ForAnyValue:StringEquals": {
-                    "aws:TagKeys": [
-                        "ingress.k8s.aws/cluster",
-                        "service.k8s.aws/cluster"
-                    ]
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
                 }
             }
         },
@@ -129,8 +127,7 @@
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:DeleteListener",
                 "elasticloadbalancing:CreateRule",
-                "elasticloadbalancing:DeleteRule",
-                "elasticloadbalancing:CreateTargetGroup"
+                "elasticloadbalancing:DeleteRule"
             ],
             "Resource": "*"
         },
@@ -140,35 +137,16 @@
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:RemoveTags"
             ],
-            "Resource": "arn:aws:elasticloadbalancing:*:*:loadbalancer/*",
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/*",
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*"
+            ],
             "Condition": {
                 "Null": {
-                    "aws:RequestTag/ingress.k8s.aws/cluster": "true",
-                    "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
                 }
             }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:RemoveTags"
-            ],
-            "Resource": "arn:aws:elasticloadbalancing:*:*:loadbalancer/*",
-            "Condition": {
-                "Null": {
-                    "aws:RequestTag/service.k8s.aws/cluster": "true",
-                    "aws:ResourceTag/service.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:RemoveTags"
-            ],
-            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*"
         },
         {
             "Effect": "Allow",
@@ -177,27 +155,17 @@
                 "elasticloadbalancing:SetIpAddressType",
                 "elasticloadbalancing:SetSecurityGroups",
                 "elasticloadbalancing:SetSubnets",
-                "elasticloadbalancing:DeleteLoadBalancer"
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets",
+                "elasticloadbalancing:DeleteTargetGroup"
             ],
             "Resource": "*",
             "Condition": {
                 "Null": {
-                    "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                "elasticloadbalancing:SetIpAddressType",
-                "elasticloadbalancing:SetSubnets",
-                "elasticloadbalancing:DeleteLoadBalancer"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "Null": {
-                    "aws:ResourceTag/service.k8s.aws/cluster": "false"
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
                 }
             }
         },
@@ -208,12 +176,7 @@
                 "elasticloadbalancing:ModifyListener",
                 "elasticloadbalancing:AddListenerCertificates",
                 "elasticloadbalancing:RemoveListenerCertificates",
-                "elasticloadbalancing:ModifyRule",
-                "elasticloadbalancing:ModifyTargetGroup",
-                "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:DeregisterTargets",
-                "elasticloadbalancing:DeleteTargetGroup"
+                "elasticloadbalancing:ModifyRule"
             ],
             "Resource": "*"
         }

--- a/docs/install/iam_policy_v1_to_v2_additional.json
+++ b/docs/install/iam_policy_v1_to_v2_additional.json
@@ -1,0 +1,34 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/*",
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Fix the IAM permissions with below changes:
1. limit the Tag operations by resource ARN format.
2. the cluster tag have changed to be `elbv2.k8s.aws/cluster` instead of `ingress.k8s.aws/cluster` and `service.k8s.aws/cluster`
3. added a separate iam permission needed for migration