### PR TITLE
Target group name based on target port

### DIFF
--- a/pkg/service/nlb/builder.go
+++ b/pkg/service/nlb/builder.go
@@ -410,14 +410,18 @@ func (t *defaultModelBuildTask) buildListeners(ctx context.Context, ec2Subnets [
 		}
 
 		svcPort := intstr.FromInt(int(port.Port))
-		tgName := t.buildTargetGroupName(ctx, svcPort, elbv2model.TargetTypeIP, tgProtocol, hc)
+		tgName := t.buildTargetGroupName(ctx, port.TargetPort, elbv2model.TargetTypeIP, tgProtocol, hc)
 		tgResId := t.buildTargetGroupResourceID(k8s.NamespacedName(t.service), svcPort)
+		targetPort := 1
+		if port.TargetPort.Type == intstr.Int {
+			targetPort = port.TargetPort.IntValue()
+		}
 		targetGroup, exists := targetGroupMap[port.TargetPort.String()]
 		if !exists {
 			targetGroup = elbv2model.NewTargetGroup(t.stack, tgResId, elbv2model.TargetGroupSpec{
 				Name:                  tgName,
 				TargetType:            elbv2model.TargetTypeIP,
-				Port:                  int64(port.TargetPort.IntValue()),
+				Port:                  int64(targetPort),
 				Protocol:              tgProtocol,
 				HealthCheckConfig:     hc,
 				TargetGroupAttributes: tgAttrs,

--- a/pkg/service/nlb/builder_test.go
+++ b/pkg/service/nlb/builder_test.go
@@ -582,7 +582,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
          },
          "default/nlb-ip-svc-tls:83":{
             "spec":{
-               "name":"k8s-default-nlbipsvc-00cd37875f",
+               "name":"k8s-default-nlbipsvc-4cde48cd00",
                "targetType":"ip",
                "port":8883,
                "protocol":"TCP",
@@ -659,7 +659,7 @@ func Test_defaultModelBuilderTask_buildNLB(t *testing.T) {
             "spec":{
                "template":{
                   "metadata":{
-                     "name":"k8s-default-nlbipsvc-00cd37875f",
+                     "name":"k8s-default-nlbipsvc-4cde48cd00",
                      "namespace":"default",
                      "creationTimestamp":null
                   },


### PR DESCRIPTION
Use target port while computing target group name hash.
If target port is string, use 1 as the target port.