### PR TITLE
add support for version & adjust flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ ARG TARGETARCH
 ENV VERSION_PKG=sigs.k8s.io/aws-load-balancer-controller/pkg/version
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache/go-build \
-    GIT_VERSION=$(git describe --tags --dirty --always) \
-    GIT_COMMIT=$(git rev-parse HEAD) \
-    BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
+    GIT_VERSION=$(git describe --tags --dirty --always) && \
+    GIT_COMMIT=$(git rev-parse HEAD) && \
+    BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on \
     CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2" \
     CGO_LDFLAGS="-Wl,-z,relro,-z,now" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,16 @@ RUN GOPROXY=direct go mod download
 FROM base AS build
 ARG TARGETOS
 ARG TARGETARCH
+ENV VERSION_PKG=sigs.k8s.io/aws-load-balancer-controller/pkg/version
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache/go-build \
+    GIT_VERSION=$(git describe --tags --dirty --always) \
+    GIT_COMMIT=$(git rev-parse HEAD) \
+    BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on \
     CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2" \
     CGO_LDFLAGS="-Wl,-z,relro,-z,now" \
-    go build -ldflags="-s -w" -buildmode=pie -a -o /out/controller main.go
+    go build -ldflags="-s -w -X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" -buildmode=pie -a -o /out/controller main.go
 
 FROM amazonlinux:2 as bin-unix
 COPY --from=build /out/controller /controller

--- a/controllers/elbv2/targetgroupbinding_controller.go
+++ b/controllers/elbv2/targetgroupbinding_controller.go
@@ -50,7 +50,7 @@ func NewTargetGroupBindingReconciler(k8sClient client.Client, finalizerManager k
 		tgbResourceManager: tgbResourceManager,
 		logger:             logger,
 
-		maxConcurrentReconciles: config.TargetgroupBindingMaxConcurrentReconciles,
+		maxConcurrentReconciles: config.TargetGroupBindingMaxConcurrentReconciles,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"github.com/spf13/pflag"
 	zapraw "go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/runtime"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"os"
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/inject"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/runtime"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/targetgroupbinding"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/version"
 	corewebhook "sigs.k8s.io/aws-load-balancer-controller/webhooks/core"
@@ -45,7 +46,7 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
+	scheme   = k8sruntime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
 
@@ -164,6 +165,8 @@ func setLogLevel(logLevel string) {
 		zapLevel = zapraw.NewAtomicLevelAt(zapraw.DebugLevel)
 	}
 
-	logger := zap.New(zap.UseDevMode(false), zap.Level(&zapLevel))
-	ctrl.SetLogger(logger)
+	logger := zap.New(zap.UseDevMode(false),
+		zap.Level(zapLevel),
+		zap.StacktraceLevel(zapraw.NewAtomicLevelAt(zapraw.FatalLevel)))
+	ctrl.SetLogger(runtime.NewConciseLogger(logger))
 }

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -77,7 +77,7 @@ func BuildRestConfig(rtCfg RuntimeConfig) (*rest.Config, error) {
 		restCFG, err = rest.InClusterConfig()
 	} else {
 		restCFG, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&clientcmd.ClientConfigLoadingRules{ExplicitPath: rtCfg.KubeConfig}, nil).ClientConfig()
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: rtCfg.KubeConfig}, &clientcmd.ConfigOverrides{}).ClientConfig()
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/runtime/concise_logger.go
+++ b/pkg/runtime/concise_logger.go
@@ -1,0 +1,42 @@
+package runtime
+
+import "github.com/go-logr/logr"
+
+// NewConciseLogger constructs new conciseLogger
+func NewConciseLogger(logger logr.Logger) *conciseLogger {
+	return &conciseLogger{
+		Logger: logger,
+	}
+}
+
+var _ logr.Logger = &conciseLogger{}
+
+// conciseLogger will log concise Error messages.
+// We have used github.com/pkg/errors extensively, when logged with zap logger, a full stacktrace is logged but it's usually unhelpful due to go routine usage.
+// this conciseLogger will wrap the error inside a conciseError, so that only necessary error message is logged.
+type conciseLogger struct {
+	logr.Logger
+}
+
+func (r *conciseLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	r.Logger.Error(&conciseError{err: err}, msg, keysAndValues...)
+}
+
+func (r *conciseLogger) WithValues(keysAndValues ...interface{}) logr.Logger {
+	return NewConciseLogger(r.Logger.WithValues(keysAndValues...))
+}
+
+func (r *conciseLogger) WithName(name string) logr.Logger {
+	return NewConciseLogger(r.Logger.WithName(name))
+}
+
+var _ error = &conciseError{}
+
+// conciseError will only contain concise error message.
+type conciseError struct {
+	err error
+}
+
+func (e *conciseError) Error() string {
+	return e.err.Error()
+}

--- a/pkg/runtime/concise_logger_test.go
+++ b/pkg/runtime/concise_logger_test.go
@@ -1,0 +1,42 @@
+package runtime
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_conciseError_Error(t *testing.T) {
+	type fields struct {
+		err error
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "plain Error",
+			fields: fields{
+				err: errors.New("plain error"),
+			},
+			want: "plain error",
+		},
+		{
+			name: "wrapped Error",
+			fields: fields{
+				err: errors.Wrap(errors.New("plain error"), "wrapped msg"),
+			},
+			want: "wrapped msg: plain error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &conciseError{
+				err: tt.fields.err,
+			}
+			got := e.Error()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,22 +1,7 @@
 package version
 
-import (
-	"encoding/json"
-)
-
 var (
 	GitVersion string
 	GitCommit  string
 	BuildDate  string
 )
-
-// PrintableVersion returns formatted version string
-func PrintableVersion() string {
-	versionData := map[string]string{
-		"GitVersion": GitVersion,
-		"GitCommit":  GitCommit,
-		"BuildDate":  BuildDate,
-	}
-	payload, _ := json.Marshal(versionData)
-	return string(payload)
-}


### PR DESCRIPTION
1. add build Flag to populate version.
2. remove the '--master' flag as it's deprecated by upstream as well.
3. added a concise logger, which will no longer log these stacktraces. (which is not useful due to nested go routines).
4. optimize the code layout

new error message:
```
{"level":"error","ts":1602732820.192087,"logger":"setup","msg":"unable to load controller config","error":"kubernetes cluster name must be specified"}
```

old error message:
```
{"level":"error","ts":1602732290.3767838,"logger":"setup","msg":"unable to load controller config","error":"kubernetes cluster name must be specified","errorVerbose":"kubernetes cluster name must be specified\nsigs.k8s.io/aws-load-balancer-controller/pkg/config.(*ControllerConfig).Validate\n\t/Volumes/workplace/aws-alb-ingress-controller/pkg/config/controller_config.go:63\nmain.loadControllerConfig\n\t/Volumes/workplace/aws-alb-ingress-controller/main.go:150\nmain.main\n\t/Volumes/workplace/aws-alb-ingress-controller/main.go:67\nruntime.main\n\t/usr/local/Cellar/go/1.15/libexec/src/runtime/proc.go:204\nruntime.goexit\n\t/usr/local/Cellar/go/1.15/libexec/src/runtime/asm_amd64.s:1374"}
```