### PR TITLE
use numeric target group if available

### DIFF
--- a/pkg/ingress/model_build_target_group.go
+++ b/pkg/ingress/model_build_target_group.go
@@ -94,18 +94,6 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingNetworking(_ context.Cont
 	}
 }
 
-func (t *defaultModelBuildTask) buildTargetGroupPort(_ context.Context, svc *corev1.Service, port intstr.IntOrString) (int64, error) {
-	svcPort, err := k8s.LookupServicePort(svc, port)
-	if err != nil {
-		return 0, err
-	}
-	targetGroupPort := 1
-	if svcPort.TargetPort.Type == intstr.Int {
-		targetGroupPort = svcPort.TargetPort.IntValue()
-	}
-	return int64(targetGroupPort), nil
-}
-
 func (t *defaultModelBuildTask) buildTargetGroupSpec(ctx context.Context,
 	ing *networking.Ingress, svc *corev1.Service, port intstr.IntOrString) (elbv2model.TargetGroupSpec, error) {
 	svcAndIngAnnotations := algorithm.MergeStringMap(svc.Annotations, ing.Annotations)
@@ -129,15 +117,19 @@ func (t *defaultModelBuildTask) buildTargetGroupSpec(ctx context.Context,
 	if err != nil {
 		return elbv2model.TargetGroupSpec{}, err
 	}
-	targetGroupPort, err := t.buildTargetGroupPort(ctx, svc, port)
+	svcPort, err := k8s.LookupServicePort(svc, port)
 	if err != nil {
 		return elbv2model.TargetGroupSpec{}, err
 	}
-	name := t.buildTargetGroupName(ctx, k8s.NamespacedName(ing), svc, port, targetType, tgProtocol)
+	targetGroupPort := 1
+	if svcPort.TargetPort.Type == intstr.Int {
+		targetGroupPort = svcPort.TargetPort.IntValue()
+	}
+	name := t.buildTargetGroupName(ctx, k8s.NamespacedName(ing), svc, svcPort.TargetPort, targetType, tgProtocol)
 	return elbv2model.TargetGroupSpec{
 		Name:                  name,
 		TargetType:            targetType,
-		Port:                  targetGroupPort,
+		Port:                  int64(targetGroupPort),
 		Protocol:              tgProtocol,
 		HealthCheckConfig:     &healthCheckConfig,
 		TargetGroupAttributes: targetGroupAttributes,

--- a/pkg/ingress/model_build_target_group.go
+++ b/pkg/ingress/model_build_target_group.go
@@ -118,10 +118,14 @@ func (t *defaultModelBuildTask) buildTargetGroupSpec(ctx context.Context,
 		return elbv2model.TargetGroupSpec{}, err
 	}
 	name := t.buildTargetGroupName(ctx, k8s.NamespacedName(ing), svc, port, targetType, tgProtocol)
+	targetGroupPort := 1
+	if port.Type == intstr.Int {
+		targetGroupPort = port.IntValue()
+	}
 	return elbv2model.TargetGroupSpec{
 		Name:                  name,
 		TargetType:            targetType,
-		Port:                  1,
+		Port:                  int64(targetGroupPort),
 		Protocol:              tgProtocol,
 		HealthCheckConfig:     &healthCheckConfig,
 		TargetGroupAttributes: targetGroupAttributes,

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -404,7 +404,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "name":"k8s-ns1-svc1-2718fcb5d7",
                     "targetType":"instance",
-                    "port":1,
+                    "port":8080,
                     "protocol":"HTTP",
                     "healthCheckConfig":{
                         "port":"traffic-port",
@@ -424,7 +424,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "name":"k8s-ns1-svc2-2718fcb5d7",
                     "targetType":"instance",
-                    "port":1,
+                    "port":8080,
                     "protocol":"HTTP",
                     "healthCheckConfig":{
                         "port":"traffic-port",
@@ -444,7 +444,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "name":"k8s-ns1-svc3-da71e18041",
                     "targetType":"ip",
-                    "port":1,
+                    "port":8443,
                     "protocol":"HTTPS",
                     "healthCheckConfig":{
                         "port":9090,
@@ -850,7 +850,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "name":"k8s-ns1-svc1-2718fcb5d7",
                     "targetType":"instance",
-                    "port":1,
+                    "port":8080,
                     "protocol":"HTTP",
                     "healthCheckConfig":{
                         "port":"traffic-port",
@@ -870,7 +870,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "name":"k8s-ns1-svc2-2718fcb5d7",
                     "targetType":"instance",
-                    "port":1,
+                    "port":8080,
                     "protocol":"HTTP",
                     "healthCheckConfig":{
                         "port":"traffic-port",
@@ -890,7 +890,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "name":"k8s-ns1-svc3-da71e18041",
                     "targetType":"ip",
-                    "port":1,
+                    "port":8443,
                     "protocol":"HTTPS",
                     "healthCheckConfig":{
                         "port":9090,

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -402,7 +402,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
         "AWS::ElasticLoadBalancingV2::TargetGroup":{
             "ns-1/ing-1-svc-1:http":{
                 "spec":{
-                    "name":"k8s-ns1-svc1-2718fcb5d7",
+                    "name":"k8s-ns1-svc1-1939f42801",
                     "targetType":"instance",
                     "port":8080,
                     "protocol":"HTTP",
@@ -422,7 +422,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
             },
             "ns-1/ing-1-svc-2:http":{
                 "spec":{
-                    "name":"k8s-ns1-svc2-2718fcb5d7",
+                    "name":"k8s-ns1-svc2-1939f42801",
                     "targetType":"instance",
                     "port":8080,
                     "protocol":"HTTP",
@@ -442,7 +442,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
             },
             "ns-1/ing-1-svc-3:https":{
                 "spec":{
-                    "name":"k8s-ns1-svc3-da71e18041",
+                    "name":"k8s-ns1-svc3-59d2f49fb4",
                     "targetType":"ip",
                     "port":8443,
                     "protocol":"HTTPS",
@@ -466,7 +466,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc1-2718fcb5d7",
+                            "name":"k8s-ns1-svc1-1939f42801",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },
@@ -507,7 +507,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc2-2718fcb5d7",
+                            "name":"k8s-ns1-svc2-1939f42801",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },
@@ -548,7 +548,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc3-da71e18041",
+                            "name":"k8s-ns1-svc3-59d2f49fb4",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },
@@ -848,7 +848,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
         "AWS::ElasticLoadBalancingV2::TargetGroup":{
             "ns-1/ing-1-svc-1:http":{
                 "spec":{
-                    "name":"k8s-ns1-svc1-2718fcb5d7",
+                    "name":"k8s-ns1-svc1-1939f42801",
                     "targetType":"instance",
                     "port":8080,
                     "protocol":"HTTP",
@@ -868,7 +868,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
             },
             "ns-1/ing-1-svc-2:http":{
                 "spec":{
-                    "name":"k8s-ns1-svc2-2718fcb5d7",
+                    "name":"k8s-ns1-svc2-1939f42801",
                     "targetType":"instance",
                     "port":8080,
                     "protocol":"HTTP",
@@ -888,7 +888,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
             },
             "ns-1/ing-1-svc-3:https":{
                 "spec":{
-                    "name":"k8s-ns1-svc3-da71e18041",
+                    "name":"k8s-ns1-svc3-59d2f49fb4",
                     "targetType":"ip",
                     "port":8443,
                     "protocol":"HTTPS",
@@ -912,7 +912,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc1-2718fcb5d7",
+                            "name":"k8s-ns1-svc1-1939f42801",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },
@@ -953,7 +953,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc2-2718fcb5d7",
+                            "name":"k8s-ns1-svc2-1939f42801",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },
@@ -994,7 +994,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc3-da71e18041",
+                            "name":"k8s-ns1-svc3-59d2f49fb4",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },


### PR DESCRIPTION
For ALB target group port, use numeric value if available. If not, use 1.