### PR TITLE
Fix documentation for contribution and building

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We also have more documentation on how to get started contributing here:
 
 - [Contributor License Agreement](https://git.k8s.io/community/CLA.md) Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
 - [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](http://git.k8s.io/community/contributors/guide#contributing)
-- [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet.md) - Common resources for existing developers
+- [Contributor Cheat Sheet](https://github.com/kubernetes/community/blob/master/contributors/guide/contributor-cheatsheet/README.md) - Common resources for existing developers
 
 ## Mentorship
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -45,7 +45,7 @@ kubectl proxy &>/dev/null &
 kubectl apply -f ./examples/echoservice/echoserver-namespace.yaml
 kubectl apply -f ./examples/echoservice/echoserver-deployment.yaml
 kubectl apply -f ./examples/echoservice/echoserver-service.yaml
-kubectl apply -f ./examples/echoservice/echoserver-ingress2.yaml
+kubectl apply -f ./examples/echoservice/echoserver-ingress.yaml
 ```
 
 ```bash


### PR DESCRIPTION
While configuring the local development environment found:

- Broken link for Contributor Cheatsheet
- Broken path for echoservice ingress Manifest