### PR TITLE
fix AWS SDK session

### DIFF
--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -73,8 +73,8 @@ func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, 
 		cfg.VpcID = vpcId
 	}
 
-	awsCfg := aws.NewConfig().WithRegion(cfg.Region).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint).WithMaxRetries(cfg.MaxRetries)
-	sess = sess.Copy(awsCfg)
+	awsCFG := aws.NewConfig().WithRegion(cfg.Region).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint).WithMaxRetries(cfg.MaxRetries)
+	sess = session.Must(session.NewSession(awsCFG))
 	return &defaultCloud{
 		cfg:         cfg,
 		ec2:         services.NewEC2(sess),


### PR DESCRIPTION
1. use a new session instead of copy from existing session. The AWS credentials is inited when init the session, we need a new session here so that the IAMForSA credentials can benefit from the region passed-in.
