### PR TITLE
Fix NLB model for supporting multiple certificate ARNs

### DIFF
--- a/pkg/service/nlb/builder.go
+++ b/pkg/service/nlb/builder.go
@@ -435,7 +435,7 @@ func (t *defaultModelBuildTask) buildListeners(ctx context.Context, ec2Subnets [
 		var certificates []elbv2model.Certificate
 		if listenerProtocol == elbv2model.ProtocolTLS {
 			for _, cert := range certificateARNs {
-				certificates = append(certificates, elbv2model.Certificate{CertificateARN: &cert})
+				certificates = append(certificates, elbv2model.Certificate{CertificateARN: aws.String(cert)})
 			}
 		}
 

--- a/pkg/service/nlb/builder_test.go
+++ b/pkg/service/nlb/builder_test.go
@@ -508,7 +508,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
                ],
                "certificates":[
                   {
-                     "certificateARN":"certArn2"
+                     "certificateARN":"certArn1"
                   },
                   {
                      "certificateARN":"certArn2"


### PR DESCRIPTION
This bug was preventing from supporting multiple certificate ARNs in the NLB model.