### PR TITLE
multiple bug fixes for v2.0.0-rc4

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -419,7 +419,7 @@ ALB supports authentication with Cognito or OIDC. See [Authenticate Users Using 
           namespace: testcase
           name: my-k8s-secret
         data:
-          clientId: base64 of your plain text clientId
+          clientID: base64 of your plain text clientId
           clientSecret: base64 of your plain text clientSecret
         ```
 

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -86,10 +86,10 @@ func (d *defaultStackDeployer) Deploy(ctx context.Context, stack core.Stack) err
 	synthesizers := []ResourceSynthesizer{
 		ec2.NewSecurityGroupSynthesizer(d.cloud.EC2(), d.trackingProvider, d.ec2TaggingManager, d.ec2SGManager, d.vpcID, d.logger, stack),
 		elbv2.NewTargetGroupSynthesizer(d.cloud.ELBV2(), d.trackingProvider, d.elbv2TaggingManager, d.elbv2TGManager, d.logger, stack),
-		elbv2.NewTargetGroupBindingSynthesizer(d.k8sClient, d.trackingProvider, d.elbv2TGBManager, d.logger, stack),
 		elbv2.NewLoadBalancerSynthesizer(d.cloud.ELBV2(), d.trackingProvider, d.elbv2TaggingManager, d.elbv2LBManager, d.logger, stack),
 		elbv2.NewListenerSynthesizer(d.cloud.ELBV2(), d.elbv2LSManager, d.logger, stack),
 		elbv2.NewListenerRuleSynthesizer(d.cloud.ELBV2(), d.elbv2LRManager, d.logger, stack),
+		elbv2.NewTargetGroupBindingSynthesizer(d.k8sClient, d.trackingProvider, d.elbv2TGBManager, d.logger, stack),
 	}
 
 	if d.addonsConfig.WAFV2Enabled {

--- a/pkg/ingress/model_build_actions_test.go
+++ b/pkg/ingress/model_build_actions_test.go
@@ -1,0 +1,250 @@
+package ingress
+
+import (
+	"context"
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func Test_defaultModelBuildTask_buildAuthenticateOIDCAction(t *testing.T) {
+	type env struct {
+		secrets []*corev1.Secret
+	}
+	type args struct {
+		authCfg   AuthConfig
+		namespace string
+	}
+	authBehaviorAuthenticate := elbv2model.AuthenticateOIDCActionConditionalBehaviorAuthenticate
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		want    elbv2model.Action
+		wantErr error
+	}{
+		{
+			name: "clientID & clientSecret configured",
+			env: env{
+				secrets: []*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "my-k8s-secret",
+						},
+						Data: map[string][]byte{
+							"clientID":     []byte("my-client-id"),
+							"clientSecret": []byte("my-client-secret"),
+						},
+					},
+				},
+			},
+			args: args{
+				authCfg: AuthConfig{
+					Type: AuthTypeCognito,
+					IDPConfigOIDC: &AuthIDPConfigOIDC{
+						Issuer:                "https://example.com",
+						AuthorizationEndpoint: "https://authorization.example.com",
+						TokenEndpoint:         "https://token.example.com",
+						UserInfoEndpoint:      "https://userinfo.example.co",
+						SecretName:            "my-k8s-secret",
+						AuthenticationRequestExtraParams: map[string]string{
+							"key1": "value1",
+						},
+					},
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "email",
+					SessionCookieName:        "my-session-cookie",
+					SessionTimeout:           65536,
+				},
+				namespace: "my-ns",
+			},
+			want: elbv2model.Action{
+				Type: elbv2model.ActionTypeAuthenticateOIDC,
+				AuthenticateOIDCConfig: &elbv2model.AuthenticateOIDCActionConfig{
+					Issuer:                "https://example.com",
+					AuthorizationEndpoint: "https://authorization.example.com",
+					TokenEndpoint:         "https://token.example.com",
+					UserInfoEndpoint:      "https://userinfo.example.co",
+					ClientID:              "my-client-id",
+					ClientSecret:          "my-client-secret",
+					AuthenticationRequestExtraParams: map[string]string{
+						"key1": "value1",
+					},
+					OnUnauthenticatedRequest: &authBehaviorAuthenticate,
+					Scope:                    awssdk.String("email"),
+					SessionCookieName:        awssdk.String("my-session-cookie"),
+					SessionTimeout:           awssdk.Int64(65536),
+				},
+			},
+		},
+		{
+			name: "clientID & clientSecret configured - legacy clientId",
+			env: env{
+				secrets: []*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "my-k8s-secret",
+						},
+						Data: map[string][]byte{
+							"clientId":     []byte("my-client-id"),
+							"clientSecret": []byte("my-client-secret"),
+						},
+					},
+				},
+			},
+			args: args{
+				authCfg: AuthConfig{
+					Type: AuthTypeCognito,
+					IDPConfigOIDC: &AuthIDPConfigOIDC{
+						Issuer:                "https://example.com",
+						AuthorizationEndpoint: "https://authorization.example.com",
+						TokenEndpoint:         "https://token.example.com",
+						UserInfoEndpoint:      "https://userinfo.example.co",
+						SecretName:            "my-k8s-secret",
+						AuthenticationRequestExtraParams: map[string]string{
+							"key1": "value1",
+						},
+					},
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "email",
+					SessionCookieName:        "my-session-cookie",
+					SessionTimeout:           65536,
+				},
+				namespace: "my-ns",
+			},
+			want: elbv2model.Action{
+				Type: elbv2model.ActionTypeAuthenticateOIDC,
+				AuthenticateOIDCConfig: &elbv2model.AuthenticateOIDCActionConfig{
+					Issuer:                "https://example.com",
+					AuthorizationEndpoint: "https://authorization.example.com",
+					TokenEndpoint:         "https://token.example.com",
+					UserInfoEndpoint:      "https://userinfo.example.co",
+					ClientID:              "my-client-id",
+					ClientSecret:          "my-client-secret",
+					AuthenticationRequestExtraParams: map[string]string{
+						"key1": "value1",
+					},
+					OnUnauthenticatedRequest: &authBehaviorAuthenticate,
+					Scope:                    awssdk.String("email"),
+					SessionCookieName:        awssdk.String("my-session-cookie"),
+					SessionTimeout:           awssdk.Int64(65536),
+				},
+			},
+		},
+		{
+			name: "missing IDPConfigOIDC",
+			args: args{
+				authCfg: AuthConfig{
+					Type:          AuthTypeCognito,
+					IDPConfigOIDC: nil,
+				},
+			},
+			wantErr: errors.New("missing IDPConfigOIDC"),
+		},
+		{
+			name: "missing clientID",
+			env: env{
+				secrets: []*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "my-k8s-secret",
+						},
+						Data: map[string][]byte{
+							"clientSecret": []byte("my-client-secret"),
+						},
+					},
+				},
+			},
+			args: args{
+				authCfg: AuthConfig{
+					Type: AuthTypeCognito,
+					IDPConfigOIDC: &AuthIDPConfigOIDC{
+						Issuer:                "https://example.com",
+						AuthorizationEndpoint: "https://authorization.example.com",
+						TokenEndpoint:         "https://token.example.com",
+						UserInfoEndpoint:      "https://userinfo.example.co",
+						SecretName:            "my-k8s-secret",
+						AuthenticationRequestExtraParams: map[string]string{
+							"key1": "value1",
+						},
+					},
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "email",
+					SessionCookieName:        "my-session-cookie",
+					SessionTimeout:           65536,
+				},
+				namespace: "my-ns",
+			},
+			wantErr: errors.New("missing clientID, secret: my-ns/my-k8s-secret"),
+		},
+		{
+			name: "missing clientSecret",
+			env: env{
+				secrets: []*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "my-k8s-secret",
+						},
+						Data: map[string][]byte{
+							"clientID": []byte("my-client-id"),
+						},
+					},
+				},
+			},
+			args: args{
+				authCfg: AuthConfig{
+					Type: AuthTypeCognito,
+					IDPConfigOIDC: &AuthIDPConfigOIDC{
+						Issuer:                "https://example.com",
+						AuthorizationEndpoint: "https://authorization.example.com",
+						TokenEndpoint:         "https://token.example.com",
+						UserInfoEndpoint:      "https://userinfo.example.co",
+						SecretName:            "my-k8s-secret",
+						AuthenticationRequestExtraParams: map[string]string{
+							"key1": "value1",
+						},
+					},
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "email",
+					SessionCookieName:        "my-session-cookie",
+					SessionTimeout:           65536,
+				},
+				namespace: "my-ns",
+			},
+			wantErr: errors.New("missing clientSecret, secret: my-ns/my-k8s-secret"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			for _, secret := range tt.env.secrets {
+				err := k8sClient.Create(context.Background(), secret.DeepCopy())
+				assert.NoError(t, err)
+			}
+
+			task := &defaultModelBuildTask{
+				k8sClient: k8sClient,
+			}
+			got, err := task.buildAuthenticateOIDCAction(context.Background(), tt.args.authCfg, tt.args.namespace)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/k8s/finalizer.go
+++ b/pkg/k8s/finalizer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -28,37 +29,50 @@ func NewDefaultFinalizerManager(k8sClient client.Client, log logr.Logger) Finali
 
 type defaultFinalizerManager struct {
 	k8sClient client.Client
-	log       logr.Logger
+
+	log logr.Logger
 }
 
 func (m *defaultFinalizerManager) AddFinalizers(ctx context.Context, obj APIObject, finalizers ...string) error {
-	oldObj := obj.DeepCopyObject()
-	needsUpdate := false
-	for _, finalizer := range finalizers {
-		if !HasFinalizer(obj, finalizer) {
-			controllerutil.AddFinalizer(obj, finalizer)
-			needsUpdate = true
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := m.k8sClient.Get(ctx, NamespacedName(obj), obj); err != nil {
+			return err
 		}
-	}
-	if !needsUpdate {
-		return nil
-	}
-	return m.k8sClient.Patch(ctx, obj, client.MergeFrom(oldObj))
+
+		oldObj := obj.DeepCopyObject()
+		needsUpdate := false
+		for _, finalizer := range finalizers {
+			if !HasFinalizer(obj, finalizer) {
+				controllerutil.AddFinalizer(obj, finalizer)
+				needsUpdate = true
+			}
+		}
+		if !needsUpdate {
+			return nil
+		}
+		return m.k8sClient.Patch(ctx, obj, client.MergeFromWithOptions(oldObj, client.MergeFromWithOptimisticLock{}))
+	})
 }
 
 func (m *defaultFinalizerManager) RemoveFinalizers(ctx context.Context, obj APIObject, finalizers ...string) error {
-	oldObj := obj.DeepCopyObject()
-	needsUpdate := false
-	for _, finalizer := range finalizers {
-		if HasFinalizer(obj, finalizer) {
-			controllerutil.RemoveFinalizer(obj, finalizer)
-			needsUpdate = true
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := m.k8sClient.Get(ctx, NamespacedName(obj), obj); err != nil {
+			return err
 		}
-	}
-	if !needsUpdate {
-		return nil
-	}
-	return m.k8sClient.Patch(ctx, obj, client.MergeFrom(oldObj))
+
+		oldObj := obj.DeepCopyObject()
+		needsUpdate := false
+		for _, finalizer := range finalizers {
+			if HasFinalizer(obj, finalizer) {
+				controllerutil.RemoveFinalizer(obj, finalizer)
+				needsUpdate = true
+			}
+		}
+		if !needsUpdate {
+			return nil
+		}
+		return m.k8sClient.Patch(ctx, obj, client.MergeFromWithOptions(oldObj, client.MergeFromWithOptimisticLock{}))
+	})
 }
 
 // HasFinalizer tests whether k8s object has specified finalizer

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-const defaultTargetHealthRequeueDuration = 10 * time.Second
+const defaultTargetHealthRequeueDuration = 15 * time.Second
 
 // ResourceManager manages the TargetGroupBinding resource.
 type ResourceManager interface {

--- a/pkg/targetgroupbinding/resource_manager_test.go
+++ b/pkg/targetgroupbinding/resource_manager_test.go
@@ -1,0 +1,360 @@
+package targetgroupbinding
+
+import (
+	"context"
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/equality"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_defaultResourceManager_updateTargetHealthPodConditionForPod(t *testing.T) {
+	type args struct {
+		pod                  *corev1.Pod
+		targetHealth         *elbv2sdk.TargetHealth
+		targetHealthCondType corev1.PodConditionType
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantPod *corev1.Pod
+		wantErr error
+	}{
+		{
+			name: "pod contains readinessGate and targetHealth is healthy - add pod condition",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-pod",
+					},
+					Spec: corev1.PodSpec{
+						ReadinessGates: []corev1.PodReadinessGate{
+							{
+								ConditionType: "target-health.elbv2.k8s.aws/my-tgb",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				targetHealth: &elbv2sdk.TargetHealth{
+					State: awssdk.String(elbv2sdk.TargetHealthStateEnumHealthy),
+				},
+				targetHealthCondType: "target-health.elbv2.k8s.aws/my-tgb",
+			},
+			want: false,
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{
+							ConditionType: "target-health.elbv2.k8s.aws/my-tgb",
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.ContainersReady,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   "target-health.elbv2.k8s.aws/my-tgb",
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod contains readinessGate and targetHealth is healthy - update pod condition",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-pod",
+					},
+					Spec: corev1.PodSpec{
+						ReadinessGates: []corev1.PodReadinessGate{
+							{
+								ConditionType: "target-health.elbv2.k8s.aws/my-tgb",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:    "target-health.elbv2.k8s.aws/my-tgb",
+								Status:  corev1.ConditionFalse,
+								Reason:  elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress,
+								Message: "Target registration is in progress",
+							},
+						},
+					},
+				},
+				targetHealth: &elbv2sdk.TargetHealth{
+					State: awssdk.String(elbv2sdk.TargetHealthStateEnumHealthy),
+				},
+				targetHealthCondType: "target-health.elbv2.k8s.aws/my-tgb",
+			},
+			want: false,
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{
+							ConditionType: "target-health.elbv2.k8s.aws/my-tgb",
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.ContainersReady,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   "target-health.elbv2.k8s.aws/my-tgb",
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod contains readinessGate and targetHealth is unhealthy - add pod condition",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-pod",
+					},
+					Spec: corev1.PodSpec{
+						ReadinessGates: []corev1.PodReadinessGate{
+							{
+								ConditionType: "target-health.elbv2.k8s.aws/my-tgb",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:    "target-health.elbv2.k8s.aws/my-tgb",
+								Status:  corev1.ConditionFalse,
+								Reason:  elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress,
+								Message: "Target registration is in progress",
+							},
+						},
+					},
+				},
+				targetHealth: &elbv2sdk.TargetHealth{
+					State:       awssdk.String(elbv2sdk.TargetHealthStateEnumUnhealthy),
+					Reason:      awssdk.String(elbv2sdk.TargetHealthReasonEnumTargetFailedHealthChecks),
+					Description: awssdk.String("Health checks failed"),
+				},
+				targetHealthCondType: "target-health.elbv2.k8s.aws/my-tgb",
+			},
+			want: true,
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{
+							ConditionType: "target-health.elbv2.k8s.aws/my-tgb",
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.ContainersReady,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:    "target-health.elbv2.k8s.aws/my-tgb",
+							Status:  corev1.ConditionFalse,
+							Reason:  elbv2sdk.TargetHealthReasonEnumTargetFailedHealthChecks,
+							Message: "Health checks failed",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod contains readinessGate and targetHealth is nil - currentPod has no condition",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-pod",
+					},
+					Spec: corev1.PodSpec{
+						ReadinessGates: []corev1.PodReadinessGate{
+							{
+								ConditionType: "target-health.elbv2.k8s.aws/my-tgb",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				targetHealth:         nil,
+				targetHealthCondType: "target-health.elbv2.k8s.aws/my-tgb",
+			},
+			want: true,
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-pod",
+				},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{
+							ConditionType: "target-health.elbv2.k8s.aws/my-tgb",
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.ContainersReady,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   "target-health.elbv2.k8s.aws/my-tgb",
+							Status: corev1.ConditionUnknown,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+
+			m := &defaultResourceManager{
+				k8sClient: k8sClient,
+				logger:    &log.NullLogger{},
+			}
+
+			ctx := context.Background()
+			pod := tt.args.pod.DeepCopy()
+			err := k8sClient.Create(ctx, pod)
+			assert.NoError(t, err)
+
+			got, err := m.updateTargetHealthPodConditionForPod(context.Background(),
+				pod, tt.args.targetHealth, tt.args.targetHealthCondType)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+
+				updatedPod := &corev1.Pod{}
+				err := m.k8sClient.Get(ctx, k8s.NamespacedName(pod), updatedPod)
+				assert.NoError(t, err)
+
+				opts := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+					cmpopts.IgnoreTypes(metav1.Time{}),
+				}
+				assert.True(t, cmp.Equal(tt.wantPod, updatedPod, opts), "diff", cmp.Diff(tt.wantPod, updatedPod, opts))
+			}
+		})
+	}
+}
+
+func Test_containsTargetsInInitialState(t *testing.T) {
+	type args struct {
+		matchedEndpointAndTargets []podEndpointAndTargetPair
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "contains initial targets",
+			args: args{
+				matchedEndpointAndTargets: []podEndpointAndTargetPair{
+					{
+						target: TargetInfo{
+							TargetHealth: &elbv2sdk.TargetHealth{
+								State:       awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+								Reason:      awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+								Description: awssdk.String("Target registration is in progress"),
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "contains no initial targets",
+			args: args{
+				matchedEndpointAndTargets: []podEndpointAndTargetPair{
+					{
+						target: TargetInfo{
+							TargetHealth: &elbv2sdk.TargetHealth{
+								State: awssdk.String(elbv2sdk.TargetHealthStateEnumHealthy),
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containsTargetsInInitialState(tt.args.matchedEndpointAndTargets)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/targetgroupbinding/targets_manager_types.go
+++ b/pkg/targetgroupbinding/targets_manager_types.go
@@ -33,11 +33,20 @@ func (t *TargetInfo) IsNotRegistered() bool {
 		awssdk.StringValue(t.TargetHealth.Reason) == elbv2sdk.TargetHealthReasonEnumTargetNotRegistered
 }
 
+// IsDraining returns whether target is in draining state.
 func (t *TargetInfo) IsDraining() bool {
 	if t.TargetHealth == nil {
 		return false
 	}
 	return awssdk.StringValue(t.TargetHealth.State) == elbv2sdk.TargetHealthStateEnumDraining
+}
+
+// IsInitial returns whether target is in initial state.
+func (t *TargetInfo) IsInitial() bool {
+	if t.TargetHealth == nil {
+		return false
+	}
+	return awssdk.StringValue(t.TargetHealth.State) == elbv2sdk.TargetHealthStateEnumInitial
 }
 
 // UniqueIDForTargetDescription generates a unique ID to differentiate targets.

--- a/pkg/targetgroupbinding/targets_manager_types_test.go
+++ b/pkg/targetgroupbinding/targets_manager_types_test.go
@@ -128,6 +128,74 @@ func TestTargetInfo_IsNotRegistered(t *testing.T) {
 	}
 }
 
+func TestTargetInfo_IsInitial(t *testing.T) {
+	tests := []struct {
+		name   string
+		target TargetInfo
+		want   bool
+	}{
+		{
+			name: "target with initial state and initial healthCheck reason",
+			target: TargetInfo{
+				Target: elbv2sdk.TargetDescription{
+					Id:   awssdk.String("192.168.1.1"),
+					Port: awssdk.Int64(8080),
+				},
+				TargetHealth: &elbv2sdk.TargetHealth{
+					Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbInitialHealthChecking),
+					State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "target with initial state and elb registrationInProgress reason",
+			target: TargetInfo{
+				Target: elbv2sdk.TargetDescription{
+					Id:   awssdk.String("192.168.1.1"),
+					Port: awssdk.Int64(8080),
+				},
+				TargetHealth: &elbv2sdk.TargetHealth{
+					Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+					State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "target with unknown TargetHealth",
+			target: TargetInfo{
+				Target: elbv2sdk.TargetDescription{
+					Id:   awssdk.String("192.168.1.1"),
+					Port: awssdk.Int64(8080),
+				},
+				TargetHealth: nil,
+			},
+			want: false,
+		},
+		{
+			name: "target with unused state and targetNotInUse reason",
+			target: TargetInfo{
+				Target: elbv2sdk.TargetDescription{
+					Id:   awssdk.String("192.168.1.1"),
+					Port: awssdk.Int64(8080),
+				},
+				TargetHealth: &elbv2sdk.TargetHealth{
+					Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumTargetNotInUse),
+					State:  awssdk.String(elbv2sdk.TargetHealthStateEnumUnused),
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t1 *testing.T) {
+			got := tt.target.IsInitial()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestUniqueIDForTargetDescription(t *testing.T) {
 	type args struct {
 		target elbv2sdk.TargetDescription


### PR DESCRIPTION
1. Tune the targetGroupBinding reconcile Requeue behavior
    * requeue with a fixed delay only when there are new targets registered or initial targets.
    * requeue with a backoff delay otherwise.
    * fixed delay is changed to 15 second to match TargetGroup's default healthCheckInterval
  
   Above requeue strategy will prevent the controller to send too many DescribeTargetHealth API call when targetGroup is not used or securityGroup rules is not setup correctly.

2. Adjust the resource synthesize order by make TargetGroupBinding  synthesize happens after listenerRule, such that when targets are been registered, it's already associated with a LoadBalancer.

3. Use OptimisticLock via Object's resourceVersion to prevent race condition when updating collection fields.

4. support both `clientID` and `clientId`(old one) for OIDC secret.

5.  Fix the log level settings. (ctrl.setLogger can only be set once)